### PR TITLE
Add clientName parameter to AssessmentService.findAssessmentByKey()

### DIFF
--- a/service/src/main/java/tds/exam/services/AssessmentService.java
+++ b/service/src/main/java/tds/exam/services/AssessmentService.java
@@ -10,8 +10,10 @@ import tds.assessment.Assessment;
 public interface AssessmentService {
     /**
      * Finds the {@link tds.assessment.Assessment}
+     *
+     * @param clientName The name of the client (e.g. SBAC or SBAC_PT)
      * @param key unique key for the assessment
      * @return {@link tds.assessment.Assessment the assessment}
      */
-    Optional<Assessment> findAssessmentByKey(String key);
+    Optional<Assessment> findAssessmentByKey(String clientName, String key);
 }

--- a/service/src/main/java/tds/exam/services/impl/AssessmentServiceImpl.java
+++ b/service/src/main/java/tds/exam/services/impl/AssessmentServiceImpl.java
@@ -25,10 +25,10 @@ class AssessmentServiceImpl implements AssessmentService {
     }
 
     @Override
-    public Optional<Assessment> findAssessmentByKey(String key) {
+    public Optional<Assessment> findAssessmentByKey(final String clientName, final String key) {
         UriComponentsBuilder builder =
             UriComponentsBuilder
-                .fromHttpUrl(String.format("%s/%s", examServiceProperties.getAssessmentUrl(), key));
+                .fromHttpUrl(String.format("%s/%s/assessments/%s", examServiceProperties.getAssessmentUrl(), clientName, key));
 
         Optional<Assessment> maybeAssessment = Optional.empty();
         try {

--- a/service/src/main/java/tds/exam/services/impl/ExamServiceImpl.java
+++ b/service/src/main/java/tds/exam/services/impl/ExamServiceImpl.java
@@ -139,7 +139,8 @@ class ExamServiceImpl implements ExamService {
             }
         }
 
-        Optional<Assessment> maybeAssessment = assessmentService.findAssessmentByKey(openExamRequest.getAssessmentKey());
+        Optional<Assessment> maybeAssessment = assessmentService.findAssessmentByKey(openExamRequest.getClientName(),
+            openExamRequest.getAssessmentKey());
         if (!maybeAssessment.isPresent()) {
             throw new IllegalArgumentException(String.format("Assessment information could not be found for assessment key %s", openExamRequest.getAssessmentKey()));
         }
@@ -222,7 +223,8 @@ class ExamServiceImpl implements ExamService {
 
         // If the ability was not retrieved from any of the exam tables, query the assessment service
         if (!ability.isPresent()) {
-            Optional<Assessment> maybeAssessment = assessmentService.findAssessmentByKey(exam.getAssessmentId());
+            Optional<Assessment> maybeAssessment = assessmentService.findAssessmentByKey(exam.getClientName(),
+                exam.getAssessmentId());
             if (maybeAssessment.isPresent()) {
                 ability = Optional.of((double) maybeAssessment.get().getStartAbility());
             } else {

--- a/service/src/test/java/tds/exam/services/impl/AssessmentServiceImplTest.java
+++ b/service/src/test/java/tds/exam/services/impl/AssessmentServiceImplTest.java
@@ -30,7 +30,7 @@ public class AssessmentServiceImplTest {
     public void setUp() {
         restTemplate = mock(RestTemplate.class);
         ExamServiceProperties properties = new ExamServiceProperties();
-        properties.setAssessmentUrl("http://localhost:8080/assessments");
+        properties.setAssessmentUrl("http://localhost:8080");
         assessmentService = new AssessmentServiceImpl(restTemplate, properties);
     }
 
@@ -51,25 +51,25 @@ public class AssessmentServiceImplTest {
         assessment.setSelectionAlgorithm(Algorithm.VIRTUAL);
         assessment.setStartAbility(100);
 
-        when(restTemplate.getForObject("http://localhost:8080/assessments/key", Assessment.class)).thenReturn(assessment);
-        Optional<Assessment> maybeAssessment = assessmentService.findAssessmentByKey("key");
-        verify(restTemplate).getForObject("http://localhost:8080/assessments/key", Assessment.class);
+        when(restTemplate.getForObject("http://localhost:8080/clientname/assessments/key", Assessment.class)).thenReturn(assessment);
+        Optional<Assessment> maybeAssessment = assessmentService.findAssessmentByKey("clientname", "key");
+        verify(restTemplate).getForObject("http://localhost:8080/clientname/assessments/key", Assessment.class);
 
         assertThat(maybeAssessment.get()).isEqualTo(assessment);
     }
 
     @Test
     public void shouldReturnEmptyWhenSetOfAdminSubjectNotFound() {
-        when(restTemplate.getForObject("http://localhost:8080/assessments/key", Assessment.class)).thenThrow(new HttpClientErrorException(HttpStatus.NOT_FOUND));
-        Optional<Assessment> maybeAssessment = assessmentService.findAssessmentByKey("key");
-        verify(restTemplate).getForObject("http://localhost:8080/assessments/key", Assessment.class);
+        when(restTemplate.getForObject("http://localhost:8080/clientname/assessments/key", Assessment.class)).thenThrow(new HttpClientErrorException(HttpStatus.NOT_FOUND));
+        Optional<Assessment> maybeAssessment = assessmentService.findAssessmentByKey("clientname", "key");
+        verify(restTemplate).getForObject("http://localhost:8080/clientname/assessments/key", Assessment.class);
 
         assertThat(maybeAssessment).isNotPresent();
     }
 
     @Test (expected = RestClientException.class)
     public void shouldThrowIfStatusNotNotFoundWhenUnexpectedErrorFindingSetOfAdminSubject() {
-        when(restTemplate.getForObject("http://localhost:8080/assessments/key", Assessment.class)).thenThrow(new HttpClientErrorException(HttpStatus.BAD_REQUEST));
-        assessmentService.findAssessmentByKey("key");
+        when(restTemplate.getForObject("http://localhost:8080/clientname/assessments/key", Assessment.class)).thenThrow(new HttpClientErrorException(HttpStatus.BAD_REQUEST));
+        assessmentService.findAssessmentByKey("clientname", "key");
     }
 }

--- a/service/src/test/java/tds/exam/services/impl/ExamServiceImplTest.java
+++ b/service/src/test/java/tds/exam/services/impl/ExamServiceImplTest.java
@@ -202,7 +202,7 @@ public class ExamServiceImplTest {
         Assessment assessment = new AssessmentBuilder().build();
 
         when(mockSessionService.findExternalSessionConfigurationByClientName(openExamRequest.getClientName())).thenReturn(Optional.of(extSessionConfig));
-        when(mockAssessmentService.findAssessmentByKey(openExamRequest.getAssessmentKey())).thenReturn(Optional.of(assessment));
+        when(mockAssessmentService.findAssessmentByKey(openExamRequest.getClientName(), openExamRequest.getAssessmentKey())).thenReturn(Optional.of(assessment));
         when(mockSessionService.findSessionById(openExamRequest.getSessionId())).thenReturn(Optional.of(currentSession));
         when(mockStudentService.getStudentById(openExamRequest.getStudentId())).thenReturn(Optional.of(student));
         when(mockExamQueryRepository.getLastAvailableExam(openExamRequest.getStudentId(), assessment.getAssessmentId(), openExamRequest.getClientName())).thenReturn(Optional.of(previousExam));
@@ -251,7 +251,7 @@ public class ExamServiceImplTest {
 
         when(mockSessionService.findSessionById(openExamRequest.getSessionId())).thenReturn(Optional.of(currentSession));
         when(mockStudentService.getStudentById(openExamRequest.getStudentId())).thenReturn(Optional.of(student));
-        when(mockAssessmentService.findAssessmentByKey(openExamRequest.getAssessmentKey())).thenReturn(Optional.of(assessment));
+        when(mockAssessmentService.findAssessmentByKey(openExamRequest.getClientName(), openExamRequest.getAssessmentKey())).thenReturn(Optional.of(assessment));
         when(mockExamQueryRepository.getLastAvailableExam(openExamRequest.getStudentId(), assessment.getAssessmentId(), openExamRequest.getClientName())).thenReturn(Optional.of(previousExam));
         when(mockSessionService.findSessionById(previousSession.getId())).thenReturn(Optional.of(previousSession));
         when(mockSessionService.findExternalSessionConfigurationByClientName(openExamRequest.getClientName())).thenReturn(Optional.of(externalSessionConfiguration));
@@ -304,7 +304,7 @@ public class ExamServiceImplTest {
         when(mockConfigService.findClientSystemFlag(openExamRequest.getClientName(), ALLOW_ANONYMOUS_STUDENT_FLAG_TYPE)).thenReturn(Optional.of(clientSystemFlag));
         when(mockSessionService.findSessionById(openExamRequest.getSessionId())).thenReturn(Optional.of(currentSession));
         when(mockStudentService.getStudentById(openExamRequest.getStudentId())).thenReturn(Optional.empty());
-        when(mockAssessmentService.findAssessmentByKey(openExamRequest.getAssessmentKey())).thenReturn(Optional.of(assessment));
+        when(mockAssessmentService.findAssessmentByKey(openExamRequest.getClientName(), openExamRequest.getAssessmentKey())).thenReturn(Optional.of(assessment));
         when(mockExamQueryRepository.getLastAvailableExam(openExamRequest.getStudentId(), assessment.getAssessmentId(), openExamRequest.getClientName())).thenReturn(Optional.empty());
         when(mockSessionService.findExternalSessionConfigurationByClientName(openExamRequest.getClientName())).thenReturn(Optional.of(extSessionConfig));
         when(mockConfigService.findAssessmentWindows(openExamRequest.getClientName(), assessment.getAssessmentId(), currentSession.getType(), openExamRequest.getStudentId(), extSessionConfig))
@@ -375,7 +375,7 @@ public class ExamServiceImplTest {
         when(mockConfigService.findClientSystemFlag(openExamRequest.getClientName(), ALLOW_ANONYMOUS_STUDENT_FLAG_TYPE)).thenReturn(Optional.of(clientSystemFlag));
         when(mockSessionService.findSessionById(openExamRequest.getSessionId())).thenReturn(Optional.of(currentSession));
         when(mockStudentService.getStudentById(openExamRequest.getStudentId())).thenReturn(Optional.empty());
-        when(mockAssessmentService.findAssessmentByKey(openExamRequest.getAssessmentKey())).thenReturn(Optional.of(assessment));
+        when(mockAssessmentService.findAssessmentByKey(openExamRequest.getClientName(), openExamRequest.getAssessmentKey())).thenReturn(Optional.of(assessment));
         when(mockExamQueryRepository.getLastAvailableExam(openExamRequest.getStudentId(), assessment.getAssessmentId(), openExamRequest.getClientName())).thenReturn(Optional.empty());
         when(mockConfigService.findAssessmentWindows(openExamRequest.getClientName(), assessment.getAssessmentId(), currentSession.getType(), openExamRequest.getStudentId(), extSessionConfig))
             .thenReturn(Collections.singletonList(window));
@@ -440,7 +440,7 @@ public class ExamServiceImplTest {
 
         when(mockSessionService.findSessionById(openExamRequest.getSessionId())).thenReturn(Optional.of(currentSession));
         when(mockStudentService.getStudentById(openExamRequest.getStudentId())).thenReturn(Optional.of(student));
-        when(mockAssessmentService.findAssessmentByKey(openExamRequest.getAssessmentKey())).thenReturn(Optional.of(assessment));
+        when(mockAssessmentService.findAssessmentByKey(openExamRequest.getClientName(), openExamRequest.getAssessmentKey())).thenReturn(Optional.of(assessment));
         when(mockExamQueryRepository.getLastAvailableExam(openExamRequest.getStudentId(), assessment.getAssessmentId(), openExamRequest.getClientName())).thenReturn(Optional.empty());
         when(mockSessionService.findExternalSessionConfigurationByClientName(openExamRequest.getClientName())).thenReturn(Optional.of(extSessionConfig));
         when(mockStudentService.findStudentPackageAttributes(openExamRequest.getStudentId(), openExamRequest.getClientName(), EXTERNAL_ID, ENTITY_NAME, ACCOMMODATIONS))
@@ -498,7 +498,7 @@ public class ExamServiceImplTest {
 
         when(mockSessionService.findSessionById(request.getSessionId())).thenReturn(Optional.of(currentSession));
         when(mockStudentService.getStudentById(1)).thenReturn(Optional.of(student));
-        when(mockAssessmentService.findAssessmentByKey(request.getAssessmentKey())).thenReturn(Optional.of(assessment));
+        when(mockAssessmentService.findAssessmentByKey(request.getClientName(), request.getAssessmentKey())).thenReturn(Optional.of(assessment));
         when(mockExamQueryRepository.getLastAvailableExam(request.getStudentId(), assessment.getAssessmentId(), request.getClientName())).thenReturn(Optional.of(previousExam));
         when(mockSessionService.findSessionById(previousSession.getId())).thenReturn(Optional.of(previousSession));
         when(mockSessionService.findExternalSessionConfigurationByClientName(request.getClientName())).thenReturn(Optional.of(externalSessionConfiguration));
@@ -554,7 +554,7 @@ public class ExamServiceImplTest {
 
         when(mockSessionService.findSessionById(request.getSessionId())).thenReturn(Optional.of(currentSession));
         when(mockStudentService.getStudentById(request.getStudentId())).thenReturn(Optional.of(student));
-        when(mockAssessmentService.findAssessmentByKey(request.getAssessmentKey())).thenReturn(Optional.of(assessment));
+        when(mockAssessmentService.findAssessmentByKey(request.getClientName(), request.getAssessmentKey())).thenReturn(Optional.of(assessment));
         when(mockExamQueryRepository.getLastAvailableExam(request.getStudentId(), assessment.getAssessmentId(), request.getClientName())).thenReturn(Optional.of(previousExam));
         when(mockSessionService.findSessionById(previousSession.getId())).thenReturn(Optional.of(previousSession));
         when(mockExamStatusQueryRepository.findExamStatusCode(STATUS_PENDING)).thenReturn(new ExamStatusCode(STATUS_PENDING, OPEN));
@@ -599,7 +599,7 @@ public class ExamServiceImplTest {
 
         when(mockSessionService.findSessionById(request.getSessionId())).thenReturn(Optional.of(currentSession));
         when(mockStudentService.getStudentById(request.getStudentId())).thenReturn(Optional.of(student));
-        when(mockAssessmentService.findAssessmentByKey(request.getAssessmentKey())).thenReturn(Optional.of(assessment));
+        when(mockAssessmentService.findAssessmentByKey(request.getClientName(), request.getAssessmentKey())).thenReturn(Optional.of(assessment));
         when(mockExamQueryRepository.getLastAvailableExam(request.getStudentId(), assessment.getAssessmentId(), request.getClientName())).thenReturn(Optional.of(previousExam));
         when(mockSessionService.findSessionById(previousSession.getId())).thenReturn(Optional.of(previousSession));
         ExternalSessionConfiguration externalSessionConfiguration = new ExternalSessionConfigurationBuilder().build();
@@ -647,7 +647,7 @@ public class ExamServiceImplTest {
 
         when(mockSessionService.findSessionById(request.getSessionId())).thenReturn(Optional.of(currentSession));
         when(mockStudentService.getStudentById(request.getStudentId())).thenReturn(Optional.of(student));
-        when(mockAssessmentService.findAssessmentByKey(request.getAssessmentKey())).thenReturn(Optional.of(assessment));
+        when(mockAssessmentService.findAssessmentByKey(request.getClientName(), request.getAssessmentKey())).thenReturn(Optional.of(assessment));
         when(mockExamQueryRepository.getLastAvailableExam(request.getStudentId(), assessment.getAssessmentId(), request.getClientName())).thenReturn(Optional.of(previousExam));
         when(mockSessionService.findSessionById(previousSession.getId())).thenReturn(Optional.of(previousSession));
         when(mockSessionService.findExternalSessionConfigurationByClientName(request.getClientName())).thenReturn(Optional.of(externalSessionConfiguration));
@@ -696,7 +696,7 @@ public class ExamServiceImplTest {
         when(mockExamQueryRepository.getLastAvailableExam(request.getStudentId(), assessment.getAssessmentId(), request.getClientName())).thenReturn(Optional.of(previousExam));
         when(mockSessionService.findSessionById(previousSession.getId())).thenReturn(Optional.of(previousSession));
         when(mockSessionService.findExternalSessionConfigurationByClientName(request.getClientName())).thenReturn(Optional.of(externalSessionConfiguration));
-        when(mockAssessmentService.findAssessmentByKey(request.getAssessmentKey())).thenReturn(Optional.of(assessment));
+        when(mockAssessmentService.findAssessmentByKey(request.getClientName(), request.getAssessmentKey())).thenReturn(Optional.of(assessment));
         when(mockExamStatusQueryRepository.findExamStatusCode(STATUS_SUSPENDED)).thenReturn(new ExamStatusCode(STATUS_SUSPENDED, INUSE));
 
         Response<Exam> examResponse = examService.openExam(request);
@@ -828,7 +828,7 @@ public class ExamServiceImplTest {
         when(mockExamQueryRepository.findAbilities(thisExamId, clientName, "ELA", studentId)).thenReturn(abilities);
         when(mockHistoryRepository.findAbilityFromHistoryForSubjectAndStudent(clientName, "ELA", studentId))
             .thenReturn(Optional.empty());
-        when(mockAssessmentService.findAssessmentByKey(thisExam.getAssessmentId())).thenReturn(Optional.empty());
+        when(mockAssessmentService.findAssessmentByKey(thisExam.getClientName(), thisExam.getAssessmentId())).thenReturn(Optional.empty());
         Optional<Double> maybeAbilityReturned = examService.getInitialAbility(thisExam, clientTestProperty);
         assertThat(maybeAbilityReturned).isNotPresent();
     }
@@ -876,7 +876,7 @@ public class ExamServiceImplTest {
         when(mockExamQueryRepository.findAbilities(thisExamId, clientName, "ELA", studentId)).thenReturn(abilities);
         when(mockHistoryRepository.findAbilityFromHistoryForSubjectAndStudent(clientName, "ELA", studentId))
             .thenReturn(Optional.empty());
-        when(mockAssessmentService.findAssessmentByKey(thisExam.getAssessmentId())).thenReturn(Optional.of(assessment));
+        when(mockAssessmentService.findAssessmentByKey(thisExam.getClientName(), thisExam.getAssessmentId())).thenReturn(Optional.of(assessment));
         Optional<Double> maybeAbilityReturned = examService.getInitialAbility(thisExam, clientTestProperty);
         assertThat(maybeAbilityReturned.get()).isEqualTo(assessmentAbilityVal);
     }


### PR DESCRIPTION
Add `clientName` parameter to `AssessmentService.findAssessmentKey()` method call.