### PR TITLE
Feature/verify access

### DIFF
--- a/client/src/main/java/tds/exam/AccessRequest.java
+++ b/client/src/main/java/tds/exam/AccessRequest.java
@@ -4,9 +4,9 @@ import javax.validation.constraints.NotNull;
 import java.util.UUID;
 
 /**
- * Request approval to start an {@link Exam}.
+ * Request access to an {@link Exam}.
  */
-public class ExamApprovalRequest {
+public class AccessRequest {
     @NotNull
     private UUID examId;
 
@@ -19,7 +19,7 @@ public class ExamApprovalRequest {
     @NotNull
     private String clientName;
 
-    public ExamApprovalRequest(UUID examId, UUID sessionId, UUID browserId, String clientName) {
+    public AccessRequest(UUID examId, UUID sessionId, UUID browserId, String clientName) {
         this.examId = examId;
         this.sessionId = sessionId;
         this.browserId = browserId;
@@ -27,7 +27,7 @@ public class ExamApprovalRequest {
     }
 
     /**
-     * @return The id of the exam for which approval is being requested
+     * @return The id of the exam for which access is being requested
      */
     public UUID getExamId() {
         return examId;

--- a/client/src/main/java/tds/exam/ApprovalRequest.java
+++ b/client/src/main/java/tds/exam/ApprovalRequest.java
@@ -4,9 +4,9 @@ import javax.validation.constraints.NotNull;
 import java.util.UUID;
 
 /**
- * Request access to an {@link Exam}.
+ * Request approval to an {@link Exam}.
  */
-public class AccessRequest {
+public class ApprovalRequest {
     @NotNull
     private UUID examId;
 
@@ -19,7 +19,7 @@ public class AccessRequest {
     @NotNull
     private String clientName;
 
-    public AccessRequest(UUID examId, UUID sessionId, UUID browserId, String clientName) {
+    public ApprovalRequest(UUID examId, UUID sessionId, UUID browserId, String clientName) {
         this.examId = examId;
         this.sessionId = sessionId;
         this.browserId = browserId;

--- a/service/src/main/java/tds/exam/services/ExamService.java
+++ b/service/src/main/java/tds/exam/services/ExamService.java
@@ -53,8 +53,8 @@ public interface ExamService {
      * <p>
      *     The rules are:
      *     <ul>
-     *         <li>The browser key of the approval request must match the browser key of the {@link Exam}.</li>
-     *         <li>The session id of the approval request must match the session id of the {@link Exam}.</li>
+     *         <li>The browser key of the access request must match the browser key of the {@link Exam}.</li>
+     *         <li>The session id of the access request must match the session id of the {@link Exam}.</li>
      *         <li>The {@link Session} must be open (unless the environment is set to "simulation" or "development")</li>
      *         <li>The TA Check-In time window cannot be passed</li>
      *     </ul>

--- a/service/src/main/java/tds/exam/services/ExamService.java
+++ b/service/src/main/java/tds/exam/services/ExamService.java
@@ -8,7 +8,7 @@ import tds.common.ValidationError;
 import tds.config.ClientTestProperty;
 import tds.exam.Exam;
 import tds.exam.ExamApproval;
-import tds.exam.AccessRequest;
+import tds.exam.ApprovalRequest;
 import tds.exam.OpenExamRequest;
 import tds.session.Session;
 
@@ -34,10 +34,10 @@ public interface ExamService {
      *     the Student's request to start his/her exam.
      * </p>
      *
-     * @param accessRequest The {@link AccessRequest} representing the request to open the specified exam.
+     * @param approvalRequest The {@link ApprovalRequest} representing the request to open the specified exam.
      * @return {@link ExamApproval} describing whether the exam is approved to be opened.
      */
-    Response<ExamApproval> getApproval(AccessRequest accessRequest);
+    Response<ExamApproval> getApproval(ApprovalRequest approvalRequest);
 
     /**
      * Retrieves the initial ability value for an {@link Exam}.
@@ -49,23 +49,23 @@ public interface ExamService {
     Optional<Double> getInitialAbility(Exam exam, ClientTestProperty clientTestProperty);
 
     /**
-     * Verify all the rules for granting access to an {@link Exam} are satisfied.
+     * Verify all the rules for granting approval to an {@link Exam} are satisfied.
      * <p>
      *     The rules are:
      *     <ul>
-     *         <li>The browser key of the access request must match the browser key of the {@link Exam}.</li>
-     *         <li>The session id of the access request must match the session id of the {@link Exam}.</li>
+     *         <li>The browser key of the approval request must match the browser key of the {@link Exam}.</li>
+     *         <li>The session id of the approval request must match the session id of the {@link Exam}.</li>
      *         <li>The {@link Session} must be open (unless the environment is set to "simulation" or "development")</li>
      *         <li>The TA Check-In time window cannot be passed</li>
      *     </ul>
      *     <strong>NOTE:</strong>  If the {@link Session} has no Proctor (because the {@link Session} is a guest session
-     *     or is otherwise proctor-less), access is granted as long as the {@link Session} is open.
+     *     or is otherwise proctor-less), approval is granted as long as the {@link Session} is open.
      * </p>
      *
-     * @param accessRequest The {@link AccessRequest} being evaluated
-     * @param exam The {@link Exam} for which access is being requested
-     * @return An empty optional if the access rules are satisfied; otherwise an optional containing a
+     * @param approvalRequest The {@link ApprovalRequest} being evaluated
+     * @param exam The {@link Exam} for which approval is being requested
+     * @return An empty optional if the approval rules are satisfied; otherwise an optional containing a
      * {@link ValidationError} describing the rule that was not satisfied
      */
-    Optional<ValidationError> verifyAccess(AccessRequest accessRequest, Exam exam);
+    Optional<ValidationError> verifyAccess(ApprovalRequest approvalRequest, Exam exam);
 }

--- a/service/src/main/java/tds/exam/services/ExamService.java
+++ b/service/src/main/java/tds/exam/services/ExamService.java
@@ -4,11 +4,13 @@ import java.util.Optional;
 import java.util.UUID;
 
 import tds.common.Response;
+import tds.common.ValidationError;
 import tds.config.ClientTestProperty;
 import tds.exam.Exam;
 import tds.exam.ExamApproval;
-import tds.exam.ExamApprovalRequest;
+import tds.exam.AccessRequest;
 import tds.exam.OpenExamRequest;
+import tds.session.Session;
 
 /**
  * Main entry point for interacting with {@link Exam}
@@ -32,10 +34,10 @@ public interface ExamService {
      *     the Student's request to start his/her exam.
      * </p>
      *
-     * @param examApprovalRequest The {@link ExamApprovalRequest} representing the request to open the specified exam.
+     * @param accessRequest The {@link AccessRequest} representing the request to open the specified exam.
      * @return {@link ExamApproval} describing whether the exam is approved to be opened.
      */
-    Response<ExamApproval> getApproval(ExamApprovalRequest examApprovalRequest);
+    Response<ExamApproval> getApproval(AccessRequest accessRequest);
 
     /**
      * Retrieves the initial ability value for an {@link Exam}.
@@ -45,4 +47,25 @@ public interface ExamService {
      * @return  the initial ability for an {@link Exam}.
      */
     Optional<Double> getInitialAbility(Exam exam, ClientTestProperty clientTestProperty);
+
+    /**
+     * Verify all the rules for granting access to an {@link Exam} are satisfied.
+     * <p>
+     *     The rules are:
+     *     <ul>
+     *         <li>The browser key of the approval request must match the browser key of the {@link Exam}.</li>
+     *         <li>The session id of the approval request must match the session id of the {@link Exam}.</li>
+     *         <li>The {@link Session} must be open (unless the environment is set to "simulation" or "development")</li>
+     *         <li>The TA Check-In time window cannot be passed</li>
+     *     </ul>
+     *     <strong>NOTE:</strong>  If the {@link Session} has no Proctor (because the {@link Session} is a guest session
+     *     or is otherwise proctor-less), access is granted as long as the {@link Session} is open.
+     * </p>
+     *
+     * @param accessRequest The {@link AccessRequest} being evaluated
+     * @param exam The {@link Exam} for which access is being requested
+     * @return An empty optional if the access rules are satisfied; otherwise an optional containing a
+     * {@link ValidationError} describing the rule that was not satisfied
+     */
+    Optional<ValidationError> verifyAccess(AccessRequest accessRequest, Exam exam);
 }

--- a/service/src/main/java/tds/exam/services/impl/ExamServiceImpl.java
+++ b/service/src/main/java/tds/exam/services/impl/ExamServiceImpl.java
@@ -109,7 +109,7 @@ class ExamServiceImpl implements ExamService {
             Optional<ExternalSessionConfiguration> maybeExternalSessionConfiguration = sessionService.findExternalSessionConfigurationByClientName(openExamRequest.getClientName());
 
             if (!maybeExternalSessionConfiguration.isPresent()) {
-                throw new IllegalStateException("External Session Configuration could not be found for client name " + openExamRequest.getClientName());
+                throw new IllegalStateException(String.format("External Session Configuration could not be found for client name %s", openExamRequest.getClientName()));
             }
 
             ExternalSessionConfiguration externalSessionConfiguration = maybeExternalSessionConfiguration.get();
@@ -128,7 +128,7 @@ class ExamServiceImpl implements ExamService {
     @Override
     public Response<ExamApproval> getApproval(AccessRequest accessRequest) {
         Exam exam = examQueryRepository.getExamById(accessRequest.getExamId())
-                .orElseThrow(() -> new IllegalArgumentException("Exam could not be found for id " + accessRequest.getExamId()));
+                .orElseThrow(() -> new IllegalArgumentException(String.format("Exam could not be found for id %s", accessRequest.getExamId())));
 
         Optional<ValidationError> maybeAccessViolation = verifyAccess(accessRequest, exam);
 

--- a/service/src/main/java/tds/exam/services/impl/ExamServiceImpl.java
+++ b/service/src/main/java/tds/exam/services/impl/ExamServiceImpl.java
@@ -217,7 +217,7 @@ class ExamServiceImpl implements ExamService {
 
         // RULE:  If the session has no proctor, there is nothing to approve.  This is either a guest session or an
         // otherwise proctor-less session.
-        if (session.getProctorId() == null) {
+        if (session.isProctorless()) {
             return Optional.empty();
         }
 

--- a/service/src/main/java/tds/exam/web/endpoints/ExamController.java
+++ b/service/src/main/java/tds/exam/web/endpoints/ExamController.java
@@ -1,27 +1,23 @@
 package tds.exam.web.endpoints;
 
 import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.hateoas.Resource;
 import org.springframework.http.HttpHeaders;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.MediaType;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
 
-import java.util.Optional;
 import java.util.UUID;
 
 import tds.common.Response;
 import tds.common.web.exceptions.NotFoundException;
 import tds.exam.Exam;
 import tds.exam.ExamApproval;
-import tds.exam.ExamApprovalRequest;
+import tds.exam.AccessRequest;
 import tds.exam.OpenExamRequest;
 import tds.exam.services.ExamService;
 import tds.exam.web.resources.ExamApprovalResource;
 import tds.exam.web.resources.ExamResource;
-
-import javax.xml.ws.RequestWrapper;
 
 @RestController
 @RequestMapping("/exam")
@@ -58,8 +54,8 @@ public class ExamController {
 
     @RequestMapping(value = "/{id}/get-approval", method = RequestMethod.GET, produces = MediaType.APPLICATION_JSON_VALUE)
     public ResponseEntity<ExamApprovalResource> getApproval(@PathVariable final UUID examId, @RequestParam final UUID sessionId, @RequestParam final UUID browserId, final String clientName) {
-        ExamApprovalRequest examApprovalRequest = new ExamApprovalRequest(examId, sessionId, browserId, clientName);
-        Response<ExamApproval> examApproval = examService.getApproval(examApprovalRequest);
+        AccessRequest accessRequest = new AccessRequest(examId, sessionId, browserId, clientName);
+        Response<ExamApproval> examApproval = examService.getApproval(accessRequest);
 
         if (examApproval.getErrors().isPresent()) {
             return new ResponseEntity<>(new ExamApprovalResource(examApproval), HttpStatus.UNPROCESSABLE_ENTITY);

--- a/service/src/main/java/tds/exam/web/endpoints/ExamController.java
+++ b/service/src/main/java/tds/exam/web/endpoints/ExamController.java
@@ -13,7 +13,7 @@ import tds.common.Response;
 import tds.common.web.exceptions.NotFoundException;
 import tds.exam.Exam;
 import tds.exam.ExamApproval;
-import tds.exam.AccessRequest;
+import tds.exam.ApprovalRequest;
 import tds.exam.OpenExamRequest;
 import tds.exam.services.ExamService;
 import tds.exam.web.resources.ExamApprovalResource;
@@ -54,8 +54,8 @@ public class ExamController {
 
     @RequestMapping(value = "/{id}/get-approval", method = RequestMethod.GET, produces = MediaType.APPLICATION_JSON_VALUE)
     public ResponseEntity<ExamApprovalResource> getApproval(@PathVariable final UUID examId, @RequestParam final UUID sessionId, @RequestParam final UUID browserId, final String clientName) {
-        AccessRequest accessRequest = new AccessRequest(examId, sessionId, browserId, clientName);
-        Response<ExamApproval> examApproval = examService.getApproval(accessRequest);
+        ApprovalRequest approvalRequest = new ApprovalRequest(examId, sessionId, browserId, clientName);
+        Response<ExamApproval> examApproval = examService.getApproval(approvalRequest);
 
         if (examApproval.getErrors().isPresent()) {
             return new ResponseEntity<>(new ExamApprovalResource(examApproval), HttpStatus.UNPROCESSABLE_ENTITY);

--- a/service/src/test/java/tds/exam/services/impl/ExamServiceImplTest.java
+++ b/service/src/test/java/tds/exam/services/impl/ExamServiceImplTest.java
@@ -17,7 +17,7 @@ import tds.common.ValidationError;
 import tds.config.ClientTestProperty;
 import tds.exam.Exam;
 import tds.exam.ExamApproval;
-import tds.exam.ExamApprovalRequest;
+import tds.exam.AccessRequest;
 import tds.exam.ExamApprovalStatus;
 import tds.exam.ExamStatusCode;
 import tds.exam.OpenExamRequest;
@@ -468,7 +468,7 @@ public class ExamServiceImplTest {
         final String clientName = "SBAC_TEST4";
         final long studentId = 9897L;
 
-        // Null slop/intercept for this test case
+        // Null slope/intercept for this test case
         ClientTestProperty clientTestProperty = new ClientTestProperty.Builder()
                 .withClientName(clientName)
                 .withAssessmentId(assessmentId)
@@ -752,9 +752,9 @@ public class ExamServiceImplTest {
                         .withTaCheckinTimeMinutes(20)
                         .build()));
 
-        ExamApprovalRequest examApprovalRequest = new ExamApprovalRequest(examId, sessionId, browserKey, clientName);
+        AccessRequest accessRequest = new AccessRequest(examId, sessionId, browserKey, clientName);
 
-        Response<ExamApproval> result = examService.getApproval(examApprovalRequest);
+        Response<ExamApproval> result = examService.getApproval(accessRequest);
 
         assertThat(result.getErrors()).isNotPresent();
         assertThat(result.getData()).isPresent();
@@ -799,9 +799,9 @@ public class ExamServiceImplTest {
                         .withTaCheckinTimeMinutes(20)
                         .build()));
 
-        ExamApprovalRequest examApprovalRequest = new ExamApprovalRequest(examId, sessionId, browserKey, clientName);
+        AccessRequest accessRequest = new AccessRequest(examId, sessionId, browserKey, clientName);
 
-        Response<ExamApproval> result = examService.getApproval(examApprovalRequest);
+        Response<ExamApproval> result = examService.getApproval(accessRequest);
 
         assertThat(result.getErrors()).isNotPresent();
         assertThat(result.getData()).isPresent();
@@ -846,9 +846,9 @@ public class ExamServiceImplTest {
                         .withTaCheckinTimeMinutes(20)
                         .build()));
 
-        ExamApprovalRequest examApprovalRequest = new ExamApprovalRequest(examId, sessionId, browserKey, clientName);
+        AccessRequest accessRequest = new AccessRequest(examId, sessionId, browserKey, clientName);
 
-        Response<ExamApproval> result = examService.getApproval(examApprovalRequest);
+        Response<ExamApproval> result = examService.getApproval(accessRequest);
 
         assertThat(result.getErrors()).isNotPresent();
         assertThat(result.getData()).isPresent();
@@ -857,7 +857,7 @@ public class ExamServiceImplTest {
     }
 
     @Test
-    public void shouldReturnExamApprovalWithDeniedStatusBecauseSessionIsProctorless() {
+    public void shouldReturnExamApprovalWithDeniedStatusBecauseOfExamStatus() {
         UUID examId = UUID.randomUUID();
         UUID browserKey = UUID.randomUUID();
         UUID sessionId = UUID.randomUUID();
@@ -893,9 +893,9 @@ public class ExamServiceImplTest {
                         .withTaCheckinTimeMinutes(20)
                         .build()));
 
-        ExamApprovalRequest examApprovalRequest = new ExamApprovalRequest(examId, sessionId, browserKey, clientName);
+        AccessRequest accessRequest = new AccessRequest(examId, sessionId, browserKey, clientName);
 
-        Response<ExamApproval> result = examService.getApproval(examApprovalRequest);
+        Response<ExamApproval> result = examService.getApproval(accessRequest);
 
         assertThat(result.getErrors()).isNotPresent();
         assertThat(result.getData()).isPresent();
@@ -937,9 +937,9 @@ public class ExamServiceImplTest {
                         .withTaCheckinTimeMinutes(20)
                         .build()));
 
-        ExamApprovalRequest examApprovalRequest = new ExamApprovalRequest(examId, sessionId, browserKey, clientName);
+        AccessRequest accessRequest = new AccessRequest(examId, sessionId, browserKey, clientName);
 
-        Response<ExamApproval> result = examService.getApproval(examApprovalRequest);
+        Response<ExamApproval> result = examService.getApproval(accessRequest);
 
         assertThat(result.getErrors()).isPresent();
         assertThat(result.getErrors().get().length).isEqualTo(1);
@@ -980,9 +980,9 @@ public class ExamServiceImplTest {
                         .withTaCheckinTimeMinutes(20)
                         .build()));
 
-        ExamApprovalRequest examApprovalRequest = new ExamApprovalRequest(examId, sessionId, browserKey, clientName);
+        AccessRequest accessRequest = new AccessRequest(examId, sessionId, browserKey, clientName);
 
-        Response<ExamApproval> result = examService.getApproval(examApprovalRequest);
+        Response<ExamApproval> result = examService.getApproval(accessRequest);
 
         assertThat(result.getErrors()).isPresent();
         assertThat(result.getErrors().get().length).isEqualTo(1);
@@ -1023,9 +1023,9 @@ public class ExamServiceImplTest {
                         .withTaCheckinTimeMinutes(20)
                         .build()));
 
-        ExamApprovalRequest examApprovalRequest = new ExamApprovalRequest(examId, sessionId, browserKey, clientName);
+        AccessRequest accessRequest = new AccessRequest(examId, sessionId, browserKey, clientName);
 
-        Response<ExamApproval> result = examService.getApproval(examApprovalRequest);
+        Response<ExamApproval> result = examService.getApproval(accessRequest);
 
         assertThat(result.getErrors()).isPresent();
         assertThat(result.getErrors().get().length).isEqualTo(1);
@@ -1066,9 +1066,9 @@ public class ExamServiceImplTest {
                         .withTaCheckinTimeMinutes(20)
                         .build()));
 
-        ExamApprovalRequest examApprovalRequest = new ExamApprovalRequest(examId, sessionId, browserKey, clientName);
+        AccessRequest accessRequest = new AccessRequest(examId, sessionId, browserKey, clientName);
 
-        Response<ExamApproval> result = examService.getApproval(examApprovalRequest);
+        Response<ExamApproval> result = examService.getApproval(accessRequest);
 
         assertThat(result.getErrors()).isPresent();
         assertThat(result.getErrors().get().length).isEqualTo(1);
@@ -1104,9 +1104,9 @@ public class ExamServiceImplTest {
                         .withTaCheckinTimeMinutes(20)
                         .build()));
 
-        ExamApprovalRequest examApprovalRequest = new ExamApprovalRequest(examId, sessionId, browserKey, clientName);
+        AccessRequest accessRequest = new AccessRequest(examId, sessionId, browserKey, clientName);
 
-        examService.getApproval(examApprovalRequest);
+        examService.getApproval(accessRequest);
     }
 
     @Test(expected = IllegalArgumentException.class)
@@ -1136,9 +1136,9 @@ public class ExamServiceImplTest {
                         .withTaCheckinTimeMinutes(20)
                         .build()));
 
-        ExamApprovalRequest examApprovalRequest = new ExamApprovalRequest(examId, sessionId, browserKey, clientName);
+        AccessRequest accessRequest = new AccessRequest(examId, sessionId, browserKey, clientName);
 
-        examService.getApproval(examApprovalRequest);
+        examService.getApproval(accessRequest);
     }
 
     @Test(expected = IllegalStateException.class)
@@ -1175,9 +1175,9 @@ public class ExamServiceImplTest {
                         .withTaCheckinTimeMinutes(20)
                         .build()));
 
-        ExamApprovalRequest examApprovalRequest = new ExamApprovalRequest(examId, sessionId, browserKey, clientName);
+        AccessRequest accessRequest = new AccessRequest(examId, sessionId, browserKey, clientName);
 
-        examService.getApproval(examApprovalRequest);
+        examService.getApproval(accessRequest);
     }
 
     @Test(expected = IllegalArgumentException.class)
@@ -1210,9 +1210,9 @@ public class ExamServiceImplTest {
         when(timeLimitConfigurationService.findTimeLimitConfiguration(clientName, mockAssessmentId))
                 .thenReturn(Optional.empty());
 
-        ExamApprovalRequest examApprovalRequest = new ExamApprovalRequest(examId, sessionId, browserKey, clientName);
+        AccessRequest accessRequest = new AccessRequest(examId, sessionId, browserKey, clientName);
 
-        examService.getApproval(examApprovalRequest);
+        examService.getApproval(accessRequest);
     }
 
     private Exam createExam(UUID sessionId, UUID thisExamId, String assessmentId, String clientName, long studentId) {

--- a/service/src/test/java/tds/exam/services/impl/ExamServiceImplTest.java
+++ b/service/src/test/java/tds/exam/services/impl/ExamServiceImplTest.java
@@ -17,7 +17,7 @@ import tds.common.ValidationError;
 import tds.config.ClientTestProperty;
 import tds.exam.Exam;
 import tds.exam.ExamApproval;
-import tds.exam.AccessRequest;
+import tds.exam.ApprovalRequest;
 import tds.exam.ExamApprovalStatus;
 import tds.exam.ExamStatusCode;
 import tds.exam.OpenExamRequest;
@@ -752,9 +752,9 @@ public class ExamServiceImplTest {
                         .withTaCheckinTimeMinutes(20)
                         .build()));
 
-        AccessRequest accessRequest = new AccessRequest(examId, sessionId, browserKey, clientName);
+        ApprovalRequest approvalRequest = new ApprovalRequest(examId, sessionId, browserKey, clientName);
 
-        Response<ExamApproval> result = examService.getApproval(accessRequest);
+        Response<ExamApproval> result = examService.getApproval(approvalRequest);
 
         assertThat(result.getErrors()).isNotPresent();
         assertThat(result.getData()).isPresent();
@@ -799,9 +799,9 @@ public class ExamServiceImplTest {
                         .withTaCheckinTimeMinutes(20)
                         .build()));
 
-        AccessRequest accessRequest = new AccessRequest(examId, sessionId, browserKey, clientName);
+        ApprovalRequest approvalRequest = new ApprovalRequest(examId, sessionId, browserKey, clientName);
 
-        Response<ExamApproval> result = examService.getApproval(accessRequest);
+        Response<ExamApproval> result = examService.getApproval(approvalRequest);
 
         assertThat(result.getErrors()).isNotPresent();
         assertThat(result.getData()).isPresent();
@@ -846,9 +846,9 @@ public class ExamServiceImplTest {
                         .withTaCheckinTimeMinutes(20)
                         .build()));
 
-        AccessRequest accessRequest = new AccessRequest(examId, sessionId, browserKey, clientName);
+        ApprovalRequest approvalRequest = new ApprovalRequest(examId, sessionId, browserKey, clientName);
 
-        Response<ExamApproval> result = examService.getApproval(accessRequest);
+        Response<ExamApproval> result = examService.getApproval(approvalRequest);
 
         assertThat(result.getErrors()).isNotPresent();
         assertThat(result.getData()).isPresent();
@@ -857,7 +857,7 @@ public class ExamServiceImplTest {
     }
 
     @Test
-    public void shouldReturnExamApprovalWithDeniedStatusBecauseOfExamStatus() {
+    public void shouldReturnExamApprovalWithCorrectExamStatusBecauseSessionIsProctorless() {
         UUID examId = UUID.randomUUID();
         UUID browserKey = UUID.randomUUID();
         UUID sessionId = UUID.randomUUID();
@@ -872,7 +872,7 @@ public class ExamServiceImplTest {
                         .withBrowserId(browserKey)
                         .withAssessmentId(mockAssessmentId)
                         .withStatus(new ExamStatusCode.Builder()
-                                .withStatus("denied")
+                                .withStatus("approved")
                                 .build())
                         .build()));
         when(sessionService.findSessionById(sessionId))
@@ -893,14 +893,14 @@ public class ExamServiceImplTest {
                         .withTaCheckinTimeMinutes(20)
                         .build()));
 
-        AccessRequest accessRequest = new AccessRequest(examId, sessionId, browserKey, clientName);
+        ApprovalRequest approvalRequest = new ApprovalRequest(examId, sessionId, browserKey, clientName);
 
-        Response<ExamApproval> result = examService.getApproval(accessRequest);
+        Response<ExamApproval> result = examService.getApproval(approvalRequest);
 
         assertThat(result.getErrors()).isNotPresent();
         assertThat(result.getData()).isPresent();
         assertThat(result.getData().get().getExamId()).isEqualTo(examId);
-        assertThat(result.getData().get().getExamApprovalStatus()).isEqualTo(ExamApprovalStatus.DENIED);
+        assertThat(result.getData().get().getExamApprovalStatus()).isEqualTo(ExamApprovalStatus.APPROVED);
     }
 
     @Test
@@ -937,9 +937,9 @@ public class ExamServiceImplTest {
                         .withTaCheckinTimeMinutes(20)
                         .build()));
 
-        AccessRequest accessRequest = new AccessRequest(examId, sessionId, browserKey, clientName);
+        ApprovalRequest approvalRequest = new ApprovalRequest(examId, sessionId, browserKey, clientName);
 
-        Response<ExamApproval> result = examService.getApproval(accessRequest);
+        Response<ExamApproval> result = examService.getApproval(approvalRequest);
 
         assertThat(result.getErrors()).isPresent();
         assertThat(result.getErrors().get().length).isEqualTo(1);
@@ -980,9 +980,9 @@ public class ExamServiceImplTest {
                         .withTaCheckinTimeMinutes(20)
                         .build()));
 
-        AccessRequest accessRequest = new AccessRequest(examId, sessionId, browserKey, clientName);
+        ApprovalRequest approvalRequest = new ApprovalRequest(examId, sessionId, browserKey, clientName);
 
-        Response<ExamApproval> result = examService.getApproval(accessRequest);
+        Response<ExamApproval> result = examService.getApproval(approvalRequest);
 
         assertThat(result.getErrors()).isPresent();
         assertThat(result.getErrors().get().length).isEqualTo(1);
@@ -1023,9 +1023,9 @@ public class ExamServiceImplTest {
                         .withTaCheckinTimeMinutes(20)
                         .build()));
 
-        AccessRequest accessRequest = new AccessRequest(examId, sessionId, browserKey, clientName);
+        ApprovalRequest approvalRequest = new ApprovalRequest(examId, sessionId, browserKey, clientName);
 
-        Response<ExamApproval> result = examService.getApproval(accessRequest);
+        Response<ExamApproval> result = examService.getApproval(approvalRequest);
 
         assertThat(result.getErrors()).isPresent();
         assertThat(result.getErrors().get().length).isEqualTo(1);
@@ -1066,9 +1066,9 @@ public class ExamServiceImplTest {
                         .withTaCheckinTimeMinutes(20)
                         .build()));
 
-        AccessRequest accessRequest = new AccessRequest(examId, sessionId, browserKey, clientName);
+        ApprovalRequest approvalRequest = new ApprovalRequest(examId, sessionId, browserKey, clientName);
 
-        Response<ExamApproval> result = examService.getApproval(accessRequest);
+        Response<ExamApproval> result = examService.getApproval(approvalRequest);
 
         assertThat(result.getErrors()).isPresent();
         assertThat(result.getErrors().get().length).isEqualTo(1);
@@ -1104,9 +1104,9 @@ public class ExamServiceImplTest {
                         .withTaCheckinTimeMinutes(20)
                         .build()));
 
-        AccessRequest accessRequest = new AccessRequest(examId, sessionId, browserKey, clientName);
+        ApprovalRequest approvalRequest = new ApprovalRequest(examId, sessionId, browserKey, clientName);
 
-        examService.getApproval(accessRequest);
+        examService.getApproval(approvalRequest);
     }
 
     @Test(expected = IllegalArgumentException.class)
@@ -1136,9 +1136,9 @@ public class ExamServiceImplTest {
                         .withTaCheckinTimeMinutes(20)
                         .build()));
 
-        AccessRequest accessRequest = new AccessRequest(examId, sessionId, browserKey, clientName);
+        ApprovalRequest approvalRequest = new ApprovalRequest(examId, sessionId, browserKey, clientName);
 
-        examService.getApproval(accessRequest);
+        examService.getApproval(approvalRequest);
     }
 
     @Test(expected = IllegalStateException.class)
@@ -1175,9 +1175,9 @@ public class ExamServiceImplTest {
                         .withTaCheckinTimeMinutes(20)
                         .build()));
 
-        AccessRequest accessRequest = new AccessRequest(examId, sessionId, browserKey, clientName);
+        ApprovalRequest approvalRequest = new ApprovalRequest(examId, sessionId, browserKey, clientName);
 
-        examService.getApproval(accessRequest);
+        examService.getApproval(approvalRequest);
     }
 
     @Test(expected = IllegalArgumentException.class)
@@ -1210,9 +1210,9 @@ public class ExamServiceImplTest {
         when(timeLimitConfigurationService.findTimeLimitConfiguration(clientName, mockAssessmentId))
                 .thenReturn(Optional.empty());
 
-        AccessRequest accessRequest = new AccessRequest(examId, sessionId, browserKey, clientName);
+        ApprovalRequest approvalRequest = new ApprovalRequest(examId, sessionId, browserKey, clientName);
 
-        examService.getApproval(accessRequest);
+        examService.getApproval(approvalRequest);
     }
 
     private Exam createExam(UUID sessionId, UUID thisExamId, String assessmentId, String clientName, long studentId) {

--- a/service/src/test/java/tds/exam/web/endpoints/ExamControllerTest.java
+++ b/service/src/test/java/tds/exam/web/endpoints/ExamControllerTest.java
@@ -105,18 +105,18 @@ public class ExamControllerTest {
         UUID sessionId = UUID.randomUUID();
         UUID browserId = UUID.randomUUID();
         String clientName = "UNIT_TEST";
-        AccessRequest accessRequest = new AccessRequest(examId, sessionId, browserId, clientName);
+        ApprovalRequest approvalRequest = new ApprovalRequest(examId, sessionId, browserId, clientName);
 
         ExamApproval mockExamApproval =
                 new ExamApproval(examId, new ExamStatusCode.Builder().withStatus("approved").build(), null);
-        when(examService.getApproval(Matchers.isA(AccessRequest.class))).thenReturn(new Response<>(mockExamApproval));
+        when(examService.getApproval(Matchers.isA(ApprovalRequest.class))).thenReturn(new Response<>(mockExamApproval));
 
         ResponseEntity<ExamApprovalResource> response = controller.getApproval(
-                accessRequest.getExamId(),
-                accessRequest.getSessionId(),
-                accessRequest.getBrowserId(),
-                accessRequest.getClientName());
-        verify(examService).getApproval(Matchers.isA(AccessRequest.class));
+                approvalRequest.getExamId(),
+                approvalRequest.getSessionId(),
+                approvalRequest.getBrowserId(),
+                approvalRequest.getClientName());
+        verify(examService).getApproval(Matchers.isA(ApprovalRequest.class));
 
         assertThat(response.getStatusCode()).isEqualTo(HttpStatus.OK);
         assertThat(response.getBody().getErrors()).isNull();
@@ -131,17 +131,17 @@ public class ExamControllerTest {
         UUID sessionId = UUID.randomUUID();
         UUID browserId = UUID.randomUUID();
         String clientName = "UNIT_TEST";
-        AccessRequest accessRequest = new AccessRequest(examId, sessionId, browserId, clientName);
+        ApprovalRequest approvalRequest = new ApprovalRequest(examId, sessionId, browserId, clientName);
 
-        when(examService.getApproval(Matchers.isA(AccessRequest.class))).thenReturn(
+        when(examService.getApproval(Matchers.isA(ApprovalRequest.class))).thenReturn(
                 new Response<>(new ExamApproval(examId, new ExamStatusCode.Builder().withStatus("pending").build(), null)));
 
         ResponseEntity<ExamApprovalResource> response = controller.getApproval(
-                accessRequest.getExamId(),
-                accessRequest.getSessionId(),
-                accessRequest.getBrowserId(),
-                accessRequest.getClientName());
-        verify(examService).getApproval(Matchers.isA(AccessRequest.class));
+                approvalRequest.getExamId(),
+                approvalRequest.getSessionId(),
+                approvalRequest.getBrowserId(),
+                approvalRequest.getClientName());
+        verify(examService).getApproval(Matchers.isA(ApprovalRequest.class));
 
         assertThat(response.getStatusCode()).isEqualTo(HttpStatus.OK);
         assertThat(response.getBody().getErrors()).isNull();
@@ -156,17 +156,17 @@ public class ExamControllerTest {
         UUID sessionId = UUID.randomUUID();
         UUID browserId = UUID.randomUUID();
         String clientName = "UNIT_TEST";
-        AccessRequest accessRequest = new AccessRequest(examId, sessionId, browserId, clientName);
+        ApprovalRequest approvalRequest = new ApprovalRequest(examId, sessionId, browserId, clientName);
 
-        when(examService.getApproval(Matchers.isA(AccessRequest.class))).thenReturn(
+        when(examService.getApproval(Matchers.isA(ApprovalRequest.class))).thenReturn(
                 new Response<>(new ExamApproval(examId, new ExamStatusCode.Builder().withStatus("paused").build(), null)));
 
         ResponseEntity<ExamApprovalResource> response = controller.getApproval(
-                accessRequest.getExamId(),
-                accessRequest.getSessionId(),
-                accessRequest.getBrowserId(),
-                accessRequest.getClientName());
-        verify(examService).getApproval(Matchers.isA(AccessRequest.class));
+                approvalRequest.getExamId(),
+                approvalRequest.getSessionId(),
+                approvalRequest.getBrowserId(),
+                approvalRequest.getClientName());
+        verify(examService).getApproval(Matchers.isA(ApprovalRequest.class));
 
         assertThat(response.getStatusCode()).isEqualTo(HttpStatus.OK);
         assertThat(response.getBody().getErrors()).isNull();
@@ -181,17 +181,17 @@ public class ExamControllerTest {
         UUID sessionId = UUID.randomUUID();
         UUID browserId = UUID.randomUUID();
         String clientName = "UNIT_TEST";
-        AccessRequest accessRequest = new AccessRequest(examId, sessionId, browserId, clientName);
+        ApprovalRequest approvalRequest = new ApprovalRequest(examId, sessionId, browserId, clientName);
 
-        when(examService.getApproval(Matchers.isA(AccessRequest.class))).thenReturn(
+        when(examService.getApproval(Matchers.isA(ApprovalRequest.class))).thenReturn(
                 new Response<>(new ExamApproval(examId, new ExamStatusCode.Builder().withStatus("denied").build(), null)));
 
         ResponseEntity<ExamApprovalResource> response = controller.getApproval(
-                accessRequest.getExamId(),
-                accessRequest.getSessionId(),
-                accessRequest.getBrowserId(),
-                accessRequest.getClientName());
-        verify(examService).getApproval(Matchers.isA(AccessRequest.class));
+                approvalRequest.getExamId(),
+                approvalRequest.getSessionId(),
+                approvalRequest.getBrowserId(),
+                approvalRequest.getClientName());
+        verify(examService).getApproval(Matchers.isA(ApprovalRequest.class));
 
         assertThat(response.getStatusCode()).isEqualTo(HttpStatus.OK);
         assertThat(response.getBody().getErrors()).isNull();
@@ -206,17 +206,17 @@ public class ExamControllerTest {
         UUID sessionId = UUID.randomUUID();
         UUID browserId = UUID.randomUUID();
         String clientName = "UNIT_TEST";
-        AccessRequest accessRequest = new AccessRequest(examId, sessionId, browserId, clientName);
+        ApprovalRequest approvalRequest = new ApprovalRequest(examId, sessionId, browserId, clientName);
 
         Response<ExamApproval> errorResponse = new Response<ExamApproval>(new ValidationError(ValidationErrorCode.EXAM_APPROVAL_BROWSER_ID_MISMATCH, "foo"));
-        when(examService.getApproval(Matchers.isA(AccessRequest.class))).thenReturn(errorResponse);
+        when(examService.getApproval(Matchers.isA(ApprovalRequest.class))).thenReturn(errorResponse);
 
         ResponseEntity<ExamApprovalResource> response = controller.getApproval(
-                accessRequest.getExamId(),
-                accessRequest.getSessionId(),
-                accessRequest.getBrowserId(),
-                accessRequest.getClientName());
-        verify(examService).getApproval(Matchers.isA(AccessRequest.class));
+                approvalRequest.getExamId(),
+                approvalRequest.getSessionId(),
+                approvalRequest.getBrowserId(),
+                approvalRequest.getClientName());
+        verify(examService).getApproval(Matchers.isA(ApprovalRequest.class));
 
         assertThat(response.getStatusCode()).isEqualTo(HttpStatus.UNPROCESSABLE_ENTITY);
         assertThat(response.getBody().getErrors()).isNotNull();

--- a/service/src/test/java/tds/exam/web/endpoints/ExamControllerTest.java
+++ b/service/src/test/java/tds/exam/web/endpoints/ExamControllerTest.java
@@ -105,18 +105,18 @@ public class ExamControllerTest {
         UUID sessionId = UUID.randomUUID();
         UUID browserId = UUID.randomUUID();
         String clientName = "UNIT_TEST";
-        ExamApprovalRequest examApprovalRequest = new ExamApprovalRequest(examId, sessionId, browserId, clientName);
+        AccessRequest accessRequest = new AccessRequest(examId, sessionId, browserId, clientName);
 
         ExamApproval mockExamApproval =
                 new ExamApproval(examId, new ExamStatusCode.Builder().withStatus("approved").build(), null);
-        when(examService.getApproval(Matchers.isA(ExamApprovalRequest.class))).thenReturn(new Response<>(mockExamApproval));
+        when(examService.getApproval(Matchers.isA(AccessRequest.class))).thenReturn(new Response<>(mockExamApproval));
 
         ResponseEntity<ExamApprovalResource> response = controller.getApproval(
-                examApprovalRequest.getExamId(),
-                examApprovalRequest.getSessionId(),
-                examApprovalRequest.getBrowserId(),
-                examApprovalRequest.getClientName());
-        verify(examService).getApproval(Matchers.isA(ExamApprovalRequest.class));
+                accessRequest.getExamId(),
+                accessRequest.getSessionId(),
+                accessRequest.getBrowserId(),
+                accessRequest.getClientName());
+        verify(examService).getApproval(Matchers.isA(AccessRequest.class));
 
         assertThat(response.getStatusCode()).isEqualTo(HttpStatus.OK);
         assertThat(response.getBody().getErrors()).isNull();
@@ -131,17 +131,17 @@ public class ExamControllerTest {
         UUID sessionId = UUID.randomUUID();
         UUID browserId = UUID.randomUUID();
         String clientName = "UNIT_TEST";
-        ExamApprovalRequest examApprovalRequest = new ExamApprovalRequest(examId, sessionId, browserId, clientName);
+        AccessRequest accessRequest = new AccessRequest(examId, sessionId, browserId, clientName);
 
-        when(examService.getApproval(Matchers.isA(ExamApprovalRequest.class))).thenReturn(
+        when(examService.getApproval(Matchers.isA(AccessRequest.class))).thenReturn(
                 new Response<>(new ExamApproval(examId, new ExamStatusCode.Builder().withStatus("pending").build(), null)));
 
         ResponseEntity<ExamApprovalResource> response = controller.getApproval(
-                examApprovalRequest.getExamId(),
-                examApprovalRequest.getSessionId(),
-                examApprovalRequest.getBrowserId(),
-                examApprovalRequest.getClientName());
-        verify(examService).getApproval(Matchers.isA(ExamApprovalRequest.class));
+                accessRequest.getExamId(),
+                accessRequest.getSessionId(),
+                accessRequest.getBrowserId(),
+                accessRequest.getClientName());
+        verify(examService).getApproval(Matchers.isA(AccessRequest.class));
 
         assertThat(response.getStatusCode()).isEqualTo(HttpStatus.OK);
         assertThat(response.getBody().getErrors()).isNull();
@@ -156,17 +156,17 @@ public class ExamControllerTest {
         UUID sessionId = UUID.randomUUID();
         UUID browserId = UUID.randomUUID();
         String clientName = "UNIT_TEST";
-        ExamApprovalRequest examApprovalRequest = new ExamApprovalRequest(examId, sessionId, browserId, clientName);
+        AccessRequest accessRequest = new AccessRequest(examId, sessionId, browserId, clientName);
 
-        when(examService.getApproval(Matchers.isA(ExamApprovalRequest.class))).thenReturn(
+        when(examService.getApproval(Matchers.isA(AccessRequest.class))).thenReturn(
                 new Response<>(new ExamApproval(examId, new ExamStatusCode.Builder().withStatus("paused").build(), null)));
 
         ResponseEntity<ExamApprovalResource> response = controller.getApproval(
-                examApprovalRequest.getExamId(),
-                examApprovalRequest.getSessionId(),
-                examApprovalRequest.getBrowserId(),
-                examApprovalRequest.getClientName());
-        verify(examService).getApproval(Matchers.isA(ExamApprovalRequest.class));
+                accessRequest.getExamId(),
+                accessRequest.getSessionId(),
+                accessRequest.getBrowserId(),
+                accessRequest.getClientName());
+        verify(examService).getApproval(Matchers.isA(AccessRequest.class));
 
         assertThat(response.getStatusCode()).isEqualTo(HttpStatus.OK);
         assertThat(response.getBody().getErrors()).isNull();
@@ -181,17 +181,17 @@ public class ExamControllerTest {
         UUID sessionId = UUID.randomUUID();
         UUID browserId = UUID.randomUUID();
         String clientName = "UNIT_TEST";
-        ExamApprovalRequest examApprovalRequest = new ExamApprovalRequest(examId, sessionId, browserId, clientName);
+        AccessRequest accessRequest = new AccessRequest(examId, sessionId, browserId, clientName);
 
-        when(examService.getApproval(Matchers.isA(ExamApprovalRequest.class))).thenReturn(
+        when(examService.getApproval(Matchers.isA(AccessRequest.class))).thenReturn(
                 new Response<>(new ExamApproval(examId, new ExamStatusCode.Builder().withStatus("denied").build(), null)));
 
         ResponseEntity<ExamApprovalResource> response = controller.getApproval(
-                examApprovalRequest.getExamId(),
-                examApprovalRequest.getSessionId(),
-                examApprovalRequest.getBrowserId(),
-                examApprovalRequest.getClientName());
-        verify(examService).getApproval(Matchers.isA(ExamApprovalRequest.class));
+                accessRequest.getExamId(),
+                accessRequest.getSessionId(),
+                accessRequest.getBrowserId(),
+                accessRequest.getClientName());
+        verify(examService).getApproval(Matchers.isA(AccessRequest.class));
 
         assertThat(response.getStatusCode()).isEqualTo(HttpStatus.OK);
         assertThat(response.getBody().getErrors()).isNull();
@@ -206,17 +206,17 @@ public class ExamControllerTest {
         UUID sessionId = UUID.randomUUID();
         UUID browserId = UUID.randomUUID();
         String clientName = "UNIT_TEST";
-        ExamApprovalRequest examApprovalRequest = new ExamApprovalRequest(examId, sessionId, browserId, clientName);
+        AccessRequest accessRequest = new AccessRequest(examId, sessionId, browserId, clientName);
 
         Response<ExamApproval> errorResponse = new Response<ExamApproval>(new ValidationError(ValidationErrorCode.EXAM_APPROVAL_BROWSER_ID_MISMATCH, "foo"));
-        when(examService.getApproval(Matchers.isA(ExamApprovalRequest.class))).thenReturn(errorResponse);
+        when(examService.getApproval(Matchers.isA(AccessRequest.class))).thenReturn(errorResponse);
 
         ResponseEntity<ExamApprovalResource> response = controller.getApproval(
-                examApprovalRequest.getExamId(),
-                examApprovalRequest.getSessionId(),
-                examApprovalRequest.getBrowserId(),
-                examApprovalRequest.getClientName());
-        verify(examService).getApproval(Matchers.isA(ExamApprovalRequest.class));
+                accessRequest.getExamId(),
+                accessRequest.getSessionId(),
+                accessRequest.getBrowserId(),
+                accessRequest.getClientName());
+        verify(examService).getApproval(Matchers.isA(AccessRequest.class));
 
         assertThat(response.getStatusCode()).isEqualTo(HttpStatus.UNPROCESSABLE_ENTITY);
         assertThat(response.getBody().getErrors()).isNotNull();


### PR DESCRIPTION
This pull request addresses TDS-349: implement a refactored version of `ValidateTesteeAccess_SP`.  `ValidateTesteeAccess_SP` conducts similar steps to the legacy `checkApproval` method, so the rules that were previously leveraged in `checkApproval` have been moved to its own method.

* Added `verifyAccess` method, which is called by `getApproval()` (previously called `verifyExamApprovalRules`).
  * The `verifyAccess` method does not currently have an HTTP endpoint; the assumption here is that this method will be called internally by other methods within the exam service
  * If other micro service methods (e.g. session or student microservices) need to call `verifyAccess`, an HTTP endpoint can easily be added
* Renamed classes that were specific to `getApproval` from `Approval` to `Access`

**NOTE:** This pull request is dependent upon the [`feature/verify-access`](https://github.com/SmarterApp/TDS_SessionService/pull/13) pull request against **TDS_Session**.  