### PR TITLE
Add missing status codes supported in the legacy system.

### DIFF
--- a/client/src/main/java/tds/exam/ExamApproval.java
+++ b/client/src/main/java/tds/exam/ExamApproval.java
@@ -13,7 +13,7 @@ public class ExamApproval {
     public ExamApproval(UUID examId, ExamStatusCode examStatusCode, String statusChangeReason) {
         this.examId = examId;
         this.statusChangeReason = statusChangeReason;
-        this.examApprovalStatus = ExamApprovalStatus.fromExamStatus(examStatusCode.getStatus());
+        this.examApprovalStatus = ExamApprovalStatus.fromExamStatus(examStatusCode.getCode());
     }
 
     /**

--- a/client/src/main/java/tds/exam/ExamStatusCode.java
+++ b/client/src/main/java/tds/exam/ExamStatusCode.java
@@ -9,12 +9,19 @@ public class ExamStatusCode {
     public static final String STATUS_INITIALIZING = "initializing";
     public static final String STATUS_STARTED = "started";
     public static final String STATUS_FAILED = "failed";
+    public static final String STATUS_DENIED = "denied";
+    public static final String STATUS_COMPLETED = "completed";
+    public static final String STATUS_SCORED = "scored";
+    public static final String STAUTS_SEGMENT_ENTRY = "segmentEntry";
+    public static final String STATUS_SEGMENT_EXIT = "segmentExit";
+    public static final String STATUS_CLOSED = "closed";
+    public static final String STATUS_DISABLED = "disabled";
 
-    private String status;
+    private String code;
     private ExamStatusStage stage;
 
-    public String getStatus() {
-        return status;
+    public String getCode() {
+        return code;
     }
 
     public ExamStatusStage getStage() {
@@ -27,8 +34,8 @@ public class ExamStatusCode {
     private ExamStatusCode() {
     }
 
-    public ExamStatusCode(String status, ExamStatusStage stage) {
-        this.status = status;
+    public ExamStatusCode(String code, ExamStatusStage stage) {
+        this.code = code;
         this.stage = stage;
     }
 
@@ -39,14 +46,14 @@ public class ExamStatusCode {
 
         ExamStatusCode that = (ExamStatusCode) o;
 
-        if (status != null ? !status.equals(that.status) : that.status != null) return false;
+        if (code != null ? !code.equals(that.code) : that.code != null) return false;
         return stage != null ? stage.equals(that.stage) : that.stage == null;
 
     }
 
     @Override
     public int hashCode() {
-        int result = status != null ? status.hashCode() : 0;
+        int result = code != null ? code.hashCode() : 0;
         result = 31 * result + (stage != null ? stage.hashCode() : 0);
         return result;
     }
@@ -54,7 +61,7 @@ public class ExamStatusCode {
     @Override
     public String toString() {
         return "ExamStatusCode{" +
-            "status='" + status + '\'' +
+            "code='" + code + '\'' +
             ", stage='" + stage + '\'' +
             '}';
     }

--- a/service/src/main/java/tds/exam/repositories/impl/ExamCommandRepositoryImpl.java
+++ b/service/src/main/java/tds/exam/repositories/impl/ExamCommandRepositoryImpl.java
@@ -89,7 +89,7 @@ class ExamCommandRepositoryImpl implements ExamCommandRepository {
         SqlParameterSource[] batchParameters = Stream.of(exams)
             .map(exam -> new MapSqlParameterSource("examId", getBytesFromUUID(exam.getId()))
                 .addValue("attempts", exam.getAttempts())
-                .addValue("status", exam.getStatus().getStatus())
+                .addValue("status", exam.getStatus().getCode())
                 .addValue("statusChangeDate", mapJodaInstantToTimestamp(exam.getStatusChangeDate()))
                 .addValue("browserId", getBytesFromUUID(exam.getBrowserId()))
                 .addValue("maxItems", exam.getMaxItems())

--- a/service/src/main/java/tds/exam/services/impl/ExamServiceImpl.java
+++ b/service/src/main/java/tds/exam/services/impl/ExamServiceImpl.java
@@ -251,9 +251,9 @@ class ExamServiceImpl implements ExamService {
         Exam exam = examQueryRepository.getExamById(examId)
             .orElseThrow(() -> new NotFoundException(String.format("Exam could not be found for id %s", examId)));
 
-        if (!statusesThatCanTransitionToPaused.contains(exam.getStatus().getStatus())) {
+        if (!statusesThatCanTransitionToPaused.contains(exam.getStatus().getCode())) {
             return Optional.of(new ValidationError(ValidationErrorCode.EXAM_STATUS_TRANSITION_FAILURE,
-                String.format("Bad status transition from %s to %s", exam.getStatus().getStatus(), ExamStatusCode.STATUS_PAUSED)));
+                String.format("Bad status transition from %s to %s", exam.getStatus().getCode(), ExamStatusCode.STATUS_PAUSED)));
         }
 
         // A status change reason is not required for pausing an exam.
@@ -351,7 +351,7 @@ class ExamServiceImpl implements ExamService {
         Exam exam = maybeExam.get();
 
         /* TestOpportunityServiceImpl [155] No need to go any further, so moving before service calls */
-        if (!exam.getStatus().getStatus().equalsIgnoreCase(ExamStatusCode.STATUS_APPROVED)) {
+        if (!exam.getStatus().getCode().equalsIgnoreCase(ExamStatusCode.STATUS_APPROVED)) {
             return new Response<ExamConfiguration>(new ValidationError(
                 ExamStatusCode.STATUS_FAILED, String.format("Cannot start exam %s: Exam was not approved.", examId)
             ));

--- a/service/src/test/java/tds/exam/repositories/impl/ExamCommandRepositoryImplIntegrationTests.java
+++ b/service/src/test/java/tds/exam/repositories/impl/ExamCommandRepositoryImplIntegrationTests.java
@@ -142,7 +142,7 @@ public class ExamCommandRepositoryImplIntegrationTests {
 
         assertThat(maybeMockFirstExamAfterUpdate).isPresent();
         Exam mockFirstExamAfterUpdate = maybeMockFirstExamAfterUpdate.get();
-        assertThat(mockFirstExamAfterUpdate.getStatus().getStatus()).isEqualTo(ExamStatusCode.STATUS_APPROVED);
+        assertThat(mockFirstExamAfterUpdate.getStatus().getCode()).isEqualTo(ExamStatusCode.STATUS_APPROVED);
         assertThat(mockFirstExamAfterUpdate.getStatusChangeDate().getMillis()).isGreaterThan(mockFirstExam.getStatusChangeDate().getMillis());
         assertThat(mockFirstExamAfterUpdate.getAttempts()).isEqualTo(500);
         assertThat(mockFirstExamAfterUpdate.getStatusChangeReason()).isEqualTo("unit test");
@@ -152,7 +152,7 @@ public class ExamCommandRepositoryImplIntegrationTests {
 
         assertThat(maybeMockSecondExamAfterUpdate).isPresent();
         Exam mockSecondExamAfterUpdate = maybeMockSecondExamAfterUpdate.get();
-        assertThat(mockSecondExamAfterUpdate.getStatus().getStatus()).isEqualTo(ExamStatusCode.STATUS_STARTED);
+        assertThat(mockSecondExamAfterUpdate.getStatus().getCode()).isEqualTo(ExamStatusCode.STATUS_STARTED);
         assertThat(mockSecondExamAfterUpdate.getStatusChangeDate().getMillis()).isGreaterThan(mockSecondExam.getStatusChangeDate().getMillis());
         assertThat(mockSecondExamAfterUpdate.getMaxItems()).isEqualTo(600);
         assertThat(mockSecondExamAfterUpdate.getStatusChangeReason()).isEqualTo("unit test 2");

--- a/service/src/test/java/tds/exam/repositories/impl/ExamQueryRepositoryImplIntegrationTests.java
+++ b/service/src/test/java/tds/exam/repositories/impl/ExamQueryRepositoryImplIntegrationTests.java
@@ -254,7 +254,7 @@ public class ExamQueryRepositoryImplIntegrationTests {
         List<Exam> exams = examQueryRepository.findAllExamsInSessionWithStatus(mockSessionId, statusesThatCanTransitionToPaused);
 
         assertThat(exams).hasSize(3);
-        assertThat(exams).doesNotContain(examsInSession.stream().filter(exam -> exam.getStatus().getStatus().equals(ExamStatusCode.STATUS_FAILED)).findAny().get());
+        assertThat(exams).doesNotContain(examsInSession.stream().filter(exam -> exam.getStatus().getCode().equals(ExamStatusCode.STATUS_FAILED)).findAny().get());
     }
 
     @Test

--- a/service/src/test/java/tds/exam/repositories/impl/ExamStatusQueryRepositoryImplIntegrationTests.java
+++ b/service/src/test/java/tds/exam/repositories/impl/ExamStatusQueryRepositoryImplIntegrationTests.java
@@ -37,7 +37,7 @@ public class ExamStatusQueryRepositoryImplIntegrationTests {
         //Statuses are current loaded via a migration script V1473962717__exam_create_status_codes_table.sql
         ExamStatusCode code = examStatusQueryRepository.findExamStatusCode("started");
 
-        assertThat(code.getStatus()).isEqualTo("started");
+        assertThat(code.getCode()).isEqualTo("started");
         assertThat(code.getStage()).isEqualTo(ExamStatusStage.IN_USE);
     }
 

--- a/service/src/test/java/tds/exam/services/impl/ExamServiceImplTest.java
+++ b/service/src/test/java/tds/exam/services/impl/ExamServiceImplTest.java
@@ -294,7 +294,7 @@ public class ExamServiceImplTest {
         assertThat(exam.getLoginSSID()).isEqualTo("GUEST");
         assertThat(exam.getStudentName()).isEqualTo("GUEST");
         assertThat(exam.getEnvironment()).isEqualTo(extSessionConfig.getEnvironment());
-        assertThat(exam.getStatus().getStatus()).isEqualTo(STATUS_PENDING);
+        assertThat(exam.getStatus().getCode()).isEqualTo(STATUS_PENDING);
         assertThat(exam.getSubject()).isEqualTo(assessment.getSubject());
     }
 
@@ -347,7 +347,7 @@ public class ExamServiceImplTest {
         assertThat(examResponse.getErrors()).isEmpty();
 
         Exam exam = examResponse.getData().get();
-        assertThat(exam.getStatus().getStatus()).isEqualTo(ExamStatusCode.STATUS_APPROVED);
+        assertThat(exam.getStatus().getCode()).isEqualTo(ExamStatusCode.STATUS_APPROVED);
     }
 
     @Test
@@ -393,7 +393,7 @@ public class ExamServiceImplTest {
         assertThat(examResponse.getErrors()).isEmpty();
 
         Exam exam = examResponse.getData().get();
-        assertThat(exam.getStatus().getStatus()).isEqualTo(STATUS_PENDING);
+        assertThat(exam.getStatus().getCode()).isEqualTo(STATUS_PENDING);
         assertThat(exam.getStudentName()).isEqualTo("Entity Id");
         assertThat(exam.getLoginSSID()).isEqualTo("External Id");
     }
@@ -452,7 +452,7 @@ public class ExamServiceImplTest {
         assertThat(savedExam.getId()).isEqualTo(previousExam.getId());
         assertThat(savedExam.getBrowserId()).isEqualTo(request.getBrowserId());
         assertThat(savedExam.getBrowserId()).isNotEqualTo(previousExam.getBrowserId());
-        assertThat(savedExam.getStatus().getStatus()).isEqualTo(STATUS_PENDING);
+        assertThat(savedExam.getStatus().getCode()).isEqualTo(STATUS_PENDING);
         assertThat(savedExam.getStatusChangeDate()).isGreaterThan(approvedStatusDate);
         assertThat(savedExam.getDateChanged()).isNotNull();
         assertThat(savedExam.getDateStarted()).isEqualTo(previousExam.getDateStarted());
@@ -504,7 +504,7 @@ public class ExamServiceImplTest {
         assertThat(savedExam.getId()).isEqualTo(previousExam.getId());
         assertThat(savedExam.getBrowserId()).isEqualTo(request.getBrowserId());
         assertThat(savedExam.getBrowserId()).isNotEqualTo(previousExam.getBrowserId());
-        assertThat(savedExam.getStatus().getStatus()).isEqualTo(STATUS_PENDING);
+        assertThat(savedExam.getStatus().getCode()).isEqualTo(STATUS_PENDING);
         assertThat(savedExam.getStatusChangeDate()).isGreaterThan(approvedStatusDate);
         assertThat(savedExam.getDateChanged()).isNotNull();
         assertThat(savedExam.getDateStarted()).isEqualTo(previousExam.getDateStarted());
@@ -557,7 +557,7 @@ public class ExamServiceImplTest {
         assertThat(savedExam.getId()).isEqualTo(previousExam.getId());
         assertThat(savedExam.getBrowserId()).isEqualTo(request.getBrowserId());
         assertThat(savedExam.getBrowserId()).isNotEqualTo(previousExam.getBrowserId());
-        assertThat(savedExam.getStatus().getStatus()).isEqualTo(STATUS_PENDING);
+        assertThat(savedExam.getStatus().getCode()).isEqualTo(STATUS_PENDING);
         assertThat(savedExam.getStatusChangeDate()).isGreaterThan(approvedStatusDate);
         assertThat(savedExam.getDateChanged()).isNotNull();
         assertThat(savedExam.getDateStarted()).isEqualTo(previousExam.getDateStarted());
@@ -610,7 +610,7 @@ public class ExamServiceImplTest {
         assertThat(savedExam.getId()).isEqualTo(previousExam.getId());
         assertThat(savedExam.getBrowserId()).isEqualTo(request.getBrowserId());
         assertThat(savedExam.getBrowserId()).isNotEqualTo(previousExam.getBrowserId());
-        assertThat(savedExam.getStatus().getStatus()).isEqualTo(STATUS_PENDING);
+        assertThat(savedExam.getStatus().getCode()).isEqualTo(STATUS_PENDING);
         assertThat(savedExam.getStatusChangeDate()).isGreaterThan(approvedStatusDate);
         assertThat(savedExam.getDateChanged()).isNotNull();
         assertThat(savedExam.getDateStarted()).isEqualTo(previousExam.getDateStarted());
@@ -661,7 +661,7 @@ public class ExamServiceImplTest {
         assertThat(savedExam.getId()).isEqualTo(previousExam.getId());
         assertThat(savedExam.getBrowserId()).isEqualTo(request.getBrowserId());
         assertThat(savedExam.getBrowserId()).isNotEqualTo(previousExam.getBrowserId());
-        assertThat(savedExam.getStatus().getStatus()).isEqualTo(STATUS_SUSPENDED);
+        assertThat(savedExam.getStatus().getCode()).isEqualTo(STATUS_SUSPENDED);
         assertThat(savedExam.getStatusChangeDate()).isGreaterThan(approvedStatusDate);
         assertThat(savedExam.getDateChanged()).isNotNull();
         assertThat(savedExam.getDateStarted()).isEqualTo(previousExam.getDateStarted());
@@ -1461,7 +1461,7 @@ public class ExamServiceImplTest {
         assertThat(updatedExam.getDateChanged()).isGreaterThan(exam.getDateChanged());
         assertThat(updatedExam.getExpireFrom()).isNotNull();
         assertThat(updatedExam.getStatus().getStage()).isEqualTo(ExamStatusStage.IN_PROGRESS);
-        assertThat(updatedExam.getStatus().getStatus()).isEqualTo(ExamStatusCode.STATUS_STARTED);
+        assertThat(updatedExam.getStatus().getCode()).isEqualTo(ExamStatusCode.STATUS_STARTED);
         assertThat(updatedExam.getStatusChangeDate()).isGreaterThan(approvedStatusDate);
     }
 
@@ -1534,7 +1534,7 @@ public class ExamServiceImplTest {
         assertThat(updatedExam.getDateChanged()).isGreaterThan(exam.getDateChanged());
         assertThat(updatedExam.getExpireFrom()).isNull();
         assertThat(updatedExam.getStatus().getStage()).isEqualTo(ExamStatusStage.IN_PROGRESS);
-        assertThat(updatedExam.getStatus().getStatus()).isEqualTo(ExamStatusCode.STATUS_STARTED);
+        assertThat(updatedExam.getStatus().getCode()).isEqualTo(ExamStatusCode.STATUS_STARTED);
         assertThat(updatedExam.getStatusChangeDate()).isGreaterThan(approvedStatusDate);
     }
 
@@ -1612,7 +1612,7 @@ public class ExamServiceImplTest {
         assertThat(updatedExam.getDateChanged()).isGreaterThan(exam.getDateChanged());
         assertThat(updatedExam.getExpireFrom()).isNull();
         assertThat(updatedExam.getStatus().getStage()).isEqualTo(ExamStatusStage.IN_PROGRESS);
-        assertThat(updatedExam.getStatus().getStatus()).isEqualTo(ExamStatusCode.STATUS_STARTED);
+        assertThat(updatedExam.getStatus().getCode()).isEqualTo(ExamStatusCode.STATUS_STARTED);
         assertThat(updatedExam.getStatusChangeDate()).isGreaterThan(approvedStatusDate);
     }
 


### PR DESCRIPTION
This is a smallish change.  I've added the missing status codes that are used by the legacy system.  They are currently unused in our code, and if we find out that they are never used we can remove them later.  This is for the legacy conversion code I'm writing.

Also renamed `status` to `code` in the `ExamStatusCode` class.