### PR TITLE
Feature/pause exams in session

### DIFF
--- a/service/src/main/java/tds/exam/repositories/ExamCommandRepository.java
+++ b/service/src/main/java/tds/exam/repositories/ExamCommandRepository.java
@@ -1,7 +1,5 @@
 package tds.exam.repositories;
 
-import java.util.List;
-
 import tds.exam.Exam;
 
 /**
@@ -16,16 +14,9 @@ public interface ExamCommandRepository {
     void insert(Exam exam);
 
     /**
-     * Updates the exam
-     *
-     * @param exam a non null {@link tds.exam.Exam}
-     */
-    void update(Exam exam);
-
-    /**
      * Update a collection of {@link tds.exam.Exam}s
      *
      * @param exams The collection of exams to update
      */
-    void update(List<Exam> exams);
+    void update(Exam... exams);
 }

--- a/service/src/main/java/tds/exam/repositories/ExamCommandRepository.java
+++ b/service/src/main/java/tds/exam/repositories/ExamCommandRepository.java
@@ -1,5 +1,7 @@
 package tds.exam.repositories;
 
+import java.util.List;
+
 import tds.exam.Exam;
 
 /**
@@ -19,4 +21,10 @@ public interface ExamCommandRepository {
      * @param exam a non null {@link tds.exam.Exam}
      */
     void update(Exam exam);
+
+    /**
+     * Update a collection of {@link tds.exam.Exam}s
+     * @param exams The collection of exams to update
+     */
+    void update(List<Exam> exams);
 }

--- a/service/src/main/java/tds/exam/repositories/ExamCommandRepository.java
+++ b/service/src/main/java/tds/exam/repositories/ExamCommandRepository.java
@@ -24,6 +24,7 @@ public interface ExamCommandRepository {
 
     /**
      * Update a collection of {@link tds.exam.Exam}s
+     *
      * @param exams The collection of exams to update
      */
     void update(List<Exam> exams);

--- a/service/src/main/java/tds/exam/repositories/ExamQueryRepository.java
+++ b/service/src/main/java/tds/exam/repositories/ExamQueryRepository.java
@@ -2,6 +2,7 @@ package tds.exam.repositories;
 
 import java.util.List;
 import java.util.Optional;
+import java.util.Set;
 import java.util.UUID;
 
 import tds.exam.Exam;
@@ -28,6 +29,15 @@ public interface ExamQueryRepository {
      * @return the {@link tds.exam.Exam Exam} if found otherwise empty
      */
     Optional<Exam> getLastAvailableExam(long studentId, String assessmentId, String clientName);
+
+    /**
+     * Find all {@link tds.exam.Exam}s that belong to a {@link tds.session.Session} so they can be paused.
+     *
+     * @param sessionId The unique identifier of the session
+     * @param statusSet A {@code java.util.Set} of statuses that can transition to "paused"
+     * @return A collection of exams that are assigned to the specified session
+     */
+    List<Exam> findAllExamsInSessionWithStatus(UUID sessionId, Set<String> statusSet);
 
     /**
      * Retrieves a listing of all ability records for the specified exam and student.

--- a/service/src/main/java/tds/exam/repositories/ExamQueryRepository.java
+++ b/service/src/main/java/tds/exam/repositories/ExamQueryRepository.java
@@ -42,11 +42,11 @@ public interface ExamQueryRepository {
     /**
      * Retrieves a listing of all ability records for the specified exam and student.
      *
-     * @param exam          the exam for which to exclude from the ability query
-     * @param clientName    client name for the exam
-     * @param subject       the subject of the exam
-     * @param studentId     the student taking the exam
-     * @return  a list of {@link Ability} objects for past exams
+     * @param exam       the exam for which to exclude from the ability query
+     * @param clientName client name for the exam
+     * @param subject    the subject of the exam
+     * @param studentId  the student taking the exam
+     * @return a list of {@link Ability} objects for past exams
      */
     List<Ability> findAbilities(UUID exam, String clientName, String subject, Long studentId);
 }

--- a/service/src/main/java/tds/exam/repositories/impl/ExamCommandRepositoryImpl.java
+++ b/service/src/main/java/tds/exam/repositories/impl/ExamCommandRepositoryImpl.java
@@ -4,12 +4,9 @@ import org.springframework.beans.factory.annotation.Qualifier;
 import org.springframework.jdbc.core.namedparam.MapSqlParameterSource;
 import org.springframework.jdbc.core.namedparam.NamedParameterJdbcTemplate;
 import org.springframework.jdbc.core.namedparam.SqlParameterSource;
-import org.springframework.jdbc.core.namedparam.SqlParameterSourceUtils;
 import org.springframework.stereotype.Repository;
 
-import java.util.Arrays;
 import java.util.List;
-import java.util.stream.Collectors;
 
 import tds.common.data.CreateRecordException;
 import tds.exam.Exam;

--- a/service/src/main/java/tds/exam/repositories/impl/ExamCommandRepositoryImpl.java
+++ b/service/src/main/java/tds/exam/repositories/impl/ExamCommandRepositoryImpl.java
@@ -6,7 +6,7 @@ import org.springframework.jdbc.core.namedparam.NamedParameterJdbcTemplate;
 import org.springframework.jdbc.core.namedparam.SqlParameterSource;
 import org.springframework.stereotype.Repository;
 
-import java.util.List;
+import java.util.stream.Stream;
 
 import tds.common.data.CreateRecordException;
 import tds.exam.Exam;
@@ -84,76 +84,76 @@ class ExamCommandRepositoryImpl implements ExamCommandRepository {
         update(exam);
     }
 
+//    @Override
+//    public void update(Exam exam) {
+//        SqlParameterSource examEventParameters = new MapSqlParameterSource("examId", getBytesFromUUID(exam.getId()))
+//            .addValue("attempts", exam.getAttempts())
+//            .addValue("status", exam.getStatus().getStatus())
+//            .addValue("statusChangeDate", mapJodaInstantToTimestamp(exam.getStatusChangeDate()))
+//            .addValue("browserId", getBytesFromUUID(exam.getBrowserId()))
+//            .addValue("maxItems", exam.getMaxItems())
+//            .addValue("languageCode", exam.getLanguageCode())
+//            .addValue("statusChangeReason", exam.getStatusChangeReason())
+//            .addValue("dateChanged", mapJodaInstantToTimestamp(exam.getDateChanged()))
+//            .addValue("dateDeleted", mapJodaInstantToTimestamp(exam.getDateDeleted()))
+//            .addValue("dateCompleted", mapJodaInstantToTimestamp(exam.getDateCompleted()))
+//            .addValue("dateScored", mapJodaInstantToTimestamp(exam.getDateScored()))
+//            .addValue("expireFrom", mapJodaInstantToTimestamp(exam.getExpireFrom()))
+//            .addValue("abnormalStarts", exam.getAbnormalStarts())
+//            .addValue("waitingForSegmentApproval", exam.isWaitingForSegmentApproval())
+//            .addValue("currentSegmentPosition", exam.getCurrentSegmentPosition())
+//            .addValue("dateStarted", mapJodaInstantToTimestamp(exam.getDateStarted()));
+//
+//        String examEventInsertSQL = "INSERT INTO exam_event (\n" +
+//            "  exam_id,\n" +
+//            "  attempts, \n" +
+//            "  max_items, \n" +
+//            "  language_code, \n" +
+//            "  expire_from, \n" +
+//            "  browser_id, \n" +
+//            "  status,\n" +
+//            "  status_change_date, \n" +
+//            "  status_change_reason,\n" +
+//            "  date_changed,\n" +
+//            "  date_deleted,\n" +
+//            "  date_completed,\n" +
+//            "  date_scored,\n" +
+//            "  date_started,\n" +
+//            "  waiting_for_segment_approval,\n" +
+//            "  current_segment_position,\n" +
+//            "  abnormal_starts\n" +
+//            ")\n" +
+//            "VALUES\n" +
+//            "(\n" +
+//            "  :examId,\n" +
+//            "  :attempts,\n" +
+//            "  :maxItems,\n" +
+//            "  :languageCode,\n" +
+//            "  :expireFrom, \n" +
+//            "  :browserId,\n" +
+//            "  :status,\n" +
+//            "  :statusChangeDate, \n" +
+//            "  :statusChangeReason,\n" +
+//            "  :dateChanged,\n" +
+//            "  :dateDeleted,\n" +
+//            "  :dateCompleted,\n" +
+//            "  :dateScored,\n" +
+//            "  :dateStarted,\n" +
+//            "  :waitingForSegmentApproval,\n" +
+//            "  :currentSegmentPosition,\n" +
+//            "  :abnormalStarts\n" +
+//            ");";
+//
+//        int insertCount = jdbcTemplate.update(examEventInsertSQL, examEventParameters);
+//
+//        if (insertCount != 1) {
+//            throw new CreateRecordException("Failed to insert exam event");
+//        }
+//    }
+
     @Override
-    public void update(Exam exam) {
-        SqlParameterSource examEventParameters = new MapSqlParameterSource("examId", getBytesFromUUID(exam.getId()))
-            .addValue("attempts", exam.getAttempts())
-            .addValue("status", exam.getStatus().getStatus())
-            .addValue("statusChangeDate", mapJodaInstantToTimestamp(exam.getStatusChangeDate()))
-            .addValue("browserId", getBytesFromUUID(exam.getBrowserId()))
-            .addValue("maxItems", exam.getMaxItems())
-            .addValue("languageCode", exam.getLanguageCode())
-            .addValue("statusChangeReason", exam.getStatusChangeReason())
-            .addValue("dateChanged", mapJodaInstantToTimestamp(exam.getDateChanged()))
-            .addValue("dateDeleted", mapJodaInstantToTimestamp(exam.getDateDeleted()))
-            .addValue("dateCompleted", mapJodaInstantToTimestamp(exam.getDateCompleted()))
-            .addValue("dateScored", mapJodaInstantToTimestamp(exam.getDateScored()))
-            .addValue("expireFrom", mapJodaInstantToTimestamp(exam.getExpireFrom()))
-            .addValue("abnormalStarts", exam.getAbnormalStarts())
-            .addValue("waitingForSegmentApproval", exam.isWaitingForSegmentApproval())
-            .addValue("currentSegmentPosition", exam.getCurrentSegmentPosition())
-            .addValue("dateStarted", mapJodaInstantToTimestamp(exam.getDateStarted()));
-
-        String examEventInsertSQL = "INSERT INTO exam_event (\n" +
-            "  exam_id,\n" +
-            "  attempts, \n" +
-            "  max_items, \n" +
-            "  language_code, \n" +
-            "  expire_from, \n" +
-            "  browser_id, \n" +
-            "  status,\n" +
-            "  status_change_date, \n" +
-            "  status_change_reason,\n" +
-            "  date_changed,\n" +
-            "  date_deleted,\n" +
-            "  date_completed,\n" +
-            "  date_scored,\n" +
-            "  date_started,\n" +
-            "  waiting_for_segment_approval,\n" +
-            "  current_segment_position,\n" +
-            "  abnormal_starts\n" +
-            ")\n" +
-            "VALUES\n" +
-            "(\n" +
-            "  :examId,\n" +
-            "  :attempts,\n" +
-            "  :maxItems,\n" +
-            "  :languageCode,\n" +
-            "  :expireFrom, \n" +
-            "  :browserId,\n" +
-            "  :status,\n" +
-            "  :statusChangeDate, \n" +
-            "  :statusChangeReason,\n" +
-            "  :dateChanged,\n" +
-            "  :dateDeleted,\n" +
-            "  :dateCompleted,\n" +
-            "  :dateScored,\n" +
-            "  :dateStarted,\n" +
-            "  :waitingForSegmentApproval,\n" +
-            "  :currentSegmentPosition,\n" +
-            "  :abnormalStarts\n" +
-            ");";
-
-        int insertCount = jdbcTemplate.update(examEventInsertSQL, examEventParameters);
-
-        if (insertCount != 1) {
-            throw new CreateRecordException("Failed to insert exam event");
-        }
-    }
-
-    @Override
-    public void update(List<Exam> exams) {
-        SqlParameterSource[] batchParameters = exams.stream()
+    public void update(Exam... exams) {
+        SqlParameterSource[] batchParameters = Stream.of(exams)
             .map(exam -> new MapSqlParameterSource("examId", getBytesFromUUID(exam.getId()))
                 .addValue("attempts", exam.getAttempts())
                 .addValue("status", exam.getStatus().getStatus())

--- a/service/src/main/java/tds/exam/repositories/impl/ExamCommandRepositoryImpl.java
+++ b/service/src/main/java/tds/exam/repositories/impl/ExamCommandRepositoryImpl.java
@@ -4,7 +4,12 @@ import org.springframework.beans.factory.annotation.Qualifier;
 import org.springframework.jdbc.core.namedparam.MapSqlParameterSource;
 import org.springframework.jdbc.core.namedparam.NamedParameterJdbcTemplate;
 import org.springframework.jdbc.core.namedparam.SqlParameterSource;
+import org.springframework.jdbc.core.namedparam.SqlParameterSourceUtils;
 import org.springframework.stereotype.Repository;
+
+import java.util.Arrays;
+import java.util.List;
+import java.util.stream.Collectors;
 
 import tds.common.data.CreateRecordException;
 import tds.exam.Exam;
@@ -147,5 +152,71 @@ class ExamCommandRepositoryImpl implements ExamCommandRepository {
         if (insertCount != 1) {
             throw new CreateRecordException("Failed to insert exam event");
         }
+    }
+
+    @Override
+    public void update(List<Exam> exams) {
+        SqlParameterSource[] batchParameters = exams.stream()
+            .map(exam -> new MapSqlParameterSource("examId", getBytesFromUUID(exam.getId()))
+                .addValue("attempts", exam.getAttempts())
+                .addValue("status", exam.getStatus().getStatus())
+                .addValue("statusChangeDate", mapJodaInstantToTimestamp(exam.getStatusChangeDate()))
+                .addValue("browserId", getBytesFromUUID(exam.getBrowserId()))
+                .addValue("maxItems", exam.getMaxItems())
+                .addValue("languageCode", exam.getLanguageCode())
+                .addValue("statusChangeReason", exam.getStatusChangeReason())
+                .addValue("dateChanged", mapJodaInstantToTimestamp(exam.getDateChanged()))
+                .addValue("dateDeleted", mapJodaInstantToTimestamp(exam.getDateDeleted()))
+                .addValue("dateCompleted", mapJodaInstantToTimestamp(exam.getDateCompleted()))
+                .addValue("dateScored", mapJodaInstantToTimestamp(exam.getDateScored()))
+                .addValue("expireFrom", mapJodaInstantToTimestamp(exam.getExpireFrom()))
+                .addValue("abnormalStarts", exam.getAbnormalStarts())
+                .addValue("waitingForSegmentApproval", exam.isWaitingForSegmentApproval())
+                .addValue("currentSegmentPosition", exam.getCurrentSegmentPosition())
+                .addValue("dateStarted", mapJodaInstantToTimestamp(exam.getDateStarted())))
+            .toArray(MapSqlParameterSource[]::new);
+
+        final String SQL =
+            "INSERT INTO exam_event (\n" +
+                "exam_id, \n" +
+                "attempts, \n" +
+                "max_items, \n" +
+                "language_code, \n" +
+                "expire_from, \n" +
+                "browser_id, \n" +
+                "status, \n" +
+                "status_change_date, \n" +
+                "status_change_reason, \n" +
+                "date_changed, \n" +
+                "date_deleted, \n" +
+                "date_completed, \n" +
+                "date_scored, \n" +
+                "date_started, \n" +
+                "waiting_for_segment_approval, \n" +
+                "current_segment_position, \n" +
+                "abnormal_starts \n" +
+                ") \n" +
+                "VALUES \n" +
+                "( \n" +
+                ":examId, \n" +
+                ":attempts, \n" +
+                ":maxItems, \n" +
+                ":languageCode, \n" +
+                ":expireFrom, \n" +
+                ":browserId, \n" +
+                ":status, \n" +
+                ":statusChangeDate, \n" +
+                ":statusChangeReason, \n" +
+                ":dateChanged, \n" +
+                ":dateDeleted, \n" +
+                ":dateCompleted, \n" +
+                ":dateScored, \n" +
+                ":dateStarted, \n" +
+                ":waitingForSegmentApproval,\n" +
+                ":currentSegmentPosition, \n" +
+                ":abnormalStarts \n" +
+                ")";
+
+        jdbcTemplate.batchUpdate(SQL, batchParameters);
     }
 }

--- a/service/src/main/java/tds/exam/repositories/impl/ExamQueryRepositoryImpl.java
+++ b/service/src/main/java/tds/exam/repositories/impl/ExamQueryRepositoryImpl.java
@@ -15,6 +15,7 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
+import java.util.Set;
 import java.util.UUID;
 
 import tds.common.data.mapping.ResultSetMapperUtility;
@@ -178,6 +179,68 @@ public class ExamQueryRepositoryImpl implements ExamQueryRepository {
         }
 
         return examOptional;
+    }
+
+    @Override
+    public List<Exam> findAllExamsInSessionWithStatus(UUID sessionId, Set<String> statusSet) {
+        final SqlParameterSource parameters = new MapSqlParameterSource("sessionId", UuidAdapter.getBytesFromUUID(sessionId))
+            .addValue("statusSet", statusSet);
+
+        final String SQL =
+            "SELECT \n" +
+                "e.id, \n" +
+                "e.session_id, \n" +
+                "ee.browser_id, \n" +
+                "e.assessment_id, \n" +
+                "e.student_id, \n" +
+                "e.client_name, \n" +
+                "e.environment, \n" +
+                "e.subject, \n" +
+                "e.login_ssid, \n" +
+                "e.student_name, \n" +
+                "e.date_joined, \n" +
+                "e.assessment_key,\n" +
+                "e.assessment_window_id, \n" +
+                "e.assessment_algorithm, \n" +
+                "e.segmented, \n" +
+                "ee.attempts, \n" +
+                "ee.status, \n" +
+                "ee.status_change_date, \n" +
+                "ee.max_items, \n" +
+                "ee.expire_from, \n" +
+                "ee.language_code, \n" +
+                "ee.status_change_reason, \n" +
+                "ee.date_deleted, \n" +
+                "ee.date_changed, \n" +
+                "ee.date_completed, \n" +
+                "ee.date_started,    \n" +
+                "ee.date_scored, \n" +
+                "ee.abnormal_starts, \n" +
+                "ee.waiting_for_segment_approval, \n" +
+                "ee.current_segment_position, \n" +
+                "e.created_at, \n" +
+                "esc.description, \n" +
+                "esc.status, \n" +
+                "esc.stage\n" +
+                "FROM exam.exam e \n" +
+                "JOIN ( \n" +
+                "   SELECT \n" +
+                "       exam_id, \n" +
+                "       MAX(id) AS id \n" +
+                "   FROM \n" +
+                "       exam.exam_event \n" +
+                "   GROUP BY exam_id \n" +
+                ") last_event \n" +
+                "  ON e.id = last_event.exam_id \n" +
+                "JOIN exam.exam_event ee \n" +
+                "  ON last_event.exam_id = ee.exam_id AND \n" +
+                "     last_event.id = ee.id\n" +
+                "JOIN exam.exam_status_codes esc \n" +
+                "  ON esc.status = ee.status \n" +
+                "WHERE e.session_id = :sessionId \n" +
+                "AND ee.status IN (:statusSet)";
+
+        return jdbcTemplate.query(SQL, parameters, new ExamRowMapper());
     }
 
     @Override

--- a/service/src/main/java/tds/exam/repositories/impl/ExamQueryRepositoryImpl.java
+++ b/service/src/main/java/tds/exam/repositories/impl/ExamQueryRepositoryImpl.java
@@ -31,6 +31,40 @@ import static tds.common.data.mapping.ResultSetMapperUtility.mapTimestampToJodaI
 @Repository
 public class ExamQueryRepositoryImpl implements ExamQueryRepository {
     private final NamedParameterJdbcTemplate jdbcTemplate;
+    private final String EXAM_QUERY_COLUMN_LIST = "e.id, \n" +
+        "e.session_id, \n" +
+        "ee.browser_id, \n" +
+        "e.assessment_id, \n" +
+        "e.student_id, \n" +
+        "e.client_name, \n" +
+        "e.environment,\n" +
+        "e.subject, \n" +
+        "e.login_ssid,\n" +
+        "e.student_name,\n" +
+        "e.date_joined, \n" +
+        "e.assessment_key, \n" +
+        "e.assessment_window_id, \n" +
+        "e.assessment_algorithm, \n" +
+        "e.segmented, \n" +
+        "ee.attempts, \n" +
+        "ee.status, \n" +
+        "ee.status_change_date, \n" +
+        "ee.max_items, \n" +
+        "ee.expire_from, \n" +
+        "ee.language_code, \n" +
+        "ee.status_change_reason, \n" +
+        "ee.date_deleted, \n" +
+        "ee.date_changed, \n" +
+        "ee.date_completed, \n" +
+        "ee.date_started, \n" +
+        "ee.date_scored, \n" +
+        "ee.abnormal_starts, \n" +
+        "ee.waiting_for_segment_approval, \n" +
+        "ee.current_segment_position, \n" +
+        "e.created_at, \n" +
+        "esc.description, \n" +
+        "esc.status, \n" +
+        "esc.stage \n";
 
     @Autowired
     public ExamQueryRepositoryImpl(@Qualifier("queryJdbcTemplate") NamedParameterJdbcTemplate queryJdbcTemplate) {
@@ -41,57 +75,25 @@ public class ExamQueryRepositoryImpl implements ExamQueryRepository {
     public Optional<Exam> getExamById(UUID id) {
         final SqlParameterSource parameters = new MapSqlParameterSource("examId", UuidAdapter.getBytesFromUUID(id));
 
-        String querySQL = "SELECT \n" +
-            "   e.id, \n" +
-            "   e.session_id, \n" +
-            "   ee.browser_id, \n" +
-            "   e.assessment_id, \n" +
-            "   e.student_id, \n" +
-            "   e.client_name, \n" +
-            "   e.environment,\n" +
-            "   e.subject,    \n" +
-            "   e.login_ssid,\n" +
-            "   e.student_name,\n" +
-            "   e.date_joined, \n" +
-            "   e.assessment_key,\n" +
-            "   e.assessment_window_id,\n" +
-            "   e.assessment_algorithm,\n" +
-            "   e.segmented,\n" +
-            "   ee.attempts, \n" +
-            "   ee.status, \n" +
-            "   ee.status_change_date, \n" +
-            "   ee.max_items, \n" +
-            "   ee.expire_from, \n" +
-            "   ee.language_code, \n" +
-            "   ee.status_change_reason, \n" +
-            "   ee.date_deleted, \n" +
-            "   ee.date_changed, \n" +
-            "   ee.date_completed, \n" +
-            "   ee.date_started,    \n" +
-            "   ee.date_scored, \n" +
-            "   ee.abnormal_starts, \n" +
-            "   ee.waiting_for_segment_approval, \n" +
-            "   ee.current_segment_position, \n" +
-            "   e.created_at, \n" +
-            "   esc.description, \n" +
-            "   esc.status, \n" +
-            "   esc.stage\n" +
-            "FROM exam.exam e\n" +
-            "JOIN ( \n" +
-            "   SELECT \n" +
-            "       exam_id, \n" +
-            "       MAX(id) AS id \n" +
-            "   FROM \n" +
-            "       exam.exam_event \n" +
-            "   WHERE exam_id = :examId\n" +
-            "   GROUP BY exam_id \n" +
-            ") last_event \n" +
-            "  ON e.id = last_event.exam_id \n" +
-            "JOIN exam.exam_event ee \n" +
-            "  ON last_event.exam_id = ee.exam_id AND \n" +
-            "     last_event.id = ee.id\n" +
-            "JOIN exam.exam_status_codes esc \n" +
-            "  ON esc.status = ee.status;";
+        String querySQL =
+            "SELECT \n" +
+                EXAM_QUERY_COLUMN_LIST +
+                "FROM exam.exam e\n" +
+                "JOIN ( \n" +
+                "   SELECT \n" +
+                "       exam_id, \n" +
+                "       MAX(id) AS id \n" +
+                "   FROM \n" +
+                "       exam.exam_event \n" +
+                "   WHERE exam_id = :examId\n" +
+                "   GROUP BY exam_id \n" +
+                ") last_event \n" +
+                "  ON e.id = last_event.exam_id \n" +
+                "JOIN exam.exam_event ee \n" +
+                "  ON last_event.exam_id = ee.exam_id AND \n" +
+                "     last_event.id = ee.id\n" +
+                "JOIN exam.exam_status_codes esc \n" +
+                "  ON esc.status = ee.status";
 
         Optional<Exam> examOptional;
         try {
@@ -114,40 +116,7 @@ public class ExamQueryRepositoryImpl implements ExamQueryRepository {
 
         String query =
             "SELECT " +
-                "   e.id, \n" +
-                "   e.session_id, \n" +
-                "   ee.browser_id, \n" +
-                "   e.assessment_id, \n" +
-                "   e.student_id, \n" +
-                "   e.client_name, \n" +
-                "   e.environment,\n" +
-                "   e.subject,    \n" +
-                "   e.login_ssid,\n" +
-                "   e.student_name,\n" +
-                "   e.assessment_key,\n" +
-                "   e.date_joined, \n" +
-                "   e.assessment_window_id,\n" +
-                "   e.assessment_algorithm,\n" +
-                "   e.segmented,\n" +
-                "   ee.attempts, \n" +
-                "   ee.status, \n" +
-                "   ee.status_change_date, \n" +
-                "   ee.status_change_reason, \n" +
-                "   ee.max_items, \n" +
-                "   ee.expire_from, \n" +
-                "   ee.language_code, \n" +
-                "   ee.date_deleted, \n" +
-                "   ee.date_changed, \n" +
-                "   ee.date_completed, \n" +
-                "   ee.date_started,    \n" +
-                "   ee.date_scored, \n" +
-                "   ee.abnormal_starts, \n" +
-                "   ee.current_segment_position, \n" +
-                "   ee.waiting_for_segment_approval, \n" +
-                "   e.created_at, \n" +
-                "   esc.description, \n" +
-                "   esc.status, \n" +
-                "   esc.stage\n" +
+                EXAM_QUERY_COLUMN_LIST +
                 "FROM exam.exam e\n" +
                 "JOIN ( \n" +
                 "   SELECT \n" +
@@ -188,40 +157,7 @@ public class ExamQueryRepositoryImpl implements ExamQueryRepository {
 
         final String SQL =
             "SELECT \n" +
-                "e.id, \n" +
-                "e.session_id, \n" +
-                "ee.browser_id, \n" +
-                "e.assessment_id, \n" +
-                "e.student_id, \n" +
-                "e.client_name, \n" +
-                "e.environment, \n" +
-                "e.subject, \n" +
-                "e.login_ssid, \n" +
-                "e.student_name, \n" +
-                "e.date_joined, \n" +
-                "e.assessment_key,\n" +
-                "e.assessment_window_id, \n" +
-                "e.assessment_algorithm, \n" +
-                "e.segmented, \n" +
-                "ee.attempts, \n" +
-                "ee.status, \n" +
-                "ee.status_change_date, \n" +
-                "ee.max_items, \n" +
-                "ee.expire_from, \n" +
-                "ee.language_code, \n" +
-                "ee.status_change_reason, \n" +
-                "ee.date_deleted, \n" +
-                "ee.date_changed, \n" +
-                "ee.date_completed, \n" +
-                "ee.date_started,    \n" +
-                "ee.date_scored, \n" +
-                "ee.abnormal_starts, \n" +
-                "ee.waiting_for_segment_approval, \n" +
-                "ee.current_segment_position, \n" +
-                "e.created_at, \n" +
-                "esc.description, \n" +
-                "esc.status, \n" +
-                "esc.stage\n" +
+                EXAM_QUERY_COLUMN_LIST +
                 "FROM exam.exam e \n" +
                 "JOIN ( \n" +
                 "   SELECT \n" +

--- a/service/src/main/java/tds/exam/services/ExamService.java
+++ b/service/src/main/java/tds/exam/services/ExamService.java
@@ -1,6 +1,7 @@
 package tds.exam.services;
 
 import java.util.Optional;
+import java.util.Set;
 import java.util.UUID;
 
 import tds.assessment.Assessment;
@@ -71,6 +72,13 @@ public interface ExamService {
      * to the new status; otherwise {@code Optional.empty()}.\
      */
     Optional<ValidationError> pauseExam(UUID examId);
+
+    /**
+     * Update the status of all {@link tds.exam.Exam}s in the specified {@link tds.session.Session} to "paused"
+     *
+     * @param sessionId The unique identifier of the session that has been closed
+     */
+    void pauseAllExamsInSession(UUID sessionId);
 
     /**
      * Verify all the rules for granting approval to an {@link Exam} are satisfied.

--- a/service/src/main/java/tds/exam/services/ExamService.java
+++ b/service/src/main/java/tds/exam/services/ExamService.java
@@ -1,7 +1,6 @@
 package tds.exam.services;
 
 import java.util.Optional;
-import java.util.Set;
 import java.util.UUID;
 
 import tds.assessment.Assessment;

--- a/service/src/main/java/tds/exam/services/impl/ExamServiceImpl.java
+++ b/service/src/main/java/tds/exam/services/impl/ExamServiceImpl.java
@@ -268,7 +268,7 @@ class ExamServiceImpl implements ExamService {
         List<Exam> examsInSession = examQueryRepository.findAllExamsInSessionWithStatus(sessionId,
             statusesThatCanTransitionToPaused);
 
-        if (examsInSession.size() == 0) {
+        if (examsInSession.isEmpty()) {
             return;
         }
 
@@ -280,7 +280,7 @@ class ExamServiceImpl implements ExamService {
                 .build())
             .collect(Collectors.toList());
 
-        examCommandRepository.update(pausedExams);
+        examCommandRepository.update(pausedExams.toArray(new Exam[pausedExams.size()]));
     }
 
     @Override

--- a/service/src/main/java/tds/exam/services/impl/ExamServiceImpl.java
+++ b/service/src/main/java/tds/exam/services/impl/ExamServiceImpl.java
@@ -268,7 +268,6 @@ class ExamServiceImpl implements ExamService {
         List<Exam> examsInSession = examQueryRepository.findAllExamsInSessionWithStatus(sessionId,
             statusesThatCanTransitionToPaused);
 
-        // TODO:  What should the response be if the examsToPause list is empty?
         if (examsInSession.size() == 0) {
             return;
         }

--- a/service/src/main/java/tds/exam/services/impl/ExamServiceImpl.java
+++ b/service/src/main/java/tds/exam/services/impl/ExamServiceImpl.java
@@ -16,6 +16,7 @@ import java.util.Optional;
 import java.util.Set;
 import java.util.UUID;
 import java.util.function.Supplier;
+import java.util.stream.Collectors;
 
 import tds.assessment.Assessment;
 import tds.common.Response;
@@ -260,6 +261,27 @@ class ExamServiceImpl implements ExamService {
         examCommandRepository.update(pausedExam);
 
         return Optional.empty();
+    }
+
+    @Override
+    public void pauseAllExamsInSession(UUID sessionId) {
+        List<Exam> examsInSession = examQueryRepository.findAllExamsInSessionWithStatus(sessionId,
+            statusesThatCanTransitionToPaused);
+
+        // TODO:  What should the response be if the examsToPause list is empty?
+        if (examsInSession.size() == 0) {
+            return;
+        }
+
+        ExamStatusCode pausedStatus = new ExamStatusCode(ExamStatusCode.STATUS_PAUSED, ExamStatusStage.INACTIVE);
+        List<Exam> pausedExams = examsInSession.stream()
+            .map(e -> new Exam.Builder().fromExam(e)
+                .withStatus(pausedStatus, org.joda.time.Instant.now())
+                .withStatusChangeReason("paused by session")
+                .build())
+            .collect(Collectors.toList());
+
+        examCommandRepository.update(pausedExams);
     }
 
     @Override

--- a/service/src/main/java/tds/exam/web/endpoints/ExamController.java
+++ b/service/src/main/java/tds/exam/web/endpoints/ExamController.java
@@ -11,6 +11,7 @@ import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestMethod;
 import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.ResponseStatus;
 import org.springframework.web.bind.annotation.RestController;
 
 import java.util.Optional;
@@ -103,5 +104,11 @@ public class ExamController {
         headers.add("Location", link.getHref());
 
         return new ResponseEntity<>(headers, HttpStatus.NO_CONTENT);
+    }
+
+    @RequestMapping(value = "/pause/{sessionId}", method = RequestMethod.PUT, produces = MediaType.APPLICATION_JSON_VALUE)
+    @ResponseStatus(HttpStatus.NO_CONTENT)
+    public void pauseExamsInSession(@PathVariable final UUID sessionId) {
+        examService.pauseAllExamsInSession(sessionId);
     }
 }

--- a/service/src/test/java/tds/exam/repositories/impl/ExamCommandRepositoryImplIntegrationTests.java
+++ b/service/src/test/java/tds/exam/repositories/impl/ExamCommandRepositoryImplIntegrationTests.java
@@ -115,12 +115,10 @@ public class ExamCommandRepositoryImplIntegrationTests {
     public void shouldUpdateManyExams() {
         Exam mockFirstExam = new ExamBuilder().build();
         Exam mockSecondExam = new ExamBuilder().build();
-        Exam mockThirdExam = new ExamBuilder().build();
 
         List<Exam> exams = new ArrayList<>();
         exams.add(mockFirstExam);
         exams.add(mockSecondExam);
-        exams.add(mockThirdExam);
 
         exams.forEach(e -> examCommandRepository.insert(e));
 
@@ -135,13 +133,8 @@ public class ExamCommandRepositoryImplIntegrationTests {
             .withStatusChangeReason("unit test 2")
             .withMaxItems(600)
             .build());
-        examsWithChanges.add(new Exam.Builder().fromExam(mockThirdExam)
-            .withStatus(new ExamStatusCode(ExamStatusCode.STATUS_PAUSED, ExamStatusStage.INACTIVE), Instant.now().plus(60000))
-            .withStatusChangeReason("unit test 3")
-            .withClientName("unit test")
-            .build());
 
-        examCommandRepository.update(examsWithChanges);
+        examCommandRepository.update(examsWithChanges.toArray(new Exam[examsWithChanges.size()]));
 
         // Verify the first exam was updated
         Optional<Exam> maybeMockFirstExamAfterUpdate = examQueryRepository.getExamById(mockFirstExam.getId());
@@ -162,14 +155,5 @@ public class ExamCommandRepositoryImplIntegrationTests {
         assertThat(mockSecondExamAfterUpdate.getStatusChangeDate().getMillis()).isGreaterThan(mockSecondExam.getStatusChangeDate().getMillis());
         assertThat(mockSecondExamAfterUpdate.getMaxItems()).isEqualTo(600);
         assertThat(mockSecondExamAfterUpdate.getStatusChangeReason()).isEqualTo("unit test 2");
-
-        // Verify the third exam was updated
-        Optional<Exam> maybeMockThirdExamAfterUpdate = examQueryRepository.getExamById(mockThirdExam.getId());
-
-        assertThat(maybeMockThirdExamAfterUpdate).isPresent();
-        Exam mockThirdExamAfterUpdate = maybeMockThirdExamAfterUpdate.get();
-        assertThat(mockThirdExamAfterUpdate.getStatus().getStatus()).isEqualTo(ExamStatusCode.STATUS_PAUSED);
-        assertThat(mockThirdExamAfterUpdate.getStatusChangeDate().getMillis()).isGreaterThan(mockThirdExam.getStatusChangeDate().getMillis());
-        assertThat(mockThirdExamAfterUpdate.getStatusChangeReason()).isEqualTo("unit test 3");
     }
 }

--- a/service/src/test/java/tds/exam/repositories/impl/ExamCommandRepositoryImplIntegrationTests.java
+++ b/service/src/test/java/tds/exam/repositories/impl/ExamCommandRepositoryImplIntegrationTests.java
@@ -143,7 +143,7 @@ public class ExamCommandRepositoryImplIntegrationTests {
 
         examCommandRepository.update(examsWithChanges);
 
-        // Verify first exam was updated
+        // Verify the first exam was updated
         Optional<Exam> maybeMockFirstExamAfterUpdate = examQueryRepository.getExamById(mockFirstExam.getId());
 
         assertThat(maybeMockFirstExamAfterUpdate).isPresent();

--- a/service/src/test/java/tds/exam/repositories/impl/ExamCommandRepositoryImplIntegrationTests.java
+++ b/service/src/test/java/tds/exam/repositories/impl/ExamCommandRepositoryImplIntegrationTests.java
@@ -11,6 +11,8 @@ import org.springframework.jdbc.core.namedparam.NamedParameterJdbcTemplate;
 import org.springframework.test.context.junit4.SpringJUnit4ClassRunner;
 import org.springframework.transaction.annotation.Transactional;
 
+import java.util.ArrayList;
+import java.util.List;
 import java.util.Optional;
 
 import tds.exam.Exam;
@@ -107,5 +109,67 @@ public class ExamCommandRepositoryImplIntegrationTests {
         Exam updatedExam = maybeUpdatedExam.get();
         assertThat(updatedExam.getStatus()).isEqualTo(pausedStatus);
         assertThat(updatedExam.getStatusChangeDate()).isEqualTo(pausedStatusDate);
+    }
+
+    @Test
+    public void shouldUpdateManyExams() {
+        Exam mockFirstExam = new ExamBuilder().build();
+        Exam mockSecondExam = new ExamBuilder().build();
+        Exam mockThirdExam = new ExamBuilder().build();
+
+        List<Exam> exams = new ArrayList<>();
+        exams.add(mockFirstExam);
+        exams.add(mockSecondExam);
+        exams.add(mockThirdExam);
+
+        exams.forEach(e -> examCommandRepository.insert(e));
+
+        List<Exam> examsWithChanges = new ArrayList<>();
+        examsWithChanges.add(new Exam.Builder().fromExam(mockFirstExam)
+            .withStatus(new ExamStatusCode(ExamStatusCode.STATUS_APPROVED, ExamStatusStage.IN_USE), Instant.now().plus(50000))
+            .withStatusChangeReason("unit test")
+            .withAttempts(500)
+            .build());
+        examsWithChanges.add(new Exam.Builder().fromExam(mockSecondExam)
+            .withStatus(new ExamStatusCode(ExamStatusCode.STATUS_STARTED, ExamStatusStage.IN_USE), Instant.now().plus(55000))
+            .withStatusChangeReason("unit test 2")
+            .withMaxItems(600)
+            .build());
+        examsWithChanges.add(new Exam.Builder().fromExam(mockThirdExam)
+            .withStatus(new ExamStatusCode(ExamStatusCode.STATUS_PAUSED, ExamStatusStage.INACTIVE), Instant.now().plus(60000))
+            .withStatusChangeReason("unit test 3")
+            .withClientName("unit test")
+            .build());
+
+        examCommandRepository.update(examsWithChanges);
+
+        // Verify first exam was updated
+        Optional<Exam> maybeMockFirstExamAfterUpdate = examQueryRepository.getExamById(mockFirstExam.getId());
+
+        assertThat(maybeMockFirstExamAfterUpdate).isPresent();
+        Exam mockFirstExamAfterUpdate = maybeMockFirstExamAfterUpdate.get();
+        assertThat(mockFirstExamAfterUpdate.getStatus().getStatus()).isEqualTo(ExamStatusCode.STATUS_APPROVED);
+        assertThat(mockFirstExamAfterUpdate.getStatusChangeDate().getMillis()).isGreaterThan(mockFirstExam.getStatusChangeDate().getMillis());
+        assertThat(mockFirstExamAfterUpdate.getAttempts()).isEqualTo(500);
+        assertThat(mockFirstExamAfterUpdate.getStatusChangeReason()).isEqualTo("unit test");
+
+        // Verify the second exam was updated
+        Optional<Exam> maybeMockSecondExamAfterUpdate = examQueryRepository.getExamById(mockSecondExam.getId());
+
+        assertThat(maybeMockSecondExamAfterUpdate).isPresent();
+        Exam mockSecondExamAfterUpdate = maybeMockSecondExamAfterUpdate.get();
+        assertThat(mockSecondExamAfterUpdate.getStatus().getStatus()).isEqualTo(ExamStatusCode.STATUS_STARTED);
+        assertThat(mockSecondExamAfterUpdate.getStatusChangeDate().getMillis()).isGreaterThan(mockSecondExam.getStatusChangeDate().getMillis());
+        assertThat(mockSecondExamAfterUpdate.getMaxItems()).isEqualTo(600);
+        assertThat(mockSecondExamAfterUpdate.getStatusChangeReason()).isEqualTo("unit test 2");
+
+        // Verify the third exam was updated
+        Optional<Exam> maybeMockThirdExamAfterUpdate = examQueryRepository.getExamById(mockThirdExam.getId());
+
+        assertThat(maybeMockThirdExamAfterUpdate).isPresent();
+        Exam mockThirdExamAfterUpdate = maybeMockThirdExamAfterUpdate.get();
+        assertThat(mockThirdExamAfterUpdate.getStatus().getStatus()).isEqualTo(ExamStatusCode.STATUS_PAUSED);
+        assertThat(mockThirdExamAfterUpdate.getStatusChangeDate().getMillis()).isGreaterThan(mockThirdExam.getStatusChangeDate().getMillis());
+        assertThat(mockThirdExamAfterUpdate.getStatusChangeReason()).isEqualTo("unit test 3");
     }
 }

--- a/service/src/test/java/tds/exam/repositories/impl/ExamQueryRepositoryImplIntegrationTests.java
+++ b/service/src/test/java/tds/exam/repositories/impl/ExamQueryRepositoryImplIntegrationTests.java
@@ -48,6 +48,8 @@ public class ExamQueryRepositoryImplIntegrationTests {
     private UUID mockSessionId = UUID.randomUUID();
     private Set<String> statusesThatCanTransitionToPaused;
 
+    private List<Exam> examsInSession;
+
     @Before
     public void setUp() {
         examQueryRepository = new ExamQueryRepositoryImpl(jdbcTemplate);
@@ -78,7 +80,7 @@ public class ExamQueryRepositoryImplIntegrationTests {
         insertExamScoresData();
 
         // Build exams that belong to the same session
-        List<Exam> examsInSession = new ArrayList<>();
+        examsInSession = new ArrayList<>();
         examsInSession.add(new ExamBuilder().withSessionId(mockSessionId)
             .withStudentId(5L)
             .withAssessmentId("assessmentId5")
@@ -166,10 +168,7 @@ public class ExamQueryRepositoryImplIntegrationTests {
         List<Exam> exams = examQueryRepository.findAllExamsInSessionWithStatus(mockSessionId, statusesThatCanTransitionToPaused);
 
         assertThat(exams).hasSize(3);
-        assertThat(exams.stream().filter(exam -> exam.getStatus().getStatus().equals(ExamStatusCode.STATUS_PENDING)).findAny()).isPresent();
-        assertThat(exams.stream().filter(exam -> exam.getStatus().getStatus().equals(ExamStatusCode.STATUS_APPROVED)).findAny()).isPresent();
-        assertThat(exams.stream().filter(exam -> exam.getStatus().getStatus().equals(ExamStatusCode.STATUS_STARTED)).findAny()).isPresent();
-        assertThat(exams.stream().filter(exam -> exam.getStatus().getStatus().equals(ExamStatusCode.STATUS_FAILED)).findAny()).isNotPresent();
+        assertThat(exams).doesNotContain(examsInSession.stream().filter(exam -> exam.getStatus().getStatus().equals(ExamStatusCode.STATUS_FAILED)).findAny().get());
     }
 
     @Test

--- a/service/src/test/java/tds/exam/repositories/impl/ExamQueryRepositoryImplIntegrationTests.java
+++ b/service/src/test/java/tds/exam/repositories/impl/ExamQueryRepositoryImplIntegrationTests.java
@@ -79,14 +79,25 @@ public class ExamQueryRepositoryImplIntegrationTests {
 
         // Build exams that belong to the same session
         List<Exam> examsInSession = new ArrayList<>();
-        examsInSession.add(new ExamBuilder().withSessionId(mockSessionId).build());
         examsInSession.add(new ExamBuilder().withSessionId(mockSessionId)
+            .withStudentId(5L)
+            .withAssessmentId("assessmentId5")
+            .build());
+        examsInSession.add(new ExamBuilder().withSessionId(mockSessionId)
+            .withStudentId(6L)
+            .withAssessmentId("assessmentId5")
             .withStatus(new ExamStatusCode(ExamStatusCode.STATUS_APPROVED, ExamStatusStage.INACTIVE), Instant.now())
+            .withStudentId(7L)
+            .withAssessmentId("assessmentId5")
             .build());
         examsInSession.add(new ExamBuilder().withSessionId(mockSessionId)
             .withStatus(new ExamStatusCode(ExamStatusCode.STATUS_STARTED, ExamStatusStage.INACTIVE), Instant.now())
+            .withStudentId(8L)
+            .withAssessmentId("assessmentId6")
             .build());
         examsInSession.add(new ExamBuilder().withSessionId(mockSessionId)
+            .withStudentId(9L)
+            .withAssessmentId("assessmentId6")
             .withStatus(new ExamStatusCode(ExamStatusCode.STATUS_FAILED, ExamStatusStage.INACTIVE), Instant.now())
             .build());
 

--- a/service/src/test/java/tds/exam/repositories/impl/ExamQueryRepositoryImplIntegrationTests.java
+++ b/service/src/test/java/tds/exam/repositories/impl/ExamQueryRepositoryImplIntegrationTests.java
@@ -143,7 +143,7 @@ public class ExamQueryRepositoryImplIntegrationTests {
     @Test
     public void shouldReturnEmptyListOfAbilities() {
         List<Ability> noAbilities = examQueryRepository.findAbilities(UUID.fromString("12345678-d1d2-4c24-805c-0dfdb45a0999"),
-                "otherclient", "ELA", 9999L);
+            "otherclient", "ELA", 9999L);
         assertThat(noAbilities).isEmpty();
     }
 
@@ -151,7 +151,7 @@ public class ExamQueryRepositoryImplIntegrationTests {
     public void shouldReturnSingleAbility() {
         UUID examId = UUID.randomUUID();
         List<Ability> oneAbility = examQueryRepository.findAbilities(examId,
-                "clientName", "ELA", 9999L);
+            "clientName", "ELA", 9999L);
         assertThat(oneAbility).hasSize(1);
         Ability myAbility = oneAbility.get(0);
         // Should not be the same exam
@@ -188,8 +188,8 @@ public class ExamQueryRepositoryImplIntegrationTests {
 
         final String SQL =
             "INSERT INTO" +
-            "   exam_scores (exam_id, measure_label, value, measure_of, use_for_ability) " +
-            "VALUES(:examId, :measureLabel, :value, :measureOf, :useForAbility)";
+                "   exam_scores (exam_id, measure_label, value, measure_of, use_for_ability) " +
+                "VALUES(:examId, :measureLabel, :value, :measureOf, :useForAbility)";
 
         jdbcTemplate.update(SQL, parameters);
     }

--- a/service/src/test/java/tds/exam/services/impl/ExamServiceImplTest.java
+++ b/service/src/test/java/tds/exam/services/impl/ExamServiceImplTest.java
@@ -1524,7 +1524,7 @@ public class ExamServiceImplTest {
 
         examService.pauseAllExamsInSession(mockSessionId);
 
-        verify(mockExamCommandRepository).update(Matchers.anyListOf(Exam.class));
+        verify(mockExamCommandRepository).update(Matchers.<Exam>anyVararg());
     }
 
     @Test
@@ -1537,7 +1537,7 @@ public class ExamServiceImplTest {
 
         examService.pauseAllExamsInSession(mockSessionId);
 
-        verify(mockExamCommandRepository, times(0)).update(Matchers.anyListOf(Exam.class));
+        verify(mockExamCommandRepository, times(0)).update(Matchers.<Exam>anyVararg());
     }
 
     private Exam createExam(UUID sessionId, UUID thisExamId, String assessmentId, String clientName, long studentId) {

--- a/service/src/test/java/tds/exam/services/impl/ExamServiceImplTest.java
+++ b/service/src/test/java/tds/exam/services/impl/ExamServiceImplTest.java
@@ -1499,7 +1499,7 @@ public class ExamServiceImplTest {
     }
 
     @Test
-    public void shouldPauseAllExamsInSession() {
+    public void shouldPauseAllExamsInASession() {
         UUID mockSessionId = UUID.randomUUID();
         Set<String> mockStatusTransitionSet = new HashSet<>(Arrays.asList(ExamStatusCode.STATUS_PAUSED,
             ExamStatusCode.STATUS_PENDING,

--- a/service/src/test/java/tds/exam/web/endpoints/ExamControllerIntegrationTests.java
+++ b/service/src/test/java/tds/exam/web/endpoints/ExamControllerIntegrationTests.java
@@ -11,7 +11,6 @@ import org.springframework.test.context.junit4.SpringRunner;
 import org.springframework.test.web.servlet.MockMvc;
 
 import java.net.URI;
-import java.sql.SQLException;
 import java.util.Optional;
 import java.util.UUID;
 
@@ -24,7 +23,6 @@ import tds.exam.services.ExamService;
 
 import static org.hamcrest.CoreMatchers.is;
 import static org.mockito.Mockito.doNothing;
-import static org.mockito.Mockito.doThrow;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
@@ -109,18 +107,6 @@ public class ExamControllerIntegrationTests {
         http.perform(put(new URI(String.format("/exam/pause/%s", sessionId)))
             .contentType(MediaType.APPLICATION_JSON))
             .andExpect(status().isNoContent());
-
-        verify(mockExamService).pauseAllExamsInSession(sessionId);
-    }
-
-    @Test
-    public void shouldReturn500WhenAnExceptionIsThrownWhilePausingExamsInASession() throws Exception {
-        UUID sessionId = UUID.randomUUID();
-        doThrow(SQLException.class).when(mockExamService).pauseAllExamsInSession(sessionId);
-
-        http.perform(put(new URI(String.format("/exam/pause/%s", sessionId)))
-            .contentType(MediaType.APPLICATION_JSON))
-            .andExpect(status().isInternalServerError());
 
         verify(mockExamService).pauseAllExamsInSession(sessionId);
     }

--- a/service/src/test/java/tds/exam/web/endpoints/ExamControllerIntegrationTests.java
+++ b/service/src/test/java/tds/exam/web/endpoints/ExamControllerIntegrationTests.java
@@ -11,6 +11,7 @@ import org.springframework.test.context.junit4.SpringRunner;
 import org.springframework.test.web.servlet.MockMvc;
 
 import java.net.URI;
+import java.sql.SQLException;
 import java.util.Optional;
 import java.util.UUID;
 
@@ -22,6 +23,8 @@ import tds.exam.error.ValidationErrorCode;
 import tds.exam.services.ExamService;
 
 import static org.hamcrest.CoreMatchers.is;
+import static org.mockito.Mockito.doNothing;
+import static org.mockito.Mockito.doThrow;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
@@ -96,5 +99,29 @@ public class ExamControllerIntegrationTests {
             .andExpect(jsonPath("errors").isArray())
             .andExpect(jsonPath("errors[0].code", is("badStatusTransition")))
             .andExpect(jsonPath("errors[0].message", is("Bad transition from foo to bar")));
+    }
+
+    @Test
+    public void shouldPauseAllExamsInASession() throws Exception {
+        UUID sessionId = UUID.randomUUID();
+        doNothing().when(mockExamService).pauseAllExamsInSession(sessionId);
+
+        http.perform(put(new URI(String.format("/exam/pause/%s", sessionId)))
+            .contentType(MediaType.APPLICATION_JSON))
+            .andExpect(status().isNoContent());
+
+        verify(mockExamService).pauseAllExamsInSession(sessionId);
+    }
+
+    @Test
+    public void shouldReturn500WhenAnExceptionIsThrownWhilePausingExamsInASession() throws Exception {
+        UUID sessionId = UUID.randomUUID();
+        doThrow(SQLException.class).when(mockExamService).pauseAllExamsInSession(sessionId);
+
+        http.perform(put(new URI(String.format("/exam/pause/%s", sessionId)))
+            .contentType(MediaType.APPLICATION_JSON))
+            .andExpect(status().isInternalServerError());
+
+        verify(mockExamService).pauseAllExamsInSession(sessionId);
     }
 }

--- a/service/src/test/java/tds/exam/web/endpoints/ExamControllerTest.java
+++ b/service/src/test/java/tds/exam/web/endpoints/ExamControllerTest.java
@@ -6,6 +6,7 @@ import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.mockito.Matchers;
 import org.mockito.Mock;
+import org.mockito.Mockito;
 import org.mockito.runners.MockitoJUnitRunner;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
@@ -16,6 +17,7 @@ import org.springframework.web.context.request.ServletRequestAttributes;
 import javax.servlet.http.HttpServletRequest;
 import java.net.URI;
 import java.net.URISyntaxException;
+import java.sql.SQLException;
 import java.util.Optional;
 import java.util.UUID;
 
@@ -37,6 +39,8 @@ import tds.exam.error.ValidationErrorCode;
 import tds.exam.services.ExamService;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.doNothing;
+import static org.mockito.Mockito.doThrow;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 import static tds.exam.ExamStatusCode.STATUS_APPROVED;
@@ -218,5 +222,25 @@ public class ExamControllerTest {
         ValidationError error = response.getBody().getErrors()[0];
         assertThat(error.getCode()).isEqualTo(ValidationErrorCode.EXAM_STATUS_TRANSITION_FAILURE);
         assertThat(error.getMessage()).isEqualTo("Bad transition from foo to bar");
+    }
+
+    @Test
+    public void shouldPauseAllExamsInASession() {
+        UUID sessionId = UUID.randomUUID();
+        doNothing().when(mockExamService).pauseAllExamsInSession(sessionId);
+
+        controller.pauseExamsInSession(sessionId);
+
+        verify(mockExamService).pauseAllExamsInSession(sessionId);
+    }
+
+    @Test(expected = SQLException.class)
+    public void shouldThrowExceptionWhenSqlFails() {
+        UUID sessionId = UUID.randomUUID();
+        doThrow(SQLException.class).when(mockExamService).pauseAllExamsInSession(sessionId);
+
+        controller.pauseExamsInSession(sessionId);
+
+        verify(mockExamService).pauseAllExamsInSession(sessionId);
     }
 }

--- a/service/src/test/java/tds/exam/web/endpoints/ExamControllerTest.java
+++ b/service/src/test/java/tds/exam/web/endpoints/ExamControllerTest.java
@@ -6,7 +6,6 @@ import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.mockito.Matchers;
 import org.mockito.Mock;
-import org.mockito.Mockito;
 import org.mockito.runners.MockitoJUnitRunner;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;

--- a/service/src/test/java/tds/exam/web/endpoints/ExamControllerTest.java
+++ b/service/src/test/java/tds/exam/web/endpoints/ExamControllerTest.java
@@ -16,7 +16,6 @@ import org.springframework.web.context.request.ServletRequestAttributes;
 import javax.servlet.http.HttpServletRequest;
 import java.net.URI;
 import java.net.URISyntaxException;
-import java.sql.SQLException;
 import java.util.Optional;
 import java.util.UUID;
 
@@ -39,7 +38,6 @@ import tds.exam.services.ExamService;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.Mockito.doNothing;
-import static org.mockito.Mockito.doThrow;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 import static tds.exam.ExamStatusCode.STATUS_APPROVED;
@@ -227,16 +225,6 @@ public class ExamControllerTest {
     public void shouldPauseAllExamsInASession() {
         UUID sessionId = UUID.randomUUID();
         doNothing().when(mockExamService).pauseAllExamsInSession(sessionId);
-
-        controller.pauseExamsInSession(sessionId);
-
-        verify(mockExamService).pauseAllExamsInSession(sessionId);
-    }
-
-    @Test(expected = SQLException.class)
-    public void shouldThrowExceptionWhenSqlFails() {
-        UUID sessionId = UUID.randomUUID();
-        doThrow(SQLException.class).when(mockExamService).pauseAllExamsInSession(sessionId);
 
         controller.pauseExamsInSession(sessionId);
 

--- a/service/src/test/resources/application.properties
+++ b/service/src/test/resources/application.properties
@@ -1,15 +1,15 @@
 #flyway.enabled=
-flyway.url=jdbc:mysql://localhost:3306/exam
-flyway.user=root
-flyway.password=password
+flyway.url=
+flyway.user=
+flyway.password=
 
-spring.ds_queries.jdbcUrl=jdbc:mysql://localhost:3306/exam
-spring.ds_queries.username=root
-spring.ds_queries.password=password
+spring.ds_queries.jdbcUrl=
+spring.ds_queries.username=
+spring.ds_queries.password=
 
-spring.ds_commands.jdbcUrl=jdbc:mysql://localhost:3306/exam
-spring.ds_commands.username=root
-spring.ds_commands.password=password
+spring.ds_commands.jdbcUrl=
+spring.ds_commands.username=
+spring.ds_commands.password=
 
 server.undertow.buffer-size=16384
 server.undertow.buffers-per-region=20

--- a/service/src/test/resources/application.properties
+++ b/service/src/test/resources/application.properties
@@ -1,15 +1,15 @@
 #flyway.enabled=
-flyway.url=
-flyway.user=
-flyway.password=
+flyway.url=jdbc:mysql://localhost:3306/exam
+flyway.user=root
+flyway.password=password
 
-spring.ds_queries.jdbcUrl=
-spring.ds_queries.username=
-spring.ds_queries.password=
+spring.ds_queries.jdbcUrl=jdbc:mysql://localhost:3306/exam
+spring.ds_queries.username=root
+spring.ds_queries.password=password
 
-spring.ds_commands.jdbcUrl=
-spring.ds_commands.username=
-spring.ds_commands.password=
+spring.ds_commands.jdbcUrl=jdbc:mysql://localhost:3306/exam
+spring.ds_commands.username=root
+spring.ds_commands.password=password
 
 server.undertow.buffer-size=16384
 server.undertow.buffers-per-region=20


### PR DESCRIPTION
Add endpoint to pause all `Exam`s that belong to a specified `Session`.  In the event there are no `Exam`s to pause, the endpoint will return successfully.