### PR TITLE
Feature/field test select items - Field Test Item Group Selection

### DIFF
--- a/service/src/main/java/tds/exam/models/FieldTestItemGroup.java
+++ b/service/src/main/java/tds/exam/models/FieldTestItemGroup.java
@@ -1,0 +1,297 @@
+package tds.exam.models;
+
+import java.time.Instant;
+import java.util.UUID;
+
+/**
+ * Represents a field test item group
+ */
+public class FieldTestItemGroup {
+    private long id;
+    private String segmentKey;
+    private UUID examId;
+    private int position;
+    private int numItems;
+    private String groupId;
+    private String groupKey;
+    private String blockId;
+    private String segmentId;
+    private UUID sessionId;
+    private String languageCode;
+    private Instant createdAt;
+    private Instant deletedAt;
+    private Integer positionAdministered;
+    private Instant administeredAt;
+
+    private FieldTestItemGroup() {}
+
+    public FieldTestItemGroup(Builder builder) {
+        this.segmentKey = builder.segmentKey;
+        this.examId = builder.examId;
+        this.position = builder.position;
+        this.numItems = builder.numItems;
+        this.groupId = builder.groupId;
+        this.groupKey = builder.groupKey;
+        this.blockId = builder.blockId;
+        this.segmentId = builder.segmentId;
+        this.sessionId = builder.sessionId;
+        this.languageCode = builder.languageCode;
+        this.administeredAt = builder.administeredAt;
+        this.createdAt = builder.createdAt;
+        this.positionAdministered = builder.positionAdministered;
+        this.deletedAt = builder.deletedAt;
+    }
+
+    /**
+     * @return The id of the {@link tds.exam.models.FieldTestItemGroup}
+     */
+    public long getId() {
+        return id;
+    }
+
+    public void setId(long id) {
+        this.id = id;
+    }
+
+    /**
+     * @return The group id of the {@link tds.exam.models.FieldTestItemGroup}
+     */
+    public String getGroupId() {
+        return groupId;
+    }
+
+    /**
+     * @return The key of the {@link tds.assessment.Segment} the {@link tds.exam.models.FieldTestItemGroup} is a part of
+     */
+    public String getSegmentKey() {
+        return segmentKey;
+    }
+
+    /**
+     * @return The id of the {@link tds.assessment.Segment} the {@link tds.exam.models.FieldTestItemGroup} is a part of
+     */
+    public String getSegmentId() {
+        return segmentId;
+    }
+
+    /**
+     * @return The id of the {@link tds.session.Session} the {@link tds.exam.models.FieldTestItemGroup} is a part of
+     */
+    public UUID getSessionId() {
+        return sessionId;
+    }
+
+    /**
+     * @return The id of the {@link tds.exam.Exam} this {@link tds.exam.models.FieldTestItemGroup} is a part of
+     */
+    public UUID getExamId() {
+        return examId;
+    }
+
+    /**
+     * @return The position of the {@link tds.exam.models.FieldTestItemGroup} in the {@link tds.exam.Exam}
+     */
+    public int getPosition() {
+        return position;
+    }
+
+    /**
+     * @return The number of field test {@link tds.assessment.Item}s in the {@link tds.exam.models.FieldTestItemGroup}
+     */
+    public int getNumItems() {
+        return numItems;
+    }
+
+    /**
+     * @return The group key of the {@link tds.exam.models.FieldTestItemGroup}. Usually in the form of "groupid_blockid".
+     */
+    public String getGroupKey() {
+        return groupKey;
+    }
+
+    /**
+     * @return The block id of the {@link tds.exam.models.FieldTestItemGroup}
+     */
+    public String getBlockId() {
+        return blockId;
+    }
+
+    /**
+     * @return The language code of the {@link tds.exam.Exam}
+     */
+    public String getLanguageCode() {
+        return languageCode;
+    }
+
+    /**
+     * @return The {@link java.time.Instant} the {@link tds.exam.models.FieldTestItemGroup} was assigned at
+     */
+    public Instant getCreatedAt() {
+        return createdAt;
+    }
+
+    /**
+     * @return The {@link java.time.Instant}
+     */
+    public Instant getDeletedAt() {
+        return deletedAt;
+    }
+
+    /**
+     * @return A flag that determines whether the {@link tds.exam.models.FieldTestItemGroup} is deleted
+     */
+    public boolean isDeleted() {
+        return deletedAt == null;
+    }
+
+    /**
+     * @return The position in the exam the {@link tds.exam.models.FieldTestItemGroup} was actually administered at
+     */
+    public Integer getPositionAdministered() {
+        return positionAdministered;
+    }
+
+    /**
+     * @return The {@link java.time.Instant} the item was administered at
+     */
+    public Instant getAdministeredAt() {
+        return administeredAt;
+    }
+
+    public static class Builder {
+        private long id;
+        private String segmentKey;
+        private UUID examId;
+        private int position;
+        private int numItems;
+        private String groupId;
+        private String groupKey;
+        private String blockId;
+        private String segmentId;
+        private UUID sessionId;
+        private String languageCode;
+        private Instant createdAt;
+        private Instant deletedAt;
+        private Integer positionAdministered;
+        private Instant administeredAt;
+
+        public Builder withId(int id) {
+            this.id = id;
+            return this;
+        }
+
+        public Builder withSegmentKey(String segmentKey) {
+            this.segmentKey = segmentKey;
+            return this;
+        }
+
+        public Builder withExamId(UUID examId) {
+            this.examId = examId;
+            return this;
+        }
+
+        public Builder withPosition(int position) {
+            this.position = position;
+            return this;
+        }
+
+        public Builder withNumItems(int numItems) {
+            this.numItems = numItems;
+            return this;
+        }
+
+        public Builder withGroupId(String groupId) {
+            this.groupId = groupId;
+            return this;
+        }
+
+        public Builder withGroupKey(String groupKey) {
+            this.groupKey = groupKey;
+            return this;
+        }
+
+        public Builder withBlockId(String blockId) {
+            this.blockId = blockId;
+            return this;
+        }
+
+        public Builder withSegmentId(String segmentId) {
+            this.segmentId = segmentId;
+            return this;
+        }
+
+        public Builder withSessionId(UUID sessionId) {
+            this.sessionId = sessionId;
+            return this;
+        }
+
+        public Builder withLanguageCode(String languageCode) {
+            this.languageCode = languageCode;
+            return this;
+        }
+
+        public Builder withCreatedAt(Instant createdAt) {
+            this.createdAt = createdAt;
+            return this;
+        }
+
+        public Builder withDeletedAt(Instant deletedAt) {
+            this.deletedAt = deletedAt;
+            return this;
+        }
+
+        public Builder withPositionAdministered(Integer positionAdministered) {
+            this.positionAdministered = positionAdministered;
+            return this;
+        }
+
+        public Builder withAdministeredAt(Instant administeredAt) {
+            this.administeredAt = administeredAt;
+            return this;
+        }
+
+        public Builder fromFieldTestItemGroup(final FieldTestItemGroup fieldTestItemGroup) {
+            this.segmentKey = fieldTestItemGroup.segmentKey;
+            this.examId = fieldTestItemGroup.examId;
+            this.position = fieldTestItemGroup.position;
+            this.numItems = fieldTestItemGroup.numItems;
+            this.groupId = fieldTestItemGroup.groupId;
+            this.groupKey = fieldTestItemGroup.groupKey;
+            this.blockId = fieldTestItemGroup.blockId;
+            this.segmentId = fieldTestItemGroup.segmentId;
+            this.sessionId = fieldTestItemGroup.sessionId;
+            this.languageCode = fieldTestItemGroup.languageCode;
+            this.administeredAt = fieldTestItemGroup.administeredAt;
+            this.createdAt = fieldTestItemGroup.createdAt;
+            this.positionAdministered = fieldTestItemGroup.positionAdministered;
+            this.deletedAt = fieldTestItemGroup.deletedAt;
+            return this;
+        }
+
+        public FieldTestItemGroup build() {
+            return new FieldTestItemGroup(this);
+        }
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) return true;
+        if (o == null || getClass() != o.getClass()) return false;
+
+        FieldTestItemGroup that = (FieldTestItemGroup) o;
+
+        if (!examId.equals(that.examId)) return false;
+        if (!languageCode.equals(that.languageCode)) return false;
+        if (!segmentKey.equals(that.segmentKey)) return false;
+        return groupKey.equals(that.groupKey);
+    }
+
+    @Override
+    public int hashCode() {
+        int result = examId.hashCode();
+        result = 31 * result + languageCode.hashCode();
+        result = 31 * result + segmentKey.hashCode();
+        result = 31 * result + groupKey.hashCode();
+        return result;
+    }
+}

--- a/service/src/main/java/tds/exam/models/FieldTestItemGroup.java
+++ b/service/src/main/java/tds/exam/models/FieldTestItemGroup.java
@@ -11,7 +11,7 @@ public class FieldTestItemGroup {
     private String segmentKey;
     private UUID examId;
     private int position;
-    private int numItems;
+    private int itemCount;
     private String groupId;
     private String groupKey;
     private String blockId;
@@ -23,13 +23,14 @@ public class FieldTestItemGroup {
     private Integer positionAdministered;
     private Instant administeredAt;
 
+    //Exists for frameworks
     private FieldTestItemGroup() {}
 
     public FieldTestItemGroup(Builder builder) {
         this.segmentKey = builder.segmentKey;
         this.examId = builder.examId;
         this.position = builder.position;
-        this.numItems = builder.numItems;
+        this.itemCount = builder.itemCount;
         this.groupId = builder.groupId;
         this.groupKey = builder.groupKey;
         this.blockId = builder.blockId;
@@ -98,8 +99,8 @@ public class FieldTestItemGroup {
     /**
      * @return The number of field test {@link tds.assessment.Item}s in the {@link tds.exam.models.FieldTestItemGroup}
      */
-    public int getNumItems() {
-        return numItems;
+    public int getItemCount() {
+        return itemCount;
     }
 
     /**
@@ -141,7 +142,7 @@ public class FieldTestItemGroup {
      * @return A flag that determines whether the {@link tds.exam.models.FieldTestItemGroup} is deleted
      */
     public boolean isDeleted() {
-        return deletedAt == null;
+        return deletedAt != null;
     }
 
     /**
@@ -163,7 +164,7 @@ public class FieldTestItemGroup {
         private String segmentKey;
         private UUID examId;
         private int position;
-        private int numItems;
+        private int itemCount;
         private String groupId;
         private String groupKey;
         private String blockId;
@@ -195,8 +196,8 @@ public class FieldTestItemGroup {
             return this;
         }
 
-        public Builder withNumItems(int numItems) {
-            this.numItems = numItems;
+        public Builder withItemCount(int itemCount) {
+            this.itemCount = itemCount;
             return this;
         }
 
@@ -251,10 +252,11 @@ public class FieldTestItemGroup {
         }
 
         public Builder fromFieldTestItemGroup(final FieldTestItemGroup fieldTestItemGroup) {
+            this.id = fieldTestItemGroup.id;
             this.segmentKey = fieldTestItemGroup.segmentKey;
             this.examId = fieldTestItemGroup.examId;
             this.position = fieldTestItemGroup.position;
-            this.numItems = fieldTestItemGroup.numItems;
+            this.itemCount = fieldTestItemGroup.itemCount;
             this.groupId = fieldTestItemGroup.groupId;
             this.groupKey = fieldTestItemGroup.groupKey;
             this.blockId = fieldTestItemGroup.blockId;

--- a/service/src/main/java/tds/exam/repositories/FieldTestItemGroupCommandRepository.java
+++ b/service/src/main/java/tds/exam/repositories/FieldTestItemGroupCommandRepository.java
@@ -1,0 +1,18 @@
+package tds.exam.repositories;
+
+import java.util.List;
+
+import tds.exam.models.FieldTestItemGroup;
+
+/**
+ * Repository for writing to the field_test_item_group and field_test_item_group_event repositories
+ */
+public interface FieldTestItemGroupCommandRepository {
+
+    /**
+     * Inserts a collection of {@link tds.exam.models.FieldTestItemGroup}s
+     *
+     * @param fieldTestItemGroups the {@link tds.exam.models.FieldTestItemGroup}s to insert
+     */
+    void insert(List<FieldTestItemGroup> fieldTestItemGroups);
+}

--- a/service/src/main/java/tds/exam/repositories/FieldTestItemGroupQueryRepository.java
+++ b/service/src/main/java/tds/exam/repositories/FieldTestItemGroupQueryRepository.java
@@ -1,0 +1,21 @@
+package tds.exam.repositories;
+
+import java.util.List;
+import java.util.UUID;
+
+import tds.exam.models.FieldTestItemGroup;
+
+/**
+ * Repository for reading from the field_test_item_group and field_test_item_group_event table.
+ */
+public interface FieldTestItemGroupQueryRepository {
+
+    /**
+     * Finds all {@link tds.exam.models.FieldTestItemGroup}s for an exam and segment.
+     *
+     * @param examId     The id of the {@link tds.exam.Exam} to fetch item groups by
+     * @param segmentKey The id of the {@link tds.assessment.Segment} to fetch item groups by
+     * @return The list of {@link tds.exam.models.FieldTestItemGroup}s fetched
+     */
+    List<FieldTestItemGroup> find(UUID examId, String segmentKey);
+}

--- a/service/src/main/java/tds/exam/repositories/impl/FieldTestItemGroupCommandRepositoryImpl.java
+++ b/service/src/main/java/tds/exam/repositories/impl/FieldTestItemGroupCommandRepositoryImpl.java
@@ -1,0 +1,99 @@
+package tds.exam.repositories.impl;
+
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.beans.factory.annotation.Qualifier;
+import org.springframework.jdbc.core.namedparam.MapSqlParameterSource;
+import org.springframework.jdbc.core.namedparam.NamedParameterJdbcTemplate;
+import org.springframework.jdbc.core.namedparam.SqlParameterSource;
+import org.springframework.jdbc.support.GeneratedKeyHolder;
+import org.springframework.jdbc.support.KeyHolder;
+import org.springframework.stereotype.Repository;
+
+import java.util.List;
+
+import tds.common.data.mapping.ResultSetMapperUtility;
+import tds.exam.models.FieldTestItemGroup;
+import tds.exam.repositories.FieldTestItemGroupCommandRepository;
+
+import static tds.common.data.mysql.UuidAdapter.getBytesFromUUID;
+
+@Repository
+public class FieldTestItemGroupCommandRepositoryImpl implements FieldTestItemGroupCommandRepository {
+    private final NamedParameterJdbcTemplate jdbcTemplate;
+
+    @Autowired
+    public FieldTestItemGroupCommandRepositoryImpl(@Qualifier("commandJdbcTemplate") NamedParameterJdbcTemplate jdbcTemplate) {
+        this.jdbcTemplate = jdbcTemplate;
+    }
+
+    @Override
+    public void insert(List<FieldTestItemGroup> fieldTestItemGroups) {
+        final String ftItemGroupSQL =
+            "INSERT INTO field_test_item_group ( \n" +
+            "   exam_id, \n" +
+            "   position, \n" +
+            "   num_items, \n" +
+            "   segment_id, \n" +
+            "   segment_key, \n" +
+            "   group_id, \n" +
+            "   group_key, \n" +
+            "   block_id, \n" +
+            "   session_id, \n" +
+            "   language_code \n" +
+            ") \n " +
+            "VALUES ( \n" +
+            "   :examId, \n" +
+            "   :position, \n" +
+            "   :numItems, \n" +
+            "   :segmentId, \n" +
+            "   :segmentKey, \n" +
+            "   :groupId, \n" +
+            "   :groupKey, \n" +
+            "   :blockId, \n" +
+            "   :sessionId, \n" +
+            "   :languageCode \n" +
+            ")";
+
+        fieldTestItemGroups.forEach(fieldTestItemGroup -> {
+            SqlParameterSource parameterSources = new MapSqlParameterSource("examId", getBytesFromUUID(fieldTestItemGroup.getExamId()))
+                .addValue("position", fieldTestItemGroup.getPosition())
+                .addValue("numItems", fieldTestItemGroup.getNumItems())
+                .addValue("segmentId", fieldTestItemGroup.getSegmentId())
+                .addValue("segmentKey", fieldTestItemGroup.getSegmentKey())
+                .addValue("groupId", fieldTestItemGroup.getGroupId())
+                .addValue("groupKey", fieldTestItemGroup.getGroupKey())
+                .addValue("blockId", fieldTestItemGroup.getBlockId())
+                .addValue("sessionId", getBytesFromUUID(fieldTestItemGroup.getSessionId()))
+                .addValue("languageCode", fieldTestItemGroup.getLanguageCode());
+
+            KeyHolder keyHolder = new GeneratedKeyHolder();
+            jdbcTemplate.update(ftItemGroupSQL, parameterSources, keyHolder);
+            fieldTestItemGroup.setId(keyHolder.getKey().longValue());
+
+            update(fieldTestItemGroup);
+        });
+    }
+
+    private void update(FieldTestItemGroup fieldTestItemGroup) {
+        final SqlParameterSource params = new MapSqlParameterSource("id", fieldTestItemGroup.getId())
+            .addValue("deletedAt", ResultSetMapperUtility.mapInstantToTimestamp(fieldTestItemGroup.getDeletedAt()))
+            .addValue("positionAdministered", fieldTestItemGroup.getPositionAdministered())
+            .addValue("administeredAt", ResultSetMapperUtility.mapInstantToTimestamp(fieldTestItemGroup.getAdministeredAt()));
+
+        final String updateSQL =
+            "INSERT INTO field_test_item_group_event ( \n" +
+            "   field_test_item_group_id, \n" +
+            "   deleted_at, \n" +
+            "   position_administered, \n" +
+            "   administered_at \n" +
+            ") \n" +
+            "VALUES ( \n"  +
+            "   :id, \n" +
+            "   :deletedAt, \n" +
+            "   :positionAdministered, \n" +
+            "   :administeredAt \n" +
+            ")";
+
+        jdbcTemplate.update(updateSQL, params);
+    }
+}

--- a/service/src/main/java/tds/exam/repositories/impl/FieldTestItemGroupCommandRepositoryImpl.java
+++ b/service/src/main/java/tds/exam/repositories/impl/FieldTestItemGroupCommandRepositoryImpl.java
@@ -30,29 +30,29 @@ public class FieldTestItemGroupCommandRepositoryImpl implements FieldTestItemGro
     public void insert(List<FieldTestItemGroup> fieldTestItemGroups) {
         final String ftItemGroupSQL =
             "INSERT INTO field_test_item_group ( \n" +
-            "   exam_id, \n" +
-            "   position, \n" +
-            "   num_items, \n" +
-            "   segment_id, \n" +
-            "   segment_key, \n" +
-            "   group_id, \n" +
-            "   group_key, \n" +
-            "   block_id, \n" +
-            "   session_id, \n" +
-            "   language_code \n" +
-            ") \n " +
-            "VALUES ( \n" +
-            "   :examId, \n" +
-            "   :position, \n" +
-            "   :numItems, \n" +
-            "   :segmentId, \n" +
-            "   :segmentKey, \n" +
-            "   :groupId, \n" +
-            "   :groupKey, \n" +
-            "   :blockId, \n" +
-            "   :sessionId, \n" +
-            "   :languageCode \n" +
-            ")";
+                "   exam_id, \n" +
+                "   position, \n" +
+                "   num_items, \n" +
+                "   segment_id, \n" +
+                "   segment_key, \n" +
+                "   group_id, \n" +
+                "   group_key, \n" +
+                "   block_id, \n" +
+                "   session_id, \n" +
+                "   language_code \n" +
+                ") \n " +
+                "VALUES ( \n" +
+                "   :examId, \n" +
+                "   :position, \n" +
+                "   :numItems, \n" +
+                "   :segmentId, \n" +
+                "   :segmentKey, \n" +
+                "   :groupId, \n" +
+                "   :groupKey, \n" +
+                "   :blockId, \n" +
+                "   :sessionId, \n" +
+                "   :languageCode \n" +
+                ")";
 
         fieldTestItemGroups.forEach(fieldTestItemGroup -> {
             SqlParameterSource parameterSources = new MapSqlParameterSource("examId", getBytesFromUUID(fieldTestItemGroup.getExamId()))
@@ -82,17 +82,17 @@ public class FieldTestItemGroupCommandRepositoryImpl implements FieldTestItemGro
 
         final String updateSQL =
             "INSERT INTO field_test_item_group_event ( \n" +
-            "   field_test_item_group_id, \n" +
-            "   deleted_at, \n" +
-            "   position_administered, \n" +
-            "   administered_at \n" +
-            ") \n" +
-            "VALUES ( \n"  +
-            "   :id, \n" +
-            "   :deletedAt, \n" +
-            "   :positionAdministered, \n" +
-            "   :administeredAt \n" +
-            ")";
+                "   field_test_item_group_id, \n" +
+                "   deleted_at, \n" +
+                "   position_administered, \n" +
+                "   administered_at \n" +
+                ") \n" +
+                "VALUES ( \n" +
+                "   :id, \n" +
+                "   :deletedAt, \n" +
+                "   :positionAdministered, \n" +
+                "   :administeredAt \n" +
+                ")";
 
         jdbcTemplate.update(updateSQL, params);
     }

--- a/service/src/main/java/tds/exam/repositories/impl/FieldTestItemGroupCommandRepositoryImpl.java
+++ b/service/src/main/java/tds/exam/repositories/impl/FieldTestItemGroupCommandRepositoryImpl.java
@@ -32,7 +32,7 @@ public class FieldTestItemGroupCommandRepositoryImpl implements FieldTestItemGro
             "INSERT INTO field_test_item_group ( \n" +
                 "   exam_id, \n" +
                 "   position, \n" +
-                "   num_items, \n" +
+                "   item_count, \n" +
                 "   segment_id, \n" +
                 "   segment_key, \n" +
                 "   group_id, \n" +
@@ -44,7 +44,7 @@ public class FieldTestItemGroupCommandRepositoryImpl implements FieldTestItemGro
                 "VALUES ( \n" +
                 "   :examId, \n" +
                 "   :position, \n" +
-                "   :numItems, \n" +
+                "   :itemCount, \n" +
                 "   :segmentId, \n" +
                 "   :segmentKey, \n" +
                 "   :groupId, \n" +
@@ -57,7 +57,7 @@ public class FieldTestItemGroupCommandRepositoryImpl implements FieldTestItemGro
         fieldTestItemGroups.forEach(fieldTestItemGroup -> {
             SqlParameterSource parameterSources = new MapSqlParameterSource("examId", getBytesFromUUID(fieldTestItemGroup.getExamId()))
                 .addValue("position", fieldTestItemGroup.getPosition())
-                .addValue("numItems", fieldTestItemGroup.getNumItems())
+                .addValue("itemCount", fieldTestItemGroup.getItemCount())
                 .addValue("segmentId", fieldTestItemGroup.getSegmentId())
                 .addValue("segmentKey", fieldTestItemGroup.getSegmentKey())
                 .addValue("groupId", fieldTestItemGroup.getGroupId())

--- a/service/src/main/java/tds/exam/repositories/impl/FieldTestItemGroupQueryRepositoryImpl.java
+++ b/service/src/main/java/tds/exam/repositories/impl/FieldTestItemGroupQueryRepositoryImpl.java
@@ -1,0 +1,86 @@
+package tds.exam.repositories.impl;
+
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.beans.factory.annotation.Qualifier;
+import org.springframework.jdbc.core.namedparam.MapSqlParameterSource;
+import org.springframework.jdbc.core.namedparam.NamedParameterJdbcTemplate;
+import org.springframework.jdbc.core.namedparam.SqlParameterSource;
+import org.springframework.stereotype.Repository;
+
+import java.util.List;
+import java.util.UUID;
+
+import tds.common.data.mapping.ResultSetMapperUtility;
+import tds.common.data.mysql.UuidAdapter;
+import tds.exam.models.FieldTestItemGroup;
+import tds.exam.repositories.FieldTestItemGroupQueryRepository;
+
+@Repository
+public class FieldTestItemGroupQueryRepositoryImpl implements FieldTestItemGroupQueryRepository {
+    private final NamedParameterJdbcTemplate jdbcTemplate;
+
+    @Autowired
+    public FieldTestItemGroupQueryRepositoryImpl(@Qualifier("queryJdbcTemplate") NamedParameterJdbcTemplate queryJdbcTemplate) {
+        this.jdbcTemplate = queryJdbcTemplate;
+    }
+
+    @Override
+    public List<FieldTestItemGroup> find(UUID examId, String segmentKey) {
+        final SqlParameterSource parameters = new MapSqlParameterSource("examId", UuidAdapter.getBytesFromUUID(examId))
+            .addValue("segmentKey", segmentKey);
+
+        final String SQL =
+            "SELECT \n" +
+                "   F.exam_id, \n" +
+                "   F.session_id, \n" +
+                "   F.segment_key, \n" +
+                "   F.segment_id, \n" +
+                "   F.position, \n" +
+                "   F.language_code, \n" +
+                "   F.num_items, \n" +
+                "   F.group_id, \n" +
+                "   F.group_key, \n" +
+                "   F.block_id, \n" +
+                "   F.created_at, \n" +
+                "   FE.position_administered, \n" +
+                "   FE.administered_at \n" +
+                "FROM \n" +
+                "   field_test_item_group F \n" +
+                "JOIN ( \n" +
+                "   SELECT \n" +
+                "       field_test_item_group_id, \n" +
+                "       MAX(id) AS id \n" +
+                "   FROM \n" +
+                "       field_test_item_group_event \n" +
+                "   GROUP BY field_test_item_group_id \n" +
+                ") last_event \n" +
+                "   ON F.id = last_event.field_test_item_group_id \n" +
+                "JOIN \n" +
+                "   field_test_item_group_event FE \n" +
+                "ON \n" +
+                "   last_event.id = FE.id \n" +
+                "WHERE \n" +
+                "   F.exam_id = :examId AND \n" +
+                "   F.segment_key = :segmentKey AND \n" +
+                "   FE.deleted_at IS NULL \n" +
+                "ORDER BY \n" +
+                "   F.position \n";
+
+        return jdbcTemplate.query(SQL, parameters, (rs, row) ->
+            new FieldTestItemGroup.Builder()
+                .withExamId(UuidAdapter.getUUIDFromBytes(rs.getBytes("exam_id")))
+                .withSessionId(UuidAdapter.getUUIDFromBytes(rs.getBytes("session_id")))
+                .withSegmentKey(rs.getString("segment_key"))
+                .withSegmentId(rs.getString("segment_id"))
+                .withPosition(rs.getInt("position"))
+                .withLanguageCode(rs.getString("language_code"))
+                .withNumItems(rs.getInt("num_items"))
+                .withGroupId(rs.getString("group_id"))
+                .withGroupKey(rs.getString("group_key"))
+                .withBlockId(rs.getString("block_id"))
+                .withCreatedAt(ResultSetMapperUtility.mapTimestampToInstant(rs, "created_at"))
+                .withPositionAdministered((Integer) rs.getObject("position_administered"))
+                .withAdministeredAt(ResultSetMapperUtility.mapTimestampToInstant(rs, "administered_at"))
+                .build());
+    }
+}

--- a/service/src/main/java/tds/exam/repositories/impl/FieldTestItemGroupQueryRepositoryImpl.java
+++ b/service/src/main/java/tds/exam/repositories/impl/FieldTestItemGroupQueryRepositoryImpl.java
@@ -37,7 +37,7 @@ public class FieldTestItemGroupQueryRepositoryImpl implements FieldTestItemGroup
                 "   F.segment_id, \n" +
                 "   F.position, \n" +
                 "   F.language_code, \n" +
-                "   F.num_items, \n" +
+                "   F.item_count, \n" +
                 "   F.group_id, \n" +
                 "   F.group_key, \n" +
                 "   F.block_id, \n" +
@@ -74,7 +74,7 @@ public class FieldTestItemGroupQueryRepositoryImpl implements FieldTestItemGroup
                 .withSegmentId(rs.getString("segment_id"))
                 .withPosition(rs.getInt("position"))
                 .withLanguageCode(rs.getString("language_code"))
-                .withNumItems(rs.getInt("num_items"))
+                .withItemCount(rs.getInt("item_count"))
                 .withGroupId(rs.getString("group_id"))
                 .withGroupKey(rs.getString("group_key"))
                 .withBlockId(rs.getString("block_id"))

--- a/service/src/main/java/tds/exam/services/FieldTestItemGroupSelector.java
+++ b/service/src/main/java/tds/exam/services/FieldTestItemGroupSelector.java
@@ -1,0 +1,26 @@
+package tds.exam.services;
+
+import java.util.List;
+import java.util.Set;
+
+import tds.assessment.Assessment;
+import tds.exam.Exam;
+import tds.exam.models.FieldTestItemGroup;
+
+/**
+ * An service for selecting field test item groups
+ */
+public interface FieldTestItemGroupSelector {
+    /**
+     * This method returns a list
+     *
+     * @param exam the {@link tds.exam.Exam} to select {@link tds.exam.models.FieldTestItemGroup}s for
+     * @param assignedGroupIds a {@link java.util.Set} of group ids that have already been assigned for this {@link tds.exam.Exam}.
+     * @param assessment the {@link tds.assessment.Assessment} to select {@link tds.exam.models.FieldTestItemGroup}s for
+     * @param segmentKey the key of the {@link tds.assessment.Segment} to select {@link tds.exam.models.FieldTestItemGroup}s for
+     * @param numItems the number of items to select
+     * @return
+     */
+    List<FieldTestItemGroup> selectItemGroupsLeastUsed(Exam exam, Set<String> assignedGroupIds,
+                                                       Assessment assessment, String segmentKey, int numItems);
+}

--- a/service/src/main/java/tds/exam/services/FieldTestItemGroupSelector.java
+++ b/service/src/main/java/tds/exam/services/FieldTestItemGroupSelector.java
@@ -14,12 +14,12 @@ public interface FieldTestItemGroupSelector {
     /**
      * This method returns a list
      *
-     * @param exam the {@link tds.exam.Exam} to select {@link tds.exam.models.FieldTestItemGroup}s for
+     * @param exam             the {@link tds.exam.Exam} to select {@link tds.exam.models.FieldTestItemGroup}s for
      * @param assignedGroupIds a {@link java.util.Set} of group ids that have already been assigned for this {@link tds.exam.Exam}.
-     * @param assessment the {@link tds.assessment.Assessment} to select {@link tds.exam.models.FieldTestItemGroup}s for
-     * @param segmentKey the key of the {@link tds.assessment.Segment} to select {@link tds.exam.models.FieldTestItemGroup}s for
-     * @param numItems the number of items to select
-     * @return
+     * @param assessment       the {@link tds.assessment.Assessment} to select {@link tds.exam.models.FieldTestItemGroup}s for
+     * @param segmentKey       the key of the {@link tds.assessment.Segment} to select {@link tds.exam.models.FieldTestItemGroup}s for
+     * @param numItems         the number of items to select
+     * @return the {@link java.util.List} of the selected {@link tds.exam.models.FieldTestItemGroup}s
      */
     List<FieldTestItemGroup> selectItemGroupsLeastUsed(Exam exam, Set<String> assignedGroupIds,
                                                        Assessment assessment, String segmentKey, int numItems);

--- a/service/src/main/java/tds/exam/services/FieldTestItemGroupSelector.java
+++ b/service/src/main/java/tds/exam/services/FieldTestItemGroupSelector.java
@@ -4,6 +4,7 @@ import java.util.List;
 import java.util.Set;
 
 import tds.assessment.Assessment;
+import tds.assessment.Segment;
 import tds.exam.Exam;
 import tds.exam.models.FieldTestItemGroup;
 
@@ -17,10 +18,10 @@ public interface FieldTestItemGroupSelector {
      * @param exam             the {@link tds.exam.Exam} to select {@link tds.exam.models.FieldTestItemGroup}s for
      * @param assignedGroupIds a {@link java.util.Set} of group ids that have already been assigned for this {@link tds.exam.Exam}.
      * @param assessment       the {@link tds.assessment.Assessment} to select {@link tds.exam.models.FieldTestItemGroup}s for
-     * @param segmentKey       the key of the {@link tds.assessment.Segment} to select {@link tds.exam.models.FieldTestItemGroup}s for
+     * @param currentSegment       the {@link tds.assessment.Segment} to select {@link tds.exam.models.FieldTestItemGroup}s for
      * @param numItems         the number of items to select
      * @return the {@link java.util.List} of the selected {@link tds.exam.models.FieldTestItemGroup}s
      */
-    List<FieldTestItemGroup> selectItemGroupsLeastUsed(Exam exam, Set<String> assignedGroupIds,
-                                                       Assessment assessment, String segmentKey, int numItems);
+    List<FieldTestItemGroup> selectLeastUsedItemGroups(Exam exam, Set<String> assignedGroupIds,
+                                                       Assessment assessment, Segment currentSegment, int numItems);
 }

--- a/service/src/main/java/tds/exam/services/FieldTestService.java
+++ b/service/src/main/java/tds/exam/services/FieldTestService.java
@@ -8,16 +8,24 @@ import tds.exam.Exam;
  */
 public interface FieldTestService {
     /**
-     *  This method checks whether the current segment contains field test items and is within a valid field test
-     *  window.
+     * This method checks whether the current segment contains field test items and is within a valid field test
+     * window.
      *
-     * @param exam          the current {@link tds.exam.Exam}
-     * @param assessment    the {@link tds.assessment.Assessment} for which to check eligibility for
-     * @param segmentKey    the key of the {@link tds.assessment.Segment} for which to check eligibility for
-     * @param languageCode  the code of the language for this {@link tds.exam.Exam}
-     * @return  true if the the exam segment is eligible for a field test, false otherwise
+     * @param exam       the current {@link tds.exam.Exam}
+     * @param assessment the {@link tds.assessment.Assessment} for which to check eligibility for
+     * @param segmentKey the key of the {@link tds.assessment.Segment} for which to check eligibility for
+     * @return true if the the exam segment is eligible for a field test, false otherwise
      */
-    boolean isFieldTestEligible(Exam exam, Assessment assessment, String segmentKey, String languageCode);
+    boolean isFieldTestEligible(Exam exam, Assessment assessment, String segmentKey);
 
-    int selectItemGroups(Exam exam, Assessment assessment, String segmentKey, String languageCode);
+    /**
+     * This method selects {@link tds.exam.models.FieldTestItemGroup}s for the exam based on the {@link tds.assessment.Assessment}s
+     * field test requirements.
+     *
+     * @param exam       the current {@link tds.exam.Exam}
+     * @param assessment the {@link tds.assessment.Assessment} of the {@link tds.exam.Exam}
+     * @param segmentKey the key of the {@link tds.assessment.Segment} to select {@link tds.exam.models.FieldTestItemGroup}s
+     * @return The total number of field test items for this {@link tds.assessment.Segment}
+     */
+    int selectItemGroups(Exam exam, Assessment assessment, String segmentKey);
 }

--- a/service/src/main/java/tds/exam/services/ItemPoolService.java
+++ b/service/src/main/java/tds/exam/services/ItemPoolService.java
@@ -29,8 +29,7 @@ public interface ItemPoolService {
      * @param examId          the id of the {@link tds.exam.Exam}
      * @param itemConstraints the {@link tds.assessment.ItemConstraint}s for the assessment
      * @param items           the collection of all possible {@link tds.assessment.Item}s in a {@link tds.assessment.Segment}
-     * @param isFieldTest     filter by field test items
      * @return returns a filtered list of {@link tds.assessment.Item}s eligible for the segment pool
      */
-    Set<Item> getItemPool(UUID examId, List<ItemConstraint> itemConstraints, List<Item> items, Boolean isFieldTest);
+    Set<Item> getFieldTestItemPool(UUID examId, List<ItemConstraint> itemConstraints, List<Item> items);
 }

--- a/service/src/main/java/tds/exam/services/impl/EqualDistributionFieldTestItemGroupSelector.java
+++ b/service/src/main/java/tds/exam/services/impl/EqualDistributionFieldTestItemGroupSelector.java
@@ -1,0 +1,146 @@
+package tds.exam.services.impl;
+
+import com.google.common.cache.Cache;
+import com.google.common.cache.CacheBuilder;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.stereotype.Component;
+
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicInteger;
+import java.util.stream.Collectors;
+
+import tds.assessment.Assessment;
+import tds.assessment.Item;
+import tds.assessment.Segment;
+import tds.exam.Exam;
+import tds.exam.models.FieldTestItemGroup;
+import tds.exam.services.FieldTestItemGroupSelector;
+import tds.exam.services.ItemPoolService;
+
+@Component
+public class EqualDistributionFieldTestItemGroupSelector implements FieldTestItemGroupSelector {
+    private final ItemPoolService itemPoolService;
+    // Keeps track of the field test item groups and their usages
+    private Cache<String, List<FieldTestItemGroupCounter>> fieldTestItemGroupCounterCache;
+
+    @Autowired
+    public EqualDistributionFieldTestItemGroupSelector(ItemPoolService itemPoolService) {
+        this.itemPoolService = itemPoolService;
+
+        fieldTestItemGroupCounterCache = CacheBuilder.newBuilder()
+            .expireAfterAccess(1, TimeUnit.DAYS)
+            .build();
+    }
+
+    @Override
+    public List<FieldTestItemGroup> selectItemGroupsLeastUsed(Exam exam, Set<String> assignedGroupIds, Assessment assessment, String segmentKey, int numItems) {
+        int ftItemCount = 0;
+        Segment currentSegment = assessment.getSegment(segmentKey);
+        // Fetch every eligible item based on item constraints, item properties, and user accommodations
+        Set<Item> fieldTestItems = itemPoolService.getItemPool(exam.getId(), assessment.getItemConstraints(), currentSegment.getItems(exam.getLanguageCode()), true);
+        /* In StudentDLL.FT_Prioritize2012_SP() [3544] - The legacy code creates temporary tables and groups data by groupid, blockid, groupkey.
+            We can just worry about grouping by groupkey since groupKey appears to be the same as "<group-id>_<block-id>".
+
+            The deletion at line [3186] simply removes item groups already found to be assigned to a student
+                - the filter below will take care of this.
+         */
+        Map<String, List<FieldTestItemGroup>> fieldTestItemGroupsMap = fieldTestItems.stream()
+            .filter(fieldTestItem -> !assignedGroupIds.contains(fieldTestItem.getGroupId()))    // Filter all previously assigned item groups
+            .map(fieldTestItem -> new FieldTestItemGroup.Builder()
+                .withExamId(exam.getId())
+                .withGroupId(fieldTestItem.getGroupId())
+                .withGroupKey(fieldTestItem.getGroupKey())
+                .withBlockId(fieldTestItem.getBlockId())
+                .build())
+            .collect(Collectors.groupingBy(FieldTestItemGroup::getGroupKey));
+
+        // If the cache does not contain any group key counters for this segment, add all of the groups this
+        // student is eligible for
+        if (!fieldTestItemGroupCounterCache.asMap().containsKey(segmentKey)) {
+            List<FieldTestItemGroupCounter> initGroupCounters = fieldTestItemGroupsMap.keySet().stream()
+                .map(groupKey -> new FieldTestItemGroupCounter(groupKey))
+                .collect(Collectors.toList());
+
+            fieldTestItemGroupCounterCache.put(segmentKey, Collections.synchronizedList(initGroupCounters));
+        }
+
+        List<FieldTestItemGroup> itemGroupsWithItemCounts = new ArrayList<>();
+        // Get the list (sorted by number of group key occurrences) and starting at the top, add as many as we need to the list
+        List<FieldTestItemGroupCounter> fieldTestItemGroupCounters = fieldTestItemGroupCounterCache.getIfPresent(segmentKey);
+        for (FieldTestItemGroupCounter groupCounter : fieldTestItemGroupCounters) {
+            // Break out of this loop if we've selected the # of items we needed to select
+            if (ftItemCount >= numItems) {
+                break;
+            }
+
+            // Check that the groupKey is one of the ones this examinee is eligible for
+            if (fieldTestItemGroupsMap.containsKey(groupCounter.getGroupKey())) {
+                List<FieldTestItemGroup> items = fieldTestItemGroupsMap.get(groupCounter.getGroupKey());
+                // Since we are only concerned with data shared between all the items in the group, we can just pick the first
+                FieldTestItemGroup firstItemGroup = items.get(0);
+
+                itemGroupsWithItemCounts.add(new FieldTestItemGroup.Builder()
+                    .fromFieldTestItemGroup(firstItemGroup)
+                    .withNumItems(items.size())
+                    .build());
+
+                // Update the occurrence counter and the field test item count
+                groupCounter.incrementOccurrance();
+                ftItemCount += items.size();
+                // Remove group from the map so we can keep track of any field test item groups that might need to be added to the cache
+                fieldTestItemGroupsMap.remove(groupCounter.getGroupKey());
+            }
+        }
+
+        // Check if there are any groups that may need to be added to cache (initialized)
+        if (!fieldTestItemGroupsMap.isEmpty()) {
+            cacheInitializedCounters(segmentKey, fieldTestItemGroupsMap);
+        }
+
+        Collections.sort(fieldTestItemGroupCounters);
+
+        return itemGroupsWithItemCounts;
+    }
+
+    private void cacheInitializedCounters(String segmentKey, Map<String, List<FieldTestItemGroup>> fieldTestItemGroupsMap) {
+        // We may need to initialize these group key counters and cache if they are not already cached
+        List<FieldTestItemGroupCounter> groupCounters = fieldTestItemGroupCounterCache.getIfPresent(segmentKey);
+        Set<String> cachedGroupKeys = groupCounters.stream()
+            .map(counter -> counter.getGroupKey())
+            .collect(Collectors.toSet());
+
+        for (String groupKey : fieldTestItemGroupsMap.keySet()) {
+            if (!cachedGroupKeys.contains(groupKey)) {
+                groupCounters.add(new FieldTestItemGroupCounter(groupKey));
+            }
+        }
+    }
+
+    private class FieldTestItemGroupCounter implements Comparable<FieldTestItemGroupCounter> {
+        private String groupKey;
+        AtomicInteger occurrences;
+
+        public FieldTestItemGroupCounter(String groupKey) {
+            this.groupKey = groupKey;
+            occurrences = new AtomicInteger(0);
+        }
+
+        public void incrementOccurrance() {
+            occurrences.incrementAndGet();
+        }
+
+        public String getGroupKey() {
+            return this.groupKey;
+        }
+
+        @Override
+        public int compareTo(FieldTestItemGroupCounter other) {
+            return occurrences.get() - other.occurrences.get();
+        }
+    }
+}

--- a/service/src/main/java/tds/exam/services/impl/EqualDistributionFieldTestItemGroupSelector.java
+++ b/service/src/main/java/tds/exam/services/impl/EqualDistributionFieldTestItemGroupSelector.java
@@ -38,7 +38,8 @@ public class EqualDistributionFieldTestItemGroupSelector implements FieldTestIte
     }
 
     @Override
-    public List<FieldTestItemGroup> selectItemGroupsLeastUsed(Exam exam, Set<String> assignedGroupIds, Assessment assessment, String segmentKey, int numItems) {
+    public List<FieldTestItemGroup> selectItemGroupsLeastUsed(final Exam exam, final Set<String> assignedGroupIds,
+                                                              final Assessment assessment, final String segmentKey, final int numItems) {
         int ftItemCount = 0;
         Segment currentSegment = assessment.getSegment(segmentKey);
         // Fetch every eligible item based on item constraints, item properties, and user accommodations

--- a/service/src/main/java/tds/exam/services/impl/ExamSegmentServiceImpl.java
+++ b/service/src/main/java/tds/exam/services/impl/ExamSegmentServiceImpl.java
@@ -108,9 +108,9 @@ public class ExamSegmentServiceImpl implements ExamSegmentService {
                 poolCount = segmentPoolInfo.getPoolCount(); // poolCount does not always == itemPool.size
 
                 /*  [4703] In legacy, opitemcnt = segment's max items. See lines [4624], [4630], [4672] */
-                if (fieldTestService.isFieldTestEligible(exam, assessment, segment.getKey(), exam.getLanguageCode())
+                if (fieldTestService.isFieldTestEligible(exam, assessment, segment.getKey())
                     && segmentPoolInfo.getLength() == segment.getMaxItems()) {
-                    fieldTestItemCount = fieldTestService.selectItemGroups(exam, assessment, segment.getKey(), exam.getLanguageCode());
+                    fieldTestItemCount = fieldTestService.selectItemGroups(exam, assessment, segment.getKey());
                 }
 
                 isSatisfied = fieldTestItemCount + segmentPoolInfo.getLength() == 0;

--- a/service/src/main/java/tds/exam/services/impl/FieldTestServiceImpl.java
+++ b/service/src/main/java/tds/exam/services/impl/FieldTestServiceImpl.java
@@ -80,7 +80,7 @@ public class FieldTestServiceImpl implements FieldTestService {
         This code covers legacy StudentDLL._FT_SelectItemgroups_SP [line 3033] and is called by _InitializeTestSegments_SP [4704]
      */
     @Override
-    public int selectItemGroups(Exam exam, Assessment assessment, String segmentKey) {
+    public int selectItemGroups(final Exam exam, final Assessment assessment, final String segmentKey) {
         Segment currentSegment = assessment.getSegment(segmentKey);
         List<FieldTestItemGroup> previouslyAssignedFieldTestItemGroups = fieldTestItemGroupQueryRepository.find(exam.getId(), segmentKey);
 

--- a/service/src/main/java/tds/exam/services/impl/FieldTestServiceImpl.java
+++ b/service/src/main/java/tds/exam/services/impl/FieldTestServiceImpl.java
@@ -1,20 +1,14 @@
 package tds.exam.services.impl;
 
-import com.google.common.cache.Cache;
-import com.google.common.cache.CacheBuilder;
 import org.joda.time.Instant;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Service;
 
 import java.util.ArrayList;
-import java.util.Collections;
 import java.util.List;
-import java.util.Map;
 import java.util.Optional;
 import java.util.Random;
 import java.util.Set;
-import java.util.concurrent.TimeUnit;
-import java.util.concurrent.atomic.AtomicInteger;
 import java.util.stream.Collectors;
 
 import tds.assessment.Assessment;
@@ -24,10 +18,8 @@ import tds.exam.Exam;
 import tds.exam.models.FieldTestItemGroup;
 import tds.exam.repositories.FieldTestItemGroupCommandRepository;
 import tds.exam.repositories.FieldTestItemGroupQueryRepository;
-import tds.exam.services.AssessmentService;
 import tds.exam.services.FieldTestItemGroupSelector;
 import tds.exam.services.FieldTestService;
-import tds.exam.services.ItemPoolService;
 import tds.session.ExternalSessionConfiguration;
 
 @Service
@@ -44,6 +36,7 @@ public class FieldTestServiceImpl implements FieldTestService {
         this.fieldTestItemGroupCommandRepository = fieldTestItemGroupCommandRepository;
         this.fieldTestItemGroupSelector = fieldTestItemGroupSelector;
     }
+
 
     @Override
     public boolean isFieldTestEligible(Exam exam, Assessment assessment, String segmentKey) {
@@ -121,7 +114,7 @@ public class FieldTestServiceImpl implements FieldTestService {
         List<FieldTestItemGroup> selectedFieldTestItemGroups = fieldTestItemGroupSelector.selectItemGroupsLeastUsed(exam, assignedGroupIds, assessment,
             segmentKey, minItems);
 
-        /* [3240-3242] endPos variable is never used - only read from in debug mode */
+        /* [3240-3242] endPos variable is never used again, no need to increment it - only read from in debug mode */
         /* [3244] no need to select an unused groupkey - we know our FieldTestGroupItems have unique groupkeys. */
         /* [3244-3246] Since we have list of unused items returned by selectItemgroupsRoundRobin(), no need to check that groupkey exists */
         List<FieldTestItemGroup> selectedItemGroups = new ArrayList<>();
@@ -188,5 +181,4 @@ public class FieldTestServiceImpl implements FieldTestService {
 
         return endTime == null ? true : endTime.isAfterNow();
     }
-
 }

--- a/service/src/main/java/tds/exam/services/impl/FieldTestServiceImpl.java
+++ b/service/src/main/java/tds/exam/services/impl/FieldTestServiceImpl.java
@@ -1,22 +1,52 @@
 package tds.exam.services.impl;
 
+import com.google.common.cache.Cache;
+import com.google.common.cache.CacheBuilder;
 import org.joda.time.Instant;
+import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Service;
 
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+import java.util.Map;
 import java.util.Optional;
+import java.util.Random;
+import java.util.Set;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicInteger;
+import java.util.stream.Collectors;
 
 import tds.assessment.Assessment;
 import tds.assessment.Item;
 import tds.assessment.Segment;
 import tds.exam.Exam;
+import tds.exam.models.FieldTestItemGroup;
+import tds.exam.repositories.FieldTestItemGroupCommandRepository;
+import tds.exam.repositories.FieldTestItemGroupQueryRepository;
+import tds.exam.services.AssessmentService;
+import tds.exam.services.FieldTestItemGroupSelector;
 import tds.exam.services.FieldTestService;
+import tds.exam.services.ItemPoolService;
 import tds.session.ExternalSessionConfiguration;
 
 @Service
 public class FieldTestServiceImpl implements FieldTestService {
+    private final FieldTestItemGroupQueryRepository fieldTestItemGroupQueryRepository;
+    private final FieldTestItemGroupCommandRepository fieldTestItemGroupCommandRepository;
+    private final FieldTestItemGroupSelector fieldTestItemGroupSelector;
+
+    @Autowired
+    public FieldTestServiceImpl(FieldTestItemGroupQueryRepository fieldTestItemGroupQueryRepository,
+                                FieldTestItemGroupCommandRepository fieldTestItemGroupCommandRepository,
+                                FieldTestItemGroupSelector fieldTestItemGroupSelector) {
+        this.fieldTestItemGroupQueryRepository = fieldTestItemGroupQueryRepository;
+        this.fieldTestItemGroupCommandRepository = fieldTestItemGroupCommandRepository;
+        this.fieldTestItemGroupSelector = fieldTestItemGroupSelector;
+    }
 
     @Override
-    public boolean isFieldTestEligible(Exam exam, Assessment assessment, String segmentKey, String languageCode) {
+    public boolean isFieldTestEligible(Exam exam, Assessment assessment, String segmentKey) {
         boolean isEligible = false;
         Segment currentSegment = assessment.getSegment(segmentKey);
 
@@ -24,7 +54,7 @@ public class FieldTestServiceImpl implements FieldTestService {
         if (currentSegment.getFieldTestMinItems() > 0) {
             // Check if there exists at least one field test item in the segment with the selected language
             /* StudentDLL [4430] */
-            Optional<Item> fieldTestItem = currentSegment.getItems(languageCode).stream()
+            Optional<Item> fieldTestItem = currentSegment.getItems(exam.getLanguageCode()).stream()
                 .filter(item -> item.isFieldTest())
                 .findFirst();
 
@@ -57,9 +87,95 @@ public class FieldTestServiceImpl implements FieldTestService {
         This code covers legacy StudentDLL._FT_SelectItemgroups_SP [line 3033] and is called by _InitializeTestSegments_SP [4704]
      */
     @Override
-    public int selectItemGroups(Exam exam, Assessment assessment, String segmentKey, String language) {
-        //TODO: Implement. Adding stub to prevent compilation errors
-        return 0;
+    public int selectItemGroups(Exam exam, Assessment assessment, String segmentKey) {
+        Segment currentSegment = assessment.getSegment(segmentKey);
+        List<FieldTestItemGroup> previouslyAssignedFieldTestItemGroups = fieldTestItemGroupQueryRepository.find(exam.getId(), segmentKey);
+
+        /* StudentDLL [3119-3126] ftcount is just fieldTestItemGroups.size()
+           [3126] - Skip, debug is always = 0                                       */
+        Integer startPosition = currentSegment.getFieldTestStartPosition();
+        Integer endPosition = currentSegment.getFieldTestEndPosition();
+        int maxItems = currentSegment.getFieldTestMaxItems();
+        int minItems = currentSegment.getFieldTestMinItems();
+        int ftItemCount = previouslyAssignedFieldTestItemGroups.size(); // Initialize it as the size of the existing item groups assigned to this student
+
+        if (startPosition == null || endPosition == null) {
+            throw new IllegalStateException("Field test start and end positions are not defined in the itembank database.");
+        } else if (endPosition - startPosition < maxItems) {
+            /* In the legacy app, this condition would result in a divide-by-zero error. */
+            throw new IllegalStateException(String.format("The maximum number of field test items (%s) cannot be greater than the difference " +
+                "between the ending and starting field test positions. (%s - %s)", maxItems, endPosition, startPosition));
+        }
+
+        /* [3131-3137] Note tht if endPos - startPos < numIntervals, the integer division below results in 0, which
+        *  results in  a division-by-zero at line [3320] */
+        int numIntervals = maxItems;
+        int intervalSize = (endPosition - startPosition) / numIntervals;
+        int intervalIndex = startPosition; // keeps track of position in exam to administer ft item
+
+        /* [3212- 3224] Skip Cohort code - the loader script hardcodes "ratio" and "cohortIndex" as 1, targetcount = ftMaxItems */
+        // Used to keep track of all the group ids that have already been assigned.
+        Set<String> assignedGroupIds = previouslyAssignedFieldTestItemGroups.stream()
+            .map(fieldTestItemGroup -> fieldTestItemGroup.getGroupId())
+            .collect(Collectors.toSet());
+        List<FieldTestItemGroup> selectedFieldTestItemGroups = fieldTestItemGroupSelector.selectItemGroupsLeastUsed(exam, assignedGroupIds, assessment,
+            segmentKey, minItems);
+
+        /* [3240-3242] endPos variable is never used - only read from in debug mode */
+        /* [3244] no need to select an unused groupkey - we know our FieldTestGroupItems have unique groupkeys. */
+        /* [3244-3246] Since we have list of unused items returned by selectItemgroupsRoundRobin(), no need to check that groupkey exists */
+        List<FieldTestItemGroup> selectedItemGroups = new ArrayList<>();
+
+        /* This loop begins at [3246] */
+        for (FieldTestItemGroup fieldTestItemGroup : selectedFieldTestItemGroups) {
+            /* Skip [3248-3274] - This code is just selecting a single item group that is unassigned and not frequently used
+              (as sorted by FT_Prioritize_2012())
+              Skip [3276-3285] - debug code */
+            int numItems = fieldTestItemGroup.getNumItems();
+            /* [3307] */
+            if (numItems > 0 && ftItemCount + numItems <= maxItems) {
+                /* [3308 - 3314] */
+                int thisIntSize = (intervalSize < 0 || numItems == 1) ?
+                    1 : intervalSize * (numItems - 1);
+
+                /* [3318] Randomly select an item position for this ft item group */
+                Random rng = new Random();
+                int nextPosition = (rng.nextInt(1000) % thisIntSize) + intervalIndex;
+
+                /* [3339] Mark item group as "used" */
+                assignedGroupIds.add(fieldTestItemGroup.getGroupId());
+                /* [3344] */
+                ftItemCount += numItems;
+
+                /* [3345-3349] */
+                intervalIndex = (intervalSize == 0)
+                    ? intervalIndex + numItems
+                    : intervalIndex + numItems * intervalSize;
+
+                /* Ignore cohort code [3357] */
+                /* Ignore delete on [3362] - Only selected items will be returned from this loop */
+                /* Note that we are not persisting the intervalSize/Start/number of intervals - these values are never read from again
+                   anywhere in the application and are simply saved for debug and testing purposes. */
+                selectedItemGroups.add(
+                    new FieldTestItemGroup.Builder()
+                        .fromFieldTestItemGroup(fieldTestItemGroup)
+                        .withExamId(exam.getId())
+                        .withSessionId(exam.getSessionId())
+                        .withLanguageCode(exam.getLanguageCode())
+                        .withPosition(nextPosition)
+                        .withNumItems(numItems)
+                        .withSegmentKey(segmentKey)
+                        .withSegmentId(currentSegment.getSegmentId())
+                        .build()
+                );
+            }
+        }
+
+        /* This insert is at [3378] */
+        fieldTestItemGroupCommandRepository.insert(selectedItemGroups);
+
+        /* [3386] No need to get the count of field test items again - this count is maintained in loop above */
+        return ftItemCount;
     }
 
     /*
@@ -72,4 +188,5 @@ public class FieldTestServiceImpl implements FieldTestService {
 
         return endTime == null ? true : endTime.isAfterNow();
     }
+
 }

--- a/service/src/main/java/tds/exam/services/impl/ItemPoolServiceImpl.java
+++ b/service/src/main/java/tds/exam/services/impl/ItemPoolServiceImpl.java
@@ -30,7 +30,11 @@ public class ItemPoolServiceImpl implements ItemPoolService {
     }
 
     @Override
-    public Set<Item> getItemPool(final UUID examId, final List<ItemConstraint> itemConstraints, final List<Item> items, Boolean isFieldTest) {
+    public Set<Item> getFieldTestItemPool(UUID examId, List<ItemConstraint> itemConstraints, List<Item> items) {
+        return getItemPool(examId, itemConstraints, items, true);
+    }
+
+    private Set<Item> getItemPool(final UUID examId, final List<ItemConstraint> itemConstraints, final List<Item> items, Boolean isFieldTest) {
         /*
             This method is meant to replace StudentDLL._AA_ItempoolString_FNOptimized() [1643]
             The purpose of this method is to find the list of items to include in the segment by taking the following steps:

--- a/service/src/main/resources/db/migration/V1483732508__exam_create_table_field_test_item_group.sql
+++ b/service/src/main/resources/db/migration/V1483732508__exam_create_table_field_test_item_group.sql
@@ -1,0 +1,43 @@
+/***********************************************************************************************************************
+  File: V1483732508__exam_create_table_field_test_item_group.sql
+
+  Desc: Creates the field_test_item_group table
+
+***********************************************************************************************************************/
+
+USE exam;
+
+DROP TABLE  IF EXISTS field_test_item_group_event;
+DROP TABLE IF EXISTS field_test_item_group;
+
+CREATE TABLE field_test_item_group (
+  id BIGINT NOT NULL AUTO_INCREMENT,
+  exam_id VARBINARY(16) NOT NULL,
+  position INT(11) NOT NULL,
+  num_items INT(11) DEFAULT NULL,
+  segment_id VARCHAR(100) NOT NULL,
+  segment_key VARCHAR(200) NOT NULL,
+  group_id VARCHAR(50) NOT NULL,
+  group_key VARCHAR(60) NOT NULL,
+  block_id VARCHAR(10) NOT NULL,
+  session_id VARBINARY(16) NOT NULL,
+  language_code VARCHAR(50) NOT NULL,
+  created_at TIMESTAMP(3) DEFAULT CURRENT_TIMESTAMP(3) NOT NULL,
+  INDEX ix_created_at (created_at),
+  PRIMARY KEY (id),
+  KEY ix_ftitem_cluster (exam_id, group_id),
+  KEY ix_ftexamitemgroup_pk (segment_key, language_code, group_key),
+  CONSTRAINT fk_field_test_item_group_exam_id_exam FOREIGN KEY (exam_id) REFERENCES exam (id) ON DELETE CASCADE ON UPDATE NO ACTION
+);
+
+CREATE TABLE field_test_item_group_event (
+  id BIGINT NOT NULL AUTO_INCREMENT,
+  field_test_item_group_id BIGINT(20) NOT NULL,
+  deleted_at DATETIME(3) DEFAULT NULL,
+  position_administered INT(11) DEFAULT NULL,
+  administered_at DATETIME(3) DEFAULT NULL,
+  created_at TIMESTAMP(3) DEFAULT CURRENT_TIMESTAMP(3) NOT NULL,
+  PRIMARY KEY(id),
+  INDEX ix_created_at (created_at),
+  FOREIGN KEY (field_test_item_group_id) REFERENCES field_test_item_group(id)
+);

--- a/service/src/main/resources/db/migration/V1483732508__exam_create_table_field_test_item_group.sql
+++ b/service/src/main/resources/db/migration/V1483732508__exam_create_table_field_test_item_group.sql
@@ -3,6 +3,8 @@
 
   Desc: Creates the field_test_item_group table
 
+  The purpose of this table is to store field test item groups assigned to exam segments.
+
 ***********************************************************************************************************************/
 
 USE exam;
@@ -14,7 +16,7 @@ CREATE TABLE field_test_item_group (
   id BIGINT NOT NULL AUTO_INCREMENT,
   exam_id VARBINARY(16) NOT NULL,
   position INT(11) NOT NULL,
-  num_items INT(11) DEFAULT NULL,
+  item_count INT(11) DEFAULT NULL,
   segment_id VARCHAR(100) NOT NULL,
   segment_key VARCHAR(200) NOT NULL,
   group_id VARCHAR(50) NOT NULL,

--- a/service/src/test/java/tds/exam/builder/AssessmentBuilder.java
+++ b/service/src/test/java/tds/exam/builder/AssessmentBuilder.java
@@ -2,11 +2,13 @@ package tds.exam.builder;
 
 import org.joda.time.Instant;
 
+import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
 
 import tds.assessment.Algorithm;
 import tds.assessment.Assessment;
+import tds.assessment.ItemConstraint;
 import tds.assessment.Segment;
 
 public class AssessmentBuilder {
@@ -17,6 +19,7 @@ public class AssessmentBuilder {
     private int prefetch = 2;
     private String subject = "ENGLISH";
     private List<Segment> segments;
+    private List<ItemConstraint> itemConstraints = new ArrayList<>();
     private boolean initialAbilityBySubject;
     private float abilitySlope;
     private float abilityIntercept;
@@ -42,6 +45,7 @@ public class AssessmentBuilder {
         assessment.setInitialAbilityBySubject(initialAbilityBySubject);
         assessment.setSubject(subject);
         assessment.setAccommodationFamily(accommodationFamily);
+        assessment.setItemConstraints(itemConstraints);
         return assessment;
     }
 

--- a/service/src/test/java/tds/exam/builder/FieldTestItemGroupBuilder.java
+++ b/service/src/test/java/tds/exam/builder/FieldTestItemGroupBuilder.java
@@ -1,0 +1,52 @@
+package tds.exam.builder;
+
+
+import java.util.UUID;
+
+import tds.exam.models.FieldTestItemGroup;
+
+public class FieldTestItemGroupBuilder {
+    private String groupKey = "group-key";
+    private String groupId = "group-id";
+    private String blockId = "A";
+    private String languageCode = "ENU";
+    private UUID examId = UUID.randomUUID();
+    private int numItems = 1;
+    private String segmentKey = "segment-key";
+
+    public FieldTestItemGroupBuilder(String groupKey) {
+        this.groupKey = groupKey;
+    }
+
+    public FieldTestItemGroup build() {
+        return new FieldTestItemGroup.Builder()
+            .withGroupKey(groupKey)
+            .withGroupId(groupId)
+            .withBlockId(blockId)
+            .withExamId(examId)
+            .withLanguageCode(languageCode)
+            .withNumItems(numItems)
+            .withSegmentKey(segmentKey)
+            .build();
+    }
+
+    public FieldTestItemGroupBuilder withExamId(UUID examId) {
+        this.examId = examId;
+        return this;
+    }
+
+    public FieldTestItemGroupBuilder withGroupId(String groupId) {
+        this.groupId = groupId;
+        return this;
+    }
+
+    public FieldTestItemGroupBuilder withNumItems(int numItems) {
+        this.numItems = numItems;
+        return this;
+    }
+
+    public FieldTestItemGroupBuilder withSegmentKey(String segmentKey) {
+        this.segmentKey = segmentKey;
+        return this;
+    }
+}

--- a/service/src/test/java/tds/exam/builder/FieldTestItemGroupBuilder.java
+++ b/service/src/test/java/tds/exam/builder/FieldTestItemGroupBuilder.java
@@ -25,7 +25,7 @@ public class FieldTestItemGroupBuilder {
             .withBlockId(blockId)
             .withExamId(examId)
             .withLanguageCode(languageCode)
-            .withNumItems(numItems)
+            .withItemCount(numItems)
             .withSegmentKey(segmentKey)
             .build();
     }

--- a/service/src/test/java/tds/exam/builder/ItemBuilder.java
+++ b/service/src/test/java/tds/exam/builder/ItemBuilder.java
@@ -1,0 +1,70 @@
+package tds.exam.builder;
+
+import java.util.ArrayList;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Set;
+
+import tds.assessment.Item;
+import tds.assessment.ItemProperty;
+
+public class ItemBuilder {
+    private String id = "item-id";
+    private String groupKey = "group-key";
+    private String groupId = "group-id";
+    private String strand = "strand";
+    private String blockId = "A";
+    private String itemType = "MI";
+    private boolean fieldTest = false;
+    private boolean required = true;
+    private List<ItemProperty> itemProperties = new ArrayList<>();
+    private Set<String> formKeys = new HashSet<>();
+
+    public ItemBuilder(String id) {
+        this.id = id;
+    }
+
+    public Item build() {
+        Item item = new Item(id);
+        item.setGroupKey(groupKey);
+        item.setGroupId(groupId);
+        item.setStrand(strand);
+        item.setBlockId(blockId);
+        item.setFieldTest(fieldTest);
+        item.setItemType(itemType);
+        item.setFormKeys(formKeys);
+        item.setRequired(required);
+        item.setItemProperties(itemProperties);
+        return item;
+    }
+
+    public ItemBuilder withGroupKey(String groupKey) {
+        this.groupKey = groupKey;
+        return this;
+    }
+
+    public ItemBuilder withGroupId(String groupId) {
+        this.groupId = groupId;
+        return this;
+    }
+
+    public ItemBuilder withBlockId(String blockId) {
+        this.blockId = blockId;
+        return this;
+    }
+
+    public ItemBuilder withStrand(String strand) {
+        this.strand = strand;
+        return this;
+    }
+
+    public ItemBuilder withFieldTest(boolean fieldTest) {
+        this.fieldTest = fieldTest;
+        return this;
+    }
+
+    public ItemBuilder withItemProperties(List<ItemProperty> itemProperties) {
+        this.itemProperties = itemProperties;
+        return this;
+    }
+}

--- a/service/src/test/java/tds/exam/builder/SegmentBuilder.java
+++ b/service/src/test/java/tds/exam/builder/SegmentBuilder.java
@@ -17,6 +17,10 @@ public class SegmentBuilder {
     private int maxItems = 10;
     private int position;
     private List<Form> forms = new ArrayList<>();
+    private Integer fieldTestStartPosition = 3;
+    private Integer fieldTestEndPosition = 10;
+    private int fieldTestMaxItems = 4;
+    private int fieldTestMinItems = 2;
 
     public Segment build() {
         Segment segment = new Segment(key, selectionAlgorithm);
@@ -27,6 +31,10 @@ public class SegmentBuilder {
         segment.setMaxItems(maxItems);
         segment.setPosition(position);
         segment.setForms(forms);
+        segment.setFieldTestMaxItems(fieldTestMaxItems);
+        segment.setFieldTestMinItems(fieldTestMinItems);
+        segment.setFieldTestEndPosition(fieldTestEndPosition);
+        segment.setFieldTestStartPosition(fieldTestStartPosition);
         return segment;
     }
 
@@ -72,6 +80,26 @@ public class SegmentBuilder {
 
     public SegmentBuilder withForms(List<Form> forms) {
         this.forms = forms;
+        return this;
+    }
+
+    public SegmentBuilder withFieldTestStartPosition(Integer startPosition) {
+        this.fieldTestStartPosition = startPosition;
+        return this;
+    }
+
+    public SegmentBuilder withFieldTestEndPosition(Integer endPosition) {
+        this.fieldTestEndPosition = endPosition;
+        return this;
+    }
+
+    public SegmentBuilder withFieldTestMaxItems(int maxItems) {
+        this.fieldTestMaxItems = maxItems;
+        return this;
+    }
+
+    public SegmentBuilder withFieldTestMinItems(int minItems) {
+        this.fieldTestMinItems = minItems;
         return this;
     }
 }

--- a/service/src/test/java/tds/exam/repositories/impl/FieldTestItemGroupRepositoryIntegrationTests.java
+++ b/service/src/test/java/tds/exam/repositories/impl/FieldTestItemGroupRepositoryIntegrationTests.java
@@ -1,0 +1,109 @@
+package tds.exam.repositories.impl;
+
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.beans.factory.annotation.Qualifier;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.jdbc.core.namedparam.NamedParameterJdbcTemplate;
+import org.springframework.test.context.junit4.SpringJUnit4ClassRunner;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.time.Instant;
+import java.util.Arrays;
+import java.util.List;
+import java.util.UUID;
+
+import tds.exam.Exam;
+import tds.exam.builder.ExamBuilder;
+import tds.exam.models.FieldTestItemGroup;
+import tds.exam.repositories.ExamCommandRepository;
+import tds.exam.repositories.FieldTestItemGroupCommandRepository;
+import tds.exam.repositories.FieldTestItemGroupQueryRepository;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+@RunWith(SpringJUnit4ClassRunner.class)
+@SpringBootTest
+@Transactional
+public class FieldTestItemGroupRepositoryIntegrationTests {
+    @Autowired
+    @Qualifier("commandJdbcTemplate")
+    private NamedParameterJdbcTemplate commandJdbcTemplate;
+    private FieldTestItemGroupQueryRepository fieldTestItemGroupQueryRepository;
+    private FieldTestItemGroupCommandRepository fieldTestItemGroupCommandRepository;
+    private ExamCommandRepository examCommandRepository;
+
+    @Before
+    public void setUp() {
+        fieldTestItemGroupCommandRepository = new FieldTestItemGroupCommandRepositoryImpl(commandJdbcTemplate);
+        fieldTestItemGroupQueryRepository = new FieldTestItemGroupQueryRepositoryImpl(commandJdbcTemplate);
+        examCommandRepository = new ExamCommandRepositoryImpl(commandJdbcTemplate);
+    }
+
+    @Test
+    public void shouldReturnListOfNonDeletedRecords() {
+        final Exam exam = new ExamBuilder().build();
+        examCommandRepository.insert(exam);
+        final UUID sessionId = UUID.randomUUID();
+        final String segmentKey = "segkey";
+
+        FieldTestItemGroup group1 = new FieldTestItemGroup.Builder()
+            .withExamId(exam.getId())
+            .withGroupId("groupid1")
+            .withGroupKey("groupkey1")
+            .withBlockId("A")
+            .withPositionAdministered(7)
+            .withLanguageCode("ENU")
+            .withPosition(2)
+            .withSegmentId("segid")
+            .withSegmentKey(segmentKey)
+            .withNumItems(1)
+            .withSessionId(sessionId)
+            .build();
+
+        FieldTestItemGroup group2 = new FieldTestItemGroup.Builder()
+            .withExamId(exam.getId())
+            .withGroupId("groupid2")
+            .withGroupKey("groupkey2")
+            .withBlockId("B")
+            .withLanguageCode("ENU")
+            .withPosition(3)
+            .withPositionAdministered(12)
+            .withSegmentId("segid")
+            .withSegmentKey(segmentKey)
+            .withNumItems(2)
+            .withSessionId(sessionId)
+            .build();
+
+        FieldTestItemGroup deletedGroup = new FieldTestItemGroup.Builder()
+            .withExamId(exam.getId())
+            .withGroupId("deleted-group-id")
+            .withGroupKey("deleted-group-key")
+            .withBlockId("C")
+            .withLanguageCode("ENU")
+            .withPosition(2)
+            .withSegmentId("segid")
+            .withSegmentKey(segmentKey)
+            .withNumItems(1)
+            .withSessionId(sessionId)
+            .withDeletedAt(Instant.now().minusMillis(100000))
+            .build();
+
+        fieldTestItemGroupCommandRepository.insert(Arrays.asList(group1, group2, deletedGroup));
+
+        List<FieldTestItemGroup> retFieldTestItemGroups = fieldTestItemGroupQueryRepository.find(exam.getId(), segmentKey);
+        assertThat(retFieldTestItemGroups).containsExactly(group1, group2);
+
+        FieldTestItemGroup retGroup1 = retFieldTestItemGroups.stream()
+                .filter(fieldTestItemGroup -> fieldTestItemGroup.equals(group1))
+                .findFirst().get();
+
+        assertThat(retGroup1.getBlockId()).isEqualTo(group1.getBlockId());
+        assertThat(retGroup1.getGroupId()).isEqualTo(group1.getGroupId());
+        assertThat(retGroup1.getNumItems()).isEqualTo(group1.getNumItems());
+        assertThat(retGroup1.getPosition()).isEqualTo(group1.getPosition());
+        assertThat(retGroup1.getPositionAdministered()).isEqualTo(group1.getPositionAdministered());
+    }
+}

--- a/service/src/test/java/tds/exam/repositories/impl/FieldTestItemGroupRepositoryIntegrationTests.java
+++ b/service/src/test/java/tds/exam/repositories/impl/FieldTestItemGroupRepositoryIntegrationTests.java
@@ -59,7 +59,7 @@ public class FieldTestItemGroupRepositoryIntegrationTests {
             .withPosition(2)
             .withSegmentId("segid")
             .withSegmentKey(segmentKey)
-            .withNumItems(1)
+            .withItemCount(1)
             .withSessionId(sessionId)
             .build();
 
@@ -73,7 +73,7 @@ public class FieldTestItemGroupRepositoryIntegrationTests {
             .withPositionAdministered(12)
             .withSegmentId("segid")
             .withSegmentKey(segmentKey)
-            .withNumItems(2)
+            .withItemCount(2)
             .withSessionId(sessionId)
             .build();
 
@@ -86,7 +86,7 @@ public class FieldTestItemGroupRepositoryIntegrationTests {
             .withPosition(2)
             .withSegmentId("segid")
             .withSegmentKey(segmentKey)
-            .withNumItems(1)
+            .withItemCount(1)
             .withSessionId(sessionId)
             .withDeletedAt(Instant.now().minusMillis(100000))
             .build();
@@ -102,7 +102,12 @@ public class FieldTestItemGroupRepositoryIntegrationTests {
 
         assertThat(retGroup1.getBlockId()).isEqualTo(group1.getBlockId());
         assertThat(retGroup1.getGroupId()).isEqualTo(group1.getGroupId());
-        assertThat(retGroup1.getNumItems()).isEqualTo(group1.getNumItems());
+        assertThat(retGroup1.isDeleted()).isFalse();
+        assertThat(retGroup1.getCreatedAt()).isNotNull();
+        assertThat(retGroup1.getSessionId()).isEqualTo(sessionId);
+        assertThat(retGroup1.getSegmentKey()).isEqualTo(segmentKey);
+        assertThat(retGroup1.getSegmentId()).isEqualTo("segid");
+        assertThat(retGroup1.getItemCount()).isEqualTo(group1.getItemCount());
         assertThat(retGroup1.getPosition()).isEqualTo(group1.getPosition());
         assertThat(retGroup1.getPositionAdministered()).isEqualTo(group1.getPositionAdministered());
     }

--- a/service/src/test/java/tds/exam/services/impl/EqualDistributionFieldTestItemGroupSelectorTest.java
+++ b/service/src/test/java/tds/exam/services/impl/EqualDistributionFieldTestItemGroupSelectorTest.java
@@ -1,0 +1,243 @@
+package tds.exam.services.impl;
+
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.Mock;
+import org.mockito.runners.MockitoJUnitRunner;
+
+import java.util.Arrays;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+
+import tds.assessment.Assessment;
+import tds.assessment.Item;
+import tds.assessment.Segment;
+import tds.exam.Exam;
+import tds.exam.builder.AssessmentBuilder;
+import tds.exam.builder.ExamBuilder;
+import tds.exam.builder.ItemBuilder;
+import tds.exam.builder.SegmentBuilder;
+import tds.exam.models.FieldTestItemGroup;
+import tds.exam.services.FieldTestItemGroupSelector;
+import tds.exam.services.ItemPoolService;
+
+import static org.assertj.core.api.Java6Assertions.assertThat;
+import static org.mockito.Matchers.any;
+import static org.mockito.Matchers.eq;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+@RunWith(MockitoJUnitRunner.class)
+public class EqualDistributionFieldTestItemGroupSelectorTest {
+    private FieldTestItemGroupSelector selector;
+
+    @Mock
+    private ItemPoolService mockItemPoolService;
+
+    @Before
+    public void setUp() {
+        selector = new EqualDistributionFieldTestItemGroupSelector(mockItemPoolService);
+    }
+
+    @Test
+    public void shouldDistributeFieldTestItemGroupsEqually() {
+        Map<String, Integer> itemGroupOccurances = new HashMap<>();
+        final String assessmentKey = "assessment-key123";
+        final int numberOfExamsToTest = 20;
+        Segment segment = new SegmentBuilder()
+            .withAssessmentKey(assessmentKey)
+            .withFieldTestStartPosition(3)
+            .withFieldTestEndPosition(7)
+            .withFieldTestMinItems(2)
+            .withFieldTestMaxItems(2)
+            .build();
+        Assessment assessment = new AssessmentBuilder()
+            .withSegments(Arrays.asList(segment))
+            .build();
+        Item ftItem1 = new ItemBuilder("item-1")
+            .withGroupId("group-id-1")
+            .withGroupKey("group-key-1")
+            .withFieldTest(true)
+            .build();
+        Item ftItem2 = new ItemBuilder("item-2")
+            .withGroupId("group-id-2")
+            .withGroupKey("group-key-2")
+            .withFieldTest(true)
+            .build();
+        Item ftItem3 = new ItemBuilder("item-3")
+            .withGroupId("group-id-3")
+            .withGroupKey("group-key-3")
+            .withFieldTest(true)
+            .build();
+        Item ftItem4 = new ItemBuilder("item-4")
+            .withGroupId("group-id-4")
+            .withGroupKey("group-key-4")
+            .withFieldTest(true)
+            .build();
+
+        Set<Item> fieldTestItems = new HashSet<>(Arrays.asList(ftItem1, ftItem2, ftItem3, ftItem4));
+
+        when(mockItemPoolService.getItemPool(any(), eq(assessment.getItemConstraints()), any(), eq(true)))
+            .thenReturn(fieldTestItems, fieldTestItems, fieldTestItems);
+
+        for (int i = 0; i < numberOfExamsToTest; i++) {
+            Exam exam = new ExamBuilder().withLanguageCode("ENU").build();
+            List<FieldTestItemGroup> retFtItemGroupsForExam = selector.selectItemGroupsLeastUsed(exam, new HashSet<>(),
+                assessment, segment.getKey(), segment.getFieldTestMinItems());
+            assertThat(retFtItemGroupsForExam).hasSize(2);
+
+            // Keep count of each item group selected by the algorithm.
+            for (FieldTestItemGroup selectedItemgroup : retFtItemGroupsForExam) {
+                Integer counter = itemGroupOccurances.get(selectedItemgroup.getGroupKey());
+                if (counter == null) {
+                    itemGroupOccurances.put(selectedItemgroup.getGroupKey(), 1);
+                } else {
+                    itemGroupOccurances.put(selectedItemgroup.getGroupKey(), counter + 1);
+                }
+            }
+        }
+
+        verify(mockItemPoolService, times(numberOfExamsToTest)).getItemPool(any(), eq(assessment.getItemConstraints()), any(), eq(true));
+
+        assertThat(itemGroupOccurances).hasSize(4);
+
+        int min = itemGroupOccurances.values().stream().min(Integer::compareTo).get();
+        int max = itemGroupOccurances.values().stream().max(Integer::compareTo).get();
+        // Make sure the difference between the maximum and minimum value of each counter is not greater than 1
+        assertThat(max - min).isLessThanOrEqualTo(1);
+
+    }
+
+    @Test
+    public void shouldExcludeGroupAlreadySelected() {
+        Exam exam = new ExamBuilder().withLanguageCode("ENU").build();
+        final String assessmentKey = "assessment-key123";
+        Segment segment = new SegmentBuilder()
+            .withAssessmentKey(assessmentKey)
+            .withFieldTestStartPosition(3)
+            .withFieldTestEndPosition(7)
+            .withFieldTestMinItems(4)
+            .withFieldTestMaxItems(4)
+            .build();
+        Assessment assessment = new AssessmentBuilder()
+            .withSegments(Arrays.asList(segment))
+            .build();
+        Item ftItem1 = new ItemBuilder("item-1")
+            .withGroupId("group-id-1")
+            .withGroupKey("group-key-1")
+            .withFieldTest(true)
+            .build();
+        Item ftItem2 = new ItemBuilder("item-2")
+            .withGroupId("group-id-2")
+            .withGroupKey("group-key-2")
+            .withFieldTest(true)
+            .build();
+        Item ftItem3 = new ItemBuilder("item-3")
+            .withGroupId("group-id-3")
+            .withGroupKey("group-key-3")
+            .withFieldTest(true)
+            .build();
+        // This item should be excluded - it has already been assigned
+        Item excludedFtItem = new ItemBuilder("item-4")
+            .withGroupId("group-id-4")
+            .withGroupKey("group-key-4")
+            .withFieldTest(true)
+            .build();
+
+        when(mockItemPoolService.getItemPool(eq(exam.getId()), eq(assessment.getItemConstraints()), any(), eq(true)))
+            .thenReturn(new HashSet<>(Arrays.asList(ftItem1, ftItem2, ftItem3, excludedFtItem)));
+        List<FieldTestItemGroup> retFtItemGroups = selector.selectItemGroupsLeastUsed(exam, new HashSet<>(Arrays.asList(excludedFtItem.getGroupId())),
+            assessment, segment.getKey(), segment.getFieldTestMinItems());
+        verify(mockItemPoolService).getItemPool(eq(exam.getId()), eq(assessment.getItemConstraints()), any(), eq(true));
+        assertThat(retFtItemGroups).hasSize(3);
+
+        FieldTestItemGroup selectedItemGroup = null;
+        FieldTestItemGroup notSelectedItemGroup = null;
+        for (FieldTestItemGroup itemGroup : retFtItemGroups) {
+            if (itemGroup.getGroupKey().equals(ftItem1.getGroupKey())) {
+                selectedItemGroup = itemGroup;
+            } else if (itemGroup.getGroupKey().equals(excludedFtItem.getGroupKey())) {
+                notSelectedItemGroup = itemGroup;
+            }
+        }
+
+        assertThat(selectedItemGroup.getGroupId()).isEqualTo(ftItem1.getGroupId());
+        assertThat(selectedItemGroup.getBlockId()).isEqualTo(ftItem1.getBlockId());
+        assertThat(selectedItemGroup.getNumItems()).isEqualTo(1);
+        assertThat(selectedItemGroup.getExamId()).isEqualTo(exam.getId());
+        assertThat(selectedItemGroup.getDeletedAt()).isNull();
+
+        assertThat(notSelectedItemGroup).isNull();
+    }
+
+    @Test
+    public void shouldSelectMultiItemGroups() {
+        Exam exam = new ExamBuilder().withLanguageCode("ENU").build();
+        final String assessmentKey = "assessment-key123";
+        Segment segment = new SegmentBuilder()
+            .withAssessmentKey(assessmentKey)
+            .withFieldTestStartPosition(3)
+            .withFieldTestEndPosition(7)
+            .withFieldTestMinItems(4)
+            .withFieldTestMaxItems(4)
+            .build();
+        Assessment assessment = new AssessmentBuilder()
+            .withSegments(Arrays.asList(segment))
+            .build();
+        // GROUP 1 (3 items)
+        Item ftItem1g1 = new ItemBuilder("item-1-group1")
+            .withGroupId("group-id-1")
+            .withGroupKey("group-key-1")
+            .withFieldTest(true)
+            .build();
+        Item ftItem2g1 = new ItemBuilder("item-2-group1")
+            .withGroupId("group-id-1")
+            .withGroupKey("group-key-1")
+            .withFieldTest(true)
+            .build();
+        Item ftItem3g1 = new ItemBuilder("item-3-group1")
+            .withGroupId("group-id-1")
+            .withGroupKey("group-key-1")
+            .withFieldTest(true)
+            .build();
+        // GROUP 2 (single item)
+        Item ftItem4g2 = new ItemBuilder("item-4-group2")
+            .withGroupId("group-id-2")
+            .withGroupKey("group-key-2")
+            .withFieldTest(true)
+            .build();
+        when(mockItemPoolService.getItemPool(eq(exam.getId()), eq(assessment.getItemConstraints()), any(), eq(true)))
+            .thenReturn(new HashSet<>(Arrays.asList(ftItem1g1, ftItem2g1, ftItem3g1, ftItem4g2)));
+        List<FieldTestItemGroup> retFtItemGroups = selector.selectItemGroupsLeastUsed(exam, new HashSet<>(),
+            assessment, segment.getKey(), segment.getFieldTestMinItems());
+        verify(mockItemPoolService).getItemPool(eq(exam.getId()), eq(assessment.getItemConstraints()), any(), eq(true));
+        assertThat(retFtItemGroups).hasSize(2);
+
+        FieldTestItemGroup multiItemItemGroup = null;
+        FieldTestItemGroup singleItemItemgGroup = null;
+        for (FieldTestItemGroup itemGroup : retFtItemGroups) {
+            if (itemGroup.getGroupKey().equals(ftItem1g1.getGroupKey())) {
+                multiItemItemGroup = itemGroup;
+            } else if (itemGroup.getGroupKey().equals(ftItem4g2.getGroupKey())) {
+                singleItemItemgGroup = itemGroup;
+            }
+        }
+
+        assertThat(multiItemItemGroup.getGroupId()).isEqualTo(ftItem1g1.getGroupId());
+        assertThat(multiItemItemGroup.getBlockId()).isEqualTo(ftItem1g1.getBlockId());
+        assertThat(multiItemItemGroup.getNumItems()).isEqualTo(3);
+        assertThat(multiItemItemGroup.getExamId()).isEqualTo(exam.getId());
+        assertThat(multiItemItemGroup.getDeletedAt()).isNull();
+
+        assertThat(singleItemItemgGroup.getGroupId()).isEqualTo(ftItem4g2.getGroupId());
+        assertThat(singleItemItemgGroup.getBlockId()).isEqualTo(ftItem4g2.getBlockId());
+        assertThat(singleItemItemgGroup.getNumItems()).isEqualTo(1);
+        assertThat(singleItemItemgGroup.getExamId()).isEqualTo(exam.getId());
+        assertThat(singleItemItemgGroup.getDeletedAt()).isNull();
+    }
+}

--- a/service/src/test/java/tds/exam/services/impl/ExamSegmentServiceImplTest.java
+++ b/service/src/test/java/tds/exam/services/impl/ExamSegmentServiceImplTest.java
@@ -21,6 +21,7 @@ import tds.assessment.Segment;
 import tds.exam.Exam;
 import tds.exam.builder.AssessmentBuilder;
 import tds.exam.builder.ExamBuilder;
+import tds.exam.builder.ItemBuilder;
 import tds.exam.builder.SegmentBuilder;
 import tds.exam.models.ExamSegment;
 import tds.exam.models.SegmentPoolInfo;
@@ -74,9 +75,9 @@ public class ExamSegmentServiceImplTest {
 
         when(mockSegmentPoolService.computeSegmentPool(exam.getId(), segment, assessment.getItemConstraints(),
             language)).thenReturn(segmentPoolInfo);
-        when(mockFieldTestService.isFieldTestEligible(exam, assessment, segment.getKey(), language))
+        when(mockFieldTestService.isFieldTestEligible(exam, assessment, segment.getKey()))
             .thenReturn(true);
-        when(mockFieldTestService.selectItemGroups(exam, assessment, segment.getKey(), language))
+        when(mockFieldTestService.selectItemGroups(exam, assessment, segment.getKey()))
             .thenReturn(2);
         examSegmentService.initializeExamSegments(exam, assessment);
     }
@@ -97,9 +98,9 @@ public class ExamSegmentServiceImplTest {
 
         when(mockSegmentPoolService.computeSegmentPool(exam.getId(), segment, assessment.getItemConstraints(),
             language)).thenReturn(segmentPoolInfo);
-        when(mockFieldTestService.isFieldTestEligible(exam, assessment, segment.getKey(), language))
+        when(mockFieldTestService.isFieldTestEligible(exam, assessment, segment.getKey()))
             .thenReturn(true);
-        when(mockFieldTestService.selectItemGroups(exam, assessment, segment.getKey(), language))
+        when(mockFieldTestService.selectItemGroups(exam, assessment, segment.getKey()))
             .thenReturn(2);
         when(mockFormSelector.selectForm(segment, language)).thenReturn(Optional.empty());
         examSegmentService.initializeExamSegments(exam, assessment);
@@ -164,17 +165,17 @@ public class ExamSegmentServiceImplTest {
             .build();
         SegmentPoolInfo segmentPoolInfo1 = new SegmentPoolInfo(3, 4,
             new HashSet<>(Arrays.asList(
-                new Item("item-1"),
-                new Item("item-2")
+                new ItemBuilder("item-1").build(),
+                new ItemBuilder("item-2").build()
             )));
 
         // Adaptive Segment w/ field test items
         when(mockSegmentPoolService.computeSegmentPool(exam.getId(), segment1, assessment.getItemConstraints(),
             language))
             .thenReturn(segmentPoolInfo1);
-        when(mockFieldTestService.isFieldTestEligible(exam, assessment, segment1.getKey(), language))
+        when(mockFieldTestService.isFieldTestEligible(exam, assessment, segment1.getKey()))
             .thenReturn(true);
-        when(mockFieldTestService.selectItemGroups(exam, assessment, segment1.getKey(), language))
+        when(mockFieldTestService.selectItemGroups(exam, assessment, segment1.getKey()))
             .thenReturn(2);
         when(mockFormSelector.selectForm(segment2, language)).thenReturn(Optional.of(enuForm));
         int totalItems = examSegmentService.initializeExamSegments(exam, assessment);
@@ -182,8 +183,8 @@ public class ExamSegmentServiceImplTest {
         // ExamSeg 1
         verify(mockSegmentPoolService).computeSegmentPool(exam.getId(), segment1, assessment.getItemConstraints(),
             language);
-        verify(mockFieldTestService).isFieldTestEligible(exam, assessment, segment1.getKey(), language);
-        verify(mockFieldTestService).selectItemGroups(exam, assessment, segment1.getKey(), language);
+        verify(mockFieldTestService).isFieldTestEligible(exam, assessment, segment1.getKey());
+        verify(mockFieldTestService).selectItemGroups(exam, assessment, segment1.getKey());
         verify(mockFormSelector).selectForm(segment2, language);
         verify(mockExamSegmentCommandRepository).insert(examSegmentCaptor.capture());
         List<ExamSegment> examSegments = examSegmentCaptor.getValue();
@@ -242,8 +243,8 @@ public class ExamSegmentServiceImplTest {
             .build();
         SegmentPoolInfo segmentPoolInfo1 = new SegmentPoolInfo(3, 4,
             new HashSet<>(Arrays.asList(
-                new Item("item-1"),
-                new Item("item-2")
+                new ItemBuilder("item-1").build(),
+                new ItemBuilder("item-2").build()
             )));
         SegmentPoolInfo segmentPoolInfo2 = new SegmentPoolInfo(0, 0,
             new HashSet<>());
@@ -252,13 +253,13 @@ public class ExamSegmentServiceImplTest {
         when(mockSegmentPoolService.computeSegmentPool(exam.getId(), segment1, assessment.getItemConstraints(),
             language))
             .thenReturn(segmentPoolInfo1);
-        when(mockFieldTestService.isFieldTestEligible(exam, assessment, segment1.getKey(), language))
+        when(mockFieldTestService.isFieldTestEligible(exam, assessment, segment1.getKey()))
             .thenReturn(false);
         // ExamSeg 2
         when(mockSegmentPoolService.computeSegmentPool(exam.getId(), segment2, assessment.getItemConstraints(),
             language))
             .thenReturn(segmentPoolInfo2);
-        when(mockFieldTestService.isFieldTestEligible(exam, assessment, segment2.getKey(), language))
+        when(mockFieldTestService.isFieldTestEligible(exam, assessment, segment2.getKey()))
             .thenReturn(false);
 
         int totalItems = examSegmentService.initializeExamSegments(exam, assessment);
@@ -266,11 +267,11 @@ public class ExamSegmentServiceImplTest {
         // ExamSeg 1
         verify(mockSegmentPoolService).computeSegmentPool(exam.getId(), segment1, assessment.getItemConstraints(),
             language);
-        verify(mockFieldTestService).isFieldTestEligible(exam, assessment, segment1.getKey(), language);
+        verify(mockFieldTestService).isFieldTestEligible(exam, assessment, segment1.getKey());
         // ExamSeg 2
         verify(mockSegmentPoolService).computeSegmentPool(exam.getId(), segment2, assessment.getItemConstraints(),
             language);
-        verify(mockFieldTestService).isFieldTestEligible(exam, assessment, segment2.getKey(), language);
+        verify(mockFieldTestService).isFieldTestEligible(exam, assessment, segment2.getKey());
 
         verify(mockExamSegmentCommandRepository).insert(examSegmentCaptor.capture());
         List<ExamSegment> examSegments = examSegmentCaptor.getValue();
@@ -348,22 +349,22 @@ public class ExamSegmentServiceImplTest {
             .build();
         SegmentPoolInfo segmentPoolInfo = new SegmentPoolInfo(3, 4,
             new HashSet<>(Arrays.asList(
-                new Item("item-1"),
-                new Item("item-2"),
-                new Item("item-3"),
-                new Item("item-4")
+                new ItemBuilder("item-1").build(),
+                new ItemBuilder("item-2").build(),
+                new ItemBuilder("item-3").build(),
+                new ItemBuilder("item-4").build()
             )));
 
         when(mockSegmentPoolService.computeSegmentPool(exam.getId(), segment, assessment.getItemConstraints(),
             language))
             .thenReturn(segmentPoolInfo);
-        when(mockFieldTestService.isFieldTestEligible(exam, assessment, segment.getKey(), language))
+        when(mockFieldTestService.isFieldTestEligible(exam, assessment, segment.getKey()))
             .thenReturn(false);
         int totalItems = examSegmentService.initializeExamSegments(exam, assessment);
         assertThat(totalItems).isEqualTo(segmentPoolInfo.getPoolCount());
         verify(mockSegmentPoolService).computeSegmentPool(exam.getId(), segment, assessment.getItemConstraints(),
             language);
-        verify(mockFieldTestService).isFieldTestEligible(exam, assessment, segment.getKey(), language);
+        verify(mockFieldTestService).isFieldTestEligible(exam, assessment, segment.getKey());
 
         verify(mockExamSegmentCommandRepository).insert(examSegmentCaptor.capture());
         List<ExamSegment> examSegments = examSegmentCaptor.getValue();
@@ -395,22 +396,22 @@ public class ExamSegmentServiceImplTest {
             .build();
         SegmentPoolInfo segmentPoolInfo = new SegmentPoolInfo(5, 4,
             new HashSet<>(Arrays.asList(
-                new Item("item-1"),
-                new Item("item-2"),
-                new Item("item-3"),
-                new Item("item-4")
+                new ItemBuilder("item-1").build(),
+                new ItemBuilder("item-2").build(),
+                new ItemBuilder("item-3").build(),
+                new ItemBuilder("item-4").build()
             )));
 
         when(mockSegmentPoolService.computeSegmentPool(exam.getId(), segment, assessment.getItemConstraints(),
             language))
             .thenReturn(segmentPoolInfo);
-        when(mockFieldTestService.isFieldTestEligible(exam, assessment, segment.getKey(), language))
+        when(mockFieldTestService.isFieldTestEligible(exam, assessment, segment.getKey()))
             .thenReturn(true);
         int totalItems = examSegmentService.initializeExamSegments(exam, assessment);
         assertThat(totalItems).isEqualTo(segmentPoolInfo.getPoolCount());
         verify(mockSegmentPoolService).computeSegmentPool(exam.getId(), segment, assessment.getItemConstraints(),
             language);
-        verify(mockFieldTestService).isFieldTestEligible(exam, assessment, segment.getKey(), language);
+        verify(mockFieldTestService).isFieldTestEligible(exam, assessment, segment.getKey());
 
         verify(mockExamSegmentCommandRepository).insert(examSegmentCaptor.capture());
         List<ExamSegment> examSegments = examSegmentCaptor.getValue();
@@ -533,25 +534,25 @@ public class ExamSegmentServiceImplTest {
             .build();
         SegmentPoolInfo segmentPoolInfo = new SegmentPoolInfo(segment.getMaxItems(), 4,
             new HashSet<>(Arrays.asList(
-                new Item("item-1"),
-                new Item("item-2"),
-                new Item("item-3"),
-                new Item("item-4")
+                new ItemBuilder("item-1").build(),
+                new ItemBuilder("item-2").build(),
+                new ItemBuilder("item-3").build(),
+                new ItemBuilder("item-4").build()
             )));
 
         when(mockSegmentPoolService.computeSegmentPool(exam.getId(), segment, assessment.getItemConstraints(),
             language))
             .thenReturn(segmentPoolInfo);
-        when(mockFieldTestService.isFieldTestEligible(exam, assessment, segment.getKey(), language))
+        when(mockFieldTestService.isFieldTestEligible(exam, assessment, segment.getKey()))
             .thenReturn(true);
-        when(mockFieldTestService.selectItemGroups(exam, assessment, segment.getKey(), language))
+        when(mockFieldTestService.selectItemGroups(exam, assessment, segment.getKey()))
             .thenReturn(2);
         int totalItems = examSegmentService.initializeExamSegments(exam, assessment);
         assertThat(totalItems).isEqualTo(segmentPoolInfo.getPoolCount() + 2);
         verify(mockSegmentPoolService).computeSegmentPool(exam.getId(), segment, assessment.getItemConstraints(),
             language);
-        verify(mockFieldTestService).isFieldTestEligible(exam, assessment, segment.getKey(), language);
-        verify(mockFieldTestService).selectItemGroups(exam, assessment, segment.getKey(), language);
+        verify(mockFieldTestService).isFieldTestEligible(exam, assessment, segment.getKey());
+        verify(mockFieldTestService).selectItemGroups(exam, assessment, segment.getKey());
 
         verify(mockExamSegmentCommandRepository).insert(examSegmentCaptor.capture());
         List<ExamSegment> examSegments = examSegmentCaptor.getValue();

--- a/service/src/test/java/tds/exam/services/impl/FieldTestServiceImplTest.java
+++ b/service/src/test/java/tds/exam/services/impl/FieldTestServiceImplTest.java
@@ -3,9 +3,19 @@ package tds.exam.services.impl;
 import org.joda.time.Instant;
 import org.junit.Before;
 import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.ArgumentCaptor;
+import org.mockito.Captor;
+import org.mockito.Mock;
+import org.mockito.runners.MockitoJUnitRunner;
+import org.springframework.test.annotation.Repeat;
 
+import java.lang.reflect.Field;
 import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.HashSet;
 import java.util.List;
+import java.util.UUID;
 
 import tds.assessment.Algorithm;
 import tds.assessment.Assessment;
@@ -15,22 +25,48 @@ import tds.assessment.Segment;
 import tds.exam.Exam;
 import tds.exam.builder.AssessmentBuilder;
 import tds.exam.builder.ExamBuilder;
+import tds.exam.builder.FieldTestItemGroupBuilder;
+import tds.exam.builder.ItemBuilder;
+import tds.exam.builder.SegmentBuilder;
+import tds.exam.models.FieldTestItemGroup;
+import tds.exam.repositories.FieldTestItemGroupCommandRepository;
+import tds.exam.repositories.FieldTestItemGroupQueryRepository;
+import tds.exam.services.FieldTestItemGroupSelector;
 import tds.exam.services.FieldTestService;
+import tds.exam.services.ItemPoolService;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Matchers.any;
+import static org.mockito.Matchers.anyInt;
+import static org.mockito.Matchers.eq;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
 
+@RunWith(MockitoJUnitRunner.class)
 public class FieldTestServiceImplTest {
     private FieldTestService fieldTestService;
 
+    @Mock
+    private FieldTestItemGroupCommandRepository mockFieldTestItemGroupCommandRepository;
+
+    @Mock
+    private FieldTestItemGroupQueryRepository mockFieldTestItemGroupQueryRepository;
+
+    @Mock
+    private FieldTestItemGroupSelector mockFieldTestItemGroupSelector;
+
+    @Captor
+    private ArgumentCaptor<List<FieldTestItemGroup>> fieldTestItemGroupInsertCaptor;
+
     @Before
     public void setUp() {
-        fieldTestService = new FieldTestServiceImpl();
+        fieldTestService = new FieldTestServiceImpl(mockFieldTestItemGroupQueryRepository, mockFieldTestItemGroupCommandRepository,
+            mockFieldTestItemGroupSelector);
     }
 
     @Test
     public void shouldReturnFalseForNoFieldTestItems() {
         final String segmentKey = "segment-key";
-        final String language = "ENU";
 
         final Exam exam = new ExamBuilder().build();
         List<Item> items = createTestItems(false);
@@ -46,14 +82,13 @@ public class FieldTestServiceImplTest {
             .withSegments(segments)
             .build();
 
-        boolean isEligible = fieldTestService.isFieldTestEligible(exam, assessment, segmentKey, language);
+        boolean isEligible = fieldTestService.isFieldTestEligible(exam, assessment, segmentKey);
         assertThat(isEligible).isFalse();
     }
 
     @Test
     public void shouldReturnTrueForSimulationWithFieldTestItems() {
         final String segmentKey = "segment-key";
-        final String language = "ENU";
         final Exam exam = new ExamBuilder()
             .withEnvironment("SIMULATION")
             .build();
@@ -71,7 +106,7 @@ public class FieldTestServiceImplTest {
             .withSegments(segments)
             .build();
 
-        boolean isEligible = fieldTestService.isFieldTestEligible(exam, assessment, segmentKey, language);
+        boolean isEligible = fieldTestService.isFieldTestEligible(exam, assessment, segmentKey);
         assertThat(isEligible).isTrue();
     }
 
@@ -94,14 +129,13 @@ public class FieldTestServiceImplTest {
             .withSegments(segments)
             .build();
 
-        boolean isEligible = fieldTestService.isFieldTestEligible(exam, assessment, segmentKey, language);
+        boolean isEligible = fieldTestService.isFieldTestEligible(exam, assessment, segmentKey);
         assertThat(isEligible).isTrue();
     }
 
     @Test
     public void shouldReturnFalseForNonSegmentedAssessmentWithFieldTestItemsNullStartDate() {
         final String segmentKey = "segment-key";
-        final String language = "ENU";
         final Exam exam = new ExamBuilder().build();
 
         List<Item> items = createTestItems(true);
@@ -119,14 +153,13 @@ public class FieldTestServiceImplTest {
             .withFieldTestEndDate(Instant.now().minus(50000))
             .build();
 
-        boolean isEligible = fieldTestService.isFieldTestEligible(exam, assessment, segmentKey, language);
+        boolean isEligible = fieldTestService.isFieldTestEligible(exam, assessment, segmentKey);
         assertThat(isEligible).isFalse();
     }
 
     @Test
     public void shouldReturnFalseForNonSegmentedAssessmentWithFieldTestItemsNullEndDate() {
         final String segmentKey = "segment-key";
-        final String language = "ENU";
         final Exam exam = new ExamBuilder().build();
         List<Item> items = createTestItems(true);
 
@@ -143,14 +176,13 @@ public class FieldTestServiceImplTest {
             .withFieldTestStartDate(Instant.now().plus(50000))
             .build();
 
-        boolean isEligible = fieldTestService.isFieldTestEligible(exam, assessment, segmentKey, language);
+        boolean isEligible = fieldTestService.isFieldTestEligible(exam, assessment, segmentKey);
         assertThat(isEligible).isFalse();
     }
 
     @Test
     public void shouldReturnTrueForNonSegmentedAssessmentWithFieldTestItemsNullEndDate() {
         final String segmentKey = "segment-key";
-        final String language = "ENU";
         final Exam exam = new ExamBuilder().build();
 
         List<Item> items = createTestItems(true);
@@ -168,14 +200,13 @@ public class FieldTestServiceImplTest {
             .withFieldTestStartDate(Instant.now().minus(50000))
             .build();
 
-        boolean isEligible = fieldTestService.isFieldTestEligible(exam, assessment, segmentKey, language);
+        boolean isEligible = fieldTestService.isFieldTestEligible(exam, assessment, segmentKey);
         assertThat(isEligible).isTrue();
     }
 
     @Test
     public void shouldReturnFalseForNonSegmentedAssessmentOutOfFTWindow() {
         final String segmentKey = "segment-key";
-        final String language = "ENU";
         final Exam exam = new ExamBuilder().build();
         List<Item> items = createTestItems(true);
 
@@ -193,7 +224,7 @@ public class FieldTestServiceImplTest {
             .withFieldTestEndDate(Instant.now().plus(2000000))
             .build();
 
-        boolean isEligible = fieldTestService.isFieldTestEligible(exam, assessment, segmentKey, language);
+        boolean isEligible = fieldTestService.isFieldTestEligible(exam, assessment, segmentKey);
         assertThat(isEligible).isFalse();
     }
 
@@ -201,7 +232,6 @@ public class FieldTestServiceImplTest {
     public void shouldReturnFalseForSegmentedAssessmentOutOfSegmentFTWindow() {
         final String segmentKey = "segment-key";
         final String segmentId = "segment-id";
-        final String language = "ENU";
         final Exam exam = new ExamBuilder().build();
         List<Item> items = createTestItems(true);
 
@@ -226,7 +256,7 @@ public class FieldTestServiceImplTest {
             .withFieldTestEndDate(Instant.now().plus(2000000))
             .build();
 
-        boolean isEligible = fieldTestService.isFieldTestEligible(exam, assessment, segmentKey, language);
+        boolean isEligible = fieldTestService.isFieldTestEligible(exam, assessment, segmentKey);
         assertThat(isEligible).isFalse();
     }
 
@@ -234,7 +264,6 @@ public class FieldTestServiceImplTest {
     public void shouldReturnTrueForSegmentedAssessmentNullSegFTWindow() {
         final String segmentKey = "segment-key";
         final String segmentId = "segment-id";
-        final String language = "ENU";
         final Exam exam = new ExamBuilder().build();
         List<Item> items = createTestItems(true);
 
@@ -257,14 +286,13 @@ public class FieldTestServiceImplTest {
             .withFieldTestEndDate(Instant.now().plus(2000000))
             .build();
 
-        boolean isEligible = fieldTestService.isFieldTestEligible(exam, assessment, segmentKey, language);
+        boolean isEligible = fieldTestService.isFieldTestEligible(exam, assessment, segmentKey);
         assertThat(isEligible).isTrue();
     }
 
     @Test
     public void shouldReturnTrueForSegmentedAssessmentInSegFTWindow() {
         final String segmentKey = "segment-key";
-        final String language = "ENU";
 
         final Exam exam = new ExamBuilder().build();
 
@@ -287,8 +315,270 @@ public class FieldTestServiceImplTest {
             .withFieldTestEndDate(Instant.now().plus(2000000))
             .build();
 
-        boolean isEligible = fieldTestService.isFieldTestEligible(exam, assessment, segmentKey, language);
+        boolean isEligible = fieldTestService.isFieldTestEligible(exam, assessment, segmentKey);
         assertThat(isEligible).isTrue();
+    }
+
+    @Test
+    public void shouldSelectAndInsertFieldTestItemGroupsWithPreviousSelected() {
+        Exam exam = new ExamBuilder().build();
+        final String assessmentKey = "assessment-key123";
+        Segment segment = new SegmentBuilder()
+            .withAssessmentKey(assessmentKey)
+            .withFieldTestStartPosition(3)
+            .withFieldTestEndPosition(7)
+            .withFieldTestMinItems(4)
+            .withFieldTestMaxItems(4)
+            .build();
+        Assessment assessment = new AssessmentBuilder()
+            .withSegments(Arrays.asList(segment))
+            .build();
+        FieldTestItemGroup ftItemGroup1 = new FieldTestItemGroupBuilder("group-key-1")
+            .withGroupId("group-id-1")
+            .withNumItems(1)
+            .withExamId(exam.getId())
+            .withSegmentKey(segment.getKey())
+            .build();
+        FieldTestItemGroup ftItemGroup2 = new FieldTestItemGroupBuilder("group-key-2")
+            .withGroupId("group-id-2")
+            .withExamId(exam.getId())
+            .withSegmentKey(segment.getKey())
+            .withNumItems(1)
+            .build();
+        FieldTestItemGroup ftItemGroup3 = new FieldTestItemGroupBuilder("group-key-3")
+            .withGroupId("group-id-3")
+            .withExamId(exam.getId())
+            .withSegmentKey(segment.getKey())
+            .withNumItems(1)
+            .build();
+        // This field test item group should be excluded (it is already selected for this exam)s
+        FieldTestItemGroup ftItemGroup4 = new FieldTestItemGroupBuilder("group-key-4")
+            .withGroupId("group-id-4")
+            .withExamId(exam.getId())
+            .withSegmentKey(segment.getKey())
+            .withNumItems(1)
+            .build();
+
+        when(mockFieldTestItemGroupQueryRepository.find(exam.getId(), segment.getKey()))
+            .thenReturn(Arrays.asList(ftItemGroup4));
+        when(mockFieldTestItemGroupSelector.selectItemGroupsLeastUsed(eq(exam), any(),
+            any(), eq(segment.getKey()), eq(segment.getFieldTestMinItems())))
+            .thenReturn(Arrays.asList(ftItemGroup1, ftItemGroup2, ftItemGroup3));
+        int totalItems = fieldTestService.selectItemGroups(exam, assessment, segment.getKey());
+        verify(mockFieldTestItemGroupQueryRepository).find(exam.getId(), segment.getKey());
+        verify(mockFieldTestItemGroupCommandRepository).insert(fieldTestItemGroupInsertCaptor.capture());
+        verify(mockFieldTestItemGroupSelector).selectItemGroupsLeastUsed(eq(exam), any(),
+            eq(assessment), eq(segment.getKey()), eq(segment.getFieldTestMinItems()));
+
+        List<FieldTestItemGroup> insertedItemGroups = fieldTestItemGroupInsertCaptor.getValue();
+
+        assertThat(insertedItemGroups).containsExactlyInAnyOrder(ftItemGroup1, ftItemGroup2, ftItemGroup3);
+
+        FieldTestItemGroup insertedFtGroup1 = null;
+        FieldTestItemGroup insertedFtGroup2 = null;
+        FieldTestItemGroup insertedFtGroup3 = null;
+        FieldTestItemGroup notInsertedFtGroup = null;
+        for (FieldTestItemGroup itemGroup : insertedItemGroups) {
+            if (itemGroup.getGroupKey().equals(ftItemGroup1.getGroupKey())) {
+                insertedFtGroup1 = itemGroup;
+            } else if (itemGroup.getGroupKey().equals(ftItemGroup2.getGroupKey())) {
+                insertedFtGroup2 = itemGroup;
+            } else if (itemGroup.getGroupKey().equals(ftItemGroup3.getGroupKey())) {
+                insertedFtGroup3 = itemGroup;
+            } else if (itemGroup.getGroupKey().equals(ftItemGroup4.getGroupKey())) {
+                notInsertedFtGroup = itemGroup;
+            }
+        }
+        assertThat(totalItems).isEqualTo(4);
+        assertThat(insertedFtGroup1.getGroupId()).isEqualTo(ftItemGroup1.getGroupId());
+        assertThat(insertedFtGroup1.getBlockId()).isEqualTo(ftItemGroup1.getBlockId());
+        assertThat(insertedFtGroup1.getPosition()).isGreaterThanOrEqualTo(segment.getFieldTestStartPosition());
+        assertThat(insertedFtGroup1.getLanguageCode()).isEqualTo(exam.getLanguageCode());
+        assertThat(insertedFtGroup1.getNumItems()).isEqualTo(1);
+        assertThat(insertedFtGroup1.getExamId()).isEqualTo(exam.getId());
+        assertThat(insertedFtGroup1.getSegmentId()).isEqualTo(segment.getSegmentId());
+        assertThat(insertedFtGroup1.getSegmentKey()).isEqualTo(segment.getKey());
+        assertThat(insertedFtGroup1.getSessionId()).isEqualTo(exam.getSessionId());
+        assertThat(insertedFtGroup1.getDeletedAt()).isNull();
+
+        assertThat(insertedFtGroup2.getPosition()).isGreaterThanOrEqualTo(segment.getFieldTestStartPosition());
+        assertThat(insertedFtGroup2.getNumItems()).isEqualTo(1);
+
+        assertThat(insertedFtGroup3.getPosition()).isGreaterThanOrEqualTo(segment.getFieldTestStartPosition());
+        assertThat(insertedFtGroup3.getNumItems()).isEqualTo(1);
+
+        assertThat(notInsertedFtGroup).isNull();
+    }
+
+    @Test(expected = IllegalStateException.class)
+    public void shouldThrowExceptionWhenNotEnoughPositionsAsMinFieldTestItems() {
+        Exam exam = new ExamBuilder().build();
+        final String assessmentKey = "assessment-key123";
+        Segment segment = new SegmentBuilder()
+            .withAssessmentKey(assessmentKey)
+            .withFieldTestStartPosition(6) // 7 - 6 < 2, so should throw exception
+            .withFieldTestEndPosition(7)
+            .withFieldTestMinItems(2)
+            .withFieldTestMaxItems(2)
+            .build();
+        Assessment assessment = new AssessmentBuilder()
+            .withSegments(Arrays.asList(segment))
+            .build();
+        fieldTestService.selectItemGroups(exam, assessment, segment.getKey());
+    }
+
+    @Test(expected = IllegalStateException.class)
+    public void shouldThrowExceptionForNullFTStartAndEndPositions() {
+        Exam exam = new ExamBuilder().build();
+        final String assessmentKey = "assessment-key123";
+        Segment segment = new SegmentBuilder()
+            .withAssessmentKey(assessmentKey)
+            .withFieldTestStartPosition(null)   // 7 - 6 < 2, so should throw exception
+            .withFieldTestEndPosition(null)
+            .withFieldTestMinItems(2)
+            .withFieldTestMaxItems(2)
+            .build();
+        Assessment assessment = new AssessmentBuilder()
+            .withSegments(Arrays.asList(segment))
+            .build();
+        fieldTestService.selectItemGroups(exam, assessment, segment.getKey());
+    }
+
+    /* This method will test the case when there are field test item groups that have more items
+    *  than there are field test positions for those items in the segment. In this case, the expected number of field test items is
+    *  2, but ftItemGroup1 below has 3 items (and therefore should never be selected).
+    * */
+    @Test
+    public void shouldSelectAndInsertFieldTestItemGroupsWithoutEnoughPositionsForAllItems() {
+        Exam exam = new ExamBuilder().build();
+        final String assessmentKey = "assessment-key123";
+        Segment segment = new SegmentBuilder()
+            .withAssessmentKey(assessmentKey)
+            .withFieldTestStartPosition(3)
+            .withFieldTestEndPosition(7)
+            .withFieldTestMinItems(2)
+            .withFieldTestMaxItems(2)
+            .build();
+        Assessment assessment = new AssessmentBuilder()
+            .withSegments(Arrays.asList(segment))
+            .build();
+        FieldTestItemGroup ftItemGroup1 = new FieldTestItemGroupBuilder("group-key-1")
+            .withGroupId("group-id-1")
+            .withExamId(exam.getId())
+            .withSegmentKey(segment.getKey())
+            .withNumItems(3)
+            .build();
+        FieldTestItemGroup ftItemGroup2 = new FieldTestItemGroupBuilder("group-key-2")
+            .withGroupId("group-id-2")
+            .withExamId(exam.getId())
+            .withSegmentKey(segment.getKey())
+            .withNumItems(1)
+            .build();
+
+        when(mockFieldTestItemGroupQueryRepository.find(exam.getId(), segment.getKey()))
+            .thenReturn(new ArrayList<>());
+        when(mockFieldTestItemGroupSelector.selectItemGroupsLeastUsed(eq(exam), any(),
+            any(), eq(segment.getKey()), eq(segment.getFieldTestMinItems())))
+            .thenReturn(Arrays.asList(ftItemGroup1, ftItemGroup2));
+        int totalItems = fieldTestService.selectItemGroups(exam, assessment, segment.getKey());
+        verify(mockFieldTestItemGroupQueryRepository).find(exam.getId(), segment.getKey());
+        verify(mockFieldTestItemGroupCommandRepository).insert(fieldTestItemGroupInsertCaptor.capture());
+        verify(mockFieldTestItemGroupSelector).selectItemGroupsLeastUsed(eq(exam), any(),
+            eq(assessment), eq(segment.getKey()), eq(segment.getFieldTestMinItems()));
+
+        List<FieldTestItemGroup> insertedItemGroups = fieldTestItemGroupInsertCaptor.getValue();
+
+        assertThat(insertedItemGroups).containsExactly(ftItemGroup2);
+
+        FieldTestItemGroup insertedFtGroup1 = null;
+        FieldTestItemGroup insertedFtGroup2 = null;
+        for (FieldTestItemGroup itemGroup : insertedItemGroups) {
+            if (itemGroup.getGroupKey().equals(ftItemGroup1.getGroupKey())) {
+                insertedFtGroup1 = itemGroup;
+            } else if (itemGroup.getGroupKey().equals(ftItemGroup2.getGroupKey())) {
+                insertedFtGroup2 = itemGroup;
+            }
+        }
+
+        assertThat(insertedFtGroup1).isNull();
+
+        assertThat(totalItems).isEqualTo(1);
+        assertThat(insertedFtGroup2.getGroupId()).isEqualTo(ftItemGroup2.getGroupId());
+        assertThat(insertedFtGroup2.getBlockId()).isEqualTo(ftItemGroup2.getBlockId());
+        assertThat(insertedFtGroup2.getPosition()).isGreaterThanOrEqualTo(segment.getFieldTestStartPosition());
+        assertThat(insertedFtGroup2.getLanguageCode()).isEqualTo(exam.getLanguageCode());
+        assertThat(insertedFtGroup2.getNumItems()).isEqualTo(1);
+        assertThat(insertedFtGroup2.getExamId()).isEqualTo(exam.getId());
+        assertThat(insertedFtGroup2.getSegmentId()).isEqualTo(segment.getSegmentId());
+        assertThat(insertedFtGroup2.getSegmentKey()).isEqualTo(segment.getKey());
+        assertThat(insertedFtGroup2.getSessionId()).isEqualTo(exam.getSessionId());
+        assertThat(insertedFtGroup2.getDeletedAt()).isNull();
+    }
+
+    @Test
+    public void shouldSelectAndInsertFieldTestItemGroupsMultiItems() {
+        Exam exam = new ExamBuilder().build();
+        final String assessmentKey = "assessment-key123";
+        Segment segment = new SegmentBuilder()
+            .withAssessmentKey(assessmentKey)
+            .withFieldTestStartPosition(3)
+            .withFieldTestEndPosition(7)
+            .withFieldTestMinItems(4)
+            .withFieldTestMaxItems(4)
+            .build();
+        Assessment assessment = new AssessmentBuilder()
+            .withSegments(Arrays.asList(segment))
+            .build();
+        FieldTestItemGroup ftItemGroup1 = new FieldTestItemGroupBuilder("group-key-1")
+            .withGroupId("group-id-1")
+            .withNumItems(3)
+            .withExamId(exam.getId())
+            .withSegmentKey(segment.getKey())
+            .build();
+        FieldTestItemGroup ftItemGroup2 = new FieldTestItemGroupBuilder("group-key-2")
+            .withGroupId("group-id-2")
+            .withNumItems(1)
+            .withExamId(exam.getId())
+            .withSegmentKey(segment.getKey())
+            .build();
+        when(mockFieldTestItemGroupQueryRepository.find(exam.getId(), segment.getKey())).thenReturn(new ArrayList<>());
+        when(mockFieldTestItemGroupSelector.selectItemGroupsLeastUsed(eq(exam), any(),
+            any(), eq(segment.getKey()), eq(segment.getFieldTestMinItems())))
+            .thenReturn(Arrays.asList(ftItemGroup1, ftItemGroup2));
+        int totalItems = fieldTestService.selectItemGroups(exam, assessment, segment.getKey());
+        verify(mockFieldTestItemGroupQueryRepository).find(exam.getId(), segment.getKey());
+        verify(mockFieldTestItemGroupCommandRepository).insert(fieldTestItemGroupInsertCaptor.capture());
+        verify(mockFieldTestItemGroupSelector).selectItemGroupsLeastUsed(eq(exam), any(),
+            eq(assessment), eq(segment.getKey()), eq(segment.getFieldTestMinItems()));
+
+        List<FieldTestItemGroup> insertedItemGroups = fieldTestItemGroupInsertCaptor.getValue();
+
+        assertThat(insertedItemGroups).containsExactlyInAnyOrder(ftItemGroup1, ftItemGroup2);
+
+        FieldTestItemGroup insertedFtGroup1 = null;
+        FieldTestItemGroup insertedFtGroup2 = null;
+        for (FieldTestItemGroup itemGroup : insertedItemGroups) {
+            if (itemGroup.getGroupKey().equals(ftItemGroup1.getGroupKey())) {
+                insertedFtGroup1 = itemGroup;
+            } else if (itemGroup.getGroupKey().equals(ftItemGroup2.getGroupKey())) {
+                insertedFtGroup2 = itemGroup;
+            }
+        }
+        assertThat(totalItems).isEqualTo(segment.getFieldTestMinItems());
+
+        assertThat(insertedFtGroup1.getGroupId()).isEqualTo(ftItemGroup1.getGroupId());
+        assertThat(insertedFtGroup1.getBlockId()).isEqualTo(ftItemGroup1.getBlockId());
+        assertThat(insertedFtGroup1.getPosition()).isGreaterThanOrEqualTo(segment.getFieldTestStartPosition());
+        assertThat(insertedFtGroup1.getLanguageCode()).isEqualTo(exam.getLanguageCode());
+        assertThat(insertedFtGroup1.getNumItems()).isEqualTo(3);
+        assertThat(insertedFtGroup1.getExamId()).isEqualTo(exam.getId());
+        assertThat(insertedFtGroup1.getSegmentId()).isEqualTo(segment.getSegmentId());
+        assertThat(insertedFtGroup1.getSegmentKey()).isEqualTo(segment.getKey());
+        assertThat(insertedFtGroup1.getSessionId()).isEqualTo(exam.getSessionId());
+        assertThat(insertedFtGroup1.getDeletedAt()).isNull();
+
+        assertThat(insertedFtGroup2.getPosition()).isGreaterThanOrEqualTo(segment.getFieldTestStartPosition());
+        assertThat(insertedFtGroup2.getNumItems()).isEqualTo(1);
     }
 
     private List<Item> createTestItems(boolean isFieldTest) {

--- a/service/src/test/java/tds/exam/services/impl/ItemPoolServiceImplTest.java
+++ b/service/src/test/java/tds/exam/services/impl/ItemPoolServiceImplTest.java
@@ -13,6 +13,7 @@ import tds.assessment.Item;
 import tds.assessment.ItemConstraint;
 import tds.assessment.ItemProperty;
 import tds.exam.ExamAccommodation;
+import tds.exam.builder.ItemBuilder;
 import tds.exam.services.ExamAccommodationService;
 import tds.exam.services.ItemPoolService;
 
@@ -57,12 +58,15 @@ public class ItemPoolServiceImplTest {
         itemProperties3.add(new ItemProperty("--ITEMTYPE--", "MI", "Matching Item", itemId3));
 
         List<Item> items = new ArrayList<>();
-        Item item1 = new Item(itemId1);
-        item1.setItemProperties(itemProperties1);
-        Item item2 = new Item(itemId2);
-        item2.setItemProperties(itemProperties2);
-        Item item3 = new Item(itemId3);
-        item3.setItemProperties(itemProperties3);
+        Item item1 = new ItemBuilder(itemId1)
+            .withItemProperties(itemProperties1)
+            .build();
+        Item item2 = new ItemBuilder(itemId2)
+            .withItemProperties(itemProperties2)
+            .build();
+        Item item3 = new ItemBuilder(itemId3)
+            .withItemProperties(itemProperties3)
+            .build();
 
         items.add(item1);
         items.add(item2);
@@ -150,12 +154,16 @@ public class ItemPoolServiceImplTest {
         itemProperties3.add(new ItemProperty("--ITEMTYPE--", "MI", "Matching Item", itemId3));
 
         List<Item> items = new ArrayList<>();
-        Item item1 = new Item(itemId1);
-        item1.setItemProperties(itemProperties1);
-        Item item2 = new Item(itemId2);
-        item2.setItemProperties(itemProperties2);
-        Item item3 = new Item(itemId3);
-        item3.setItemProperties(itemProperties3);
+        Item item1 = new ItemBuilder(itemId1)
+            .withItemProperties(itemProperties1)
+            .build();
+        Item item2 = new ItemBuilder(itemId2)
+            .withItemProperties(itemProperties2)
+            .build();
+        Item item3 = new ItemBuilder(itemId3)
+            .withItemProperties(itemProperties3)
+            .build();
+
         items.add(item1);
         items.add(item2);
         items.add(item3);
@@ -307,17 +315,19 @@ public class ItemPoolServiceImplTest {
         itemProperties1.add(new ItemProperty("--ITEMTYPE--", "ER", "Extended Response", itemId3));
 
         List<Item> items = new ArrayList<>();
-        Item ftItem1 = new Item(itemId1);
-        ftItem1.setFieldTest(true);
-        ftItem1.setItemProperties(itemProperties1);
+        Item ftItem1 = new ItemBuilder(itemId1)
+            .withFieldTest(true)
+            .withItemProperties(itemProperties1)
+            .build();
 
-        Item ftItem2 = new Item(itemId2);
-        ftItem2.setFieldTest(true);
-        ftItem2.setItemProperties(itemProperties2);
+        Item ftItem2 = new ItemBuilder(itemId2)
+            .withFieldTest(true)
+            .withItemProperties(itemProperties2)
+            .build();
 
-        Item regularItem = new Item(itemId3);
-        regularItem.setFieldTest(false);
-        regularItem.setItemProperties(itemProperties3);
+        Item regularItem = new ItemBuilder(itemId3)
+            .withItemProperties(itemProperties1)
+            .build();
 
         items.add(ftItem1);
         items.add(ftItem2);

--- a/service/src/test/java/tds/exam/services/impl/ItemPoolServiceImplTest.java
+++ b/service/src/test/java/tds/exam/services/impl/ItemPoolServiceImplTest.java
@@ -310,10 +310,6 @@ public class ItemPoolServiceImplTest {
         itemProperties1.add(new ItemProperty("Language", "ENU", "English", itemId2));
         itemProperties1.add(new ItemProperty("--ITEMTYPE--", "ER", "Extended Response", itemId2));
 
-        List<ItemProperty> itemProperties3 = new ArrayList<>();
-        itemProperties1.add(new ItemProperty("Language", "ENU", "English", itemId3));
-        itemProperties1.add(new ItemProperty("--ITEMTYPE--", "ER", "Extended Response", itemId3));
-
         List<Item> items = new ArrayList<>();
         Item ftItem1 = new ItemBuilder(itemId1)
             .withFieldTest(true)
@@ -353,7 +349,7 @@ public class ItemPoolServiceImplTest {
             .build());
 
         when(mockExamAccommodationService.findAllAccommodations(examId)).thenReturn(examAccommodations);
-        Set<Item> retFtItems = itemPoolService.getItemPool(examId, itemConstraints, items, true);
+        Set<Item> retFtItems = itemPoolService.getFieldTestItemPool(examId, itemConstraints, items);
         verify(mockExamAccommodationService).findAllAccommodations(examId);
         assertThat(retFtItems).hasSize(2);
 
@@ -370,19 +366,6 @@ public class ItemPoolServiceImplTest {
 
         assertThat(retItem1).isNotNull();
         assertThat(retItem2).isNotNull();
-
-        Set<Item> nonFtItems = itemPoolService.getItemPool(examId, itemConstraints, items, false);
-        assertThat(nonFtItems).hasSize(1);
-
-        Item nonFtItem = null;
-
-        for (Item item : nonFtItems) {
-            if (item.getId().equals(itemId3)) {
-                nonFtItem = item;
-            }
-        }
-
-        assertThat(nonFtItem).isNotNull();
     }
 
     @Test

--- a/service/src/test/java/tds/exam/services/impl/SegmentPoolServiceImplTest.java
+++ b/service/src/test/java/tds/exam/services/impl/SegmentPoolServiceImplTest.java
@@ -17,6 +17,7 @@ import tds.assessment.ItemProperty;
 import tds.assessment.Segment;
 import tds.assessment.Strand;
 import tds.exam.ExamAccommodation;
+import tds.exam.builder.ItemBuilder;
 import tds.exam.models.SegmentPoolInfo;
 import tds.exam.services.ItemPoolService;
 
@@ -104,32 +105,31 @@ public class SegmentPoolServiceImplTest {
         enuProps2.add(new ItemProperty("--ITEMTYPE--", "MI", "Matching Item", excludedStrandItemId));
 
         List<Item> items = new ArrayList<>();
-        Item item1 = new Item(itemId1);
-        item1.setStrand(includedStrand1.getName());
-        item1.setItemProperties(enuProps1);
-        item1.setFieldTest(false);
-
-        Item item2 = new Item(itemId2);
-        item2.setStrand(includedStrand1.getName());
-        item2.setItemProperties(enuProps2);
-        item2.setFieldTest(false);
-
-        Item item3 = new Item(itemId3);
-        item3.setStrand(includedStrand2.getName());
-        item3.setItemProperties(enuProps3);
-        item3.setFieldTest(false);
+        Item item1 = new ItemBuilder(itemId1)
+            .withStrand(includedStrand1.getName())
+            .withItemProperties(enuProps1)
+            .build();
+        Item item2 = new ItemBuilder(itemId2)
+            .withStrand(includedStrand1.getName())
+            .withItemProperties(enuProps2)
+            .build();
+        Item item3 = new ItemBuilder(itemId3)
+            .withStrand(includedStrand2.getName())
+            .withItemProperties(enuProps3)
+            .build();
 
         // Should be included in the itemPoolIds list, but wont be factored into other calculations because its an FT item
-        Item ftItem = new Item(ftItemId);
-        ftItem.setStrand(includedStrand2.getName());
-        ftItem.setItemProperties(ftProps);
-        ftItem.setFieldTest(true);
+        Item ftItem = new ItemBuilder(ftItemId)
+            .withStrand(includedStrand2.getName())
+            .withItemProperties(ftProps)
+            .withFieldTest(true)
+            .build();
 
         // This item will be included in the itemPoolIds list, but wont be factored into other calculations
-        Item excludedStrandItem = new Item(excludedStrandItemId);
-        excludedStrandItem.setItemProperties(excludedStrandItemProps);
-        excludedStrandItem.setStrand(excludedStrand.getName());       // This should be excluded from strand calculations
-        excludedStrandItem.setFieldTest(false);
+        Item excludedStrandItem = new ItemBuilder(excludedStrandItemId)
+            .withItemProperties(excludedStrandItemProps)
+            .withStrand(excludedStrand.getName())       // This should be excluded from strand calculations
+            .build();
 
         items.add(item1);
         items.add(item2);
@@ -260,32 +260,33 @@ public class SegmentPoolServiceImplTest {
         enuProps2.add(new ItemProperty("--ITEMTYPE--", "MI", "Matching Item", excludedStrandItemId));
 
         List<Item> items = new ArrayList<>();
-        Item item1 = new Item(itemId1);
-        item1.setStrand(includedStrand1.getName());
-        item1.setItemProperties(enuProps1);
-        item1.setFieldTest(false);
+        Item item1 = new ItemBuilder(itemId1)
+            .withStrand(includedStrand1.getName())
+            .withItemProperties(enuProps1)
+            .build();
 
-        Item item2 = new Item(itemId2);
-        item2.setStrand(includedStrand1.getName());
-        item2.setItemProperties(enuProps2);
-        item2.setFieldTest(false);
+        Item item2 = new ItemBuilder(itemId2)
+            .withStrand(includedStrand1.getName())
+            .withItemProperties(enuProps2)
+            .build();
 
-        Item item3 = new Item(itemId3);
-        item3.setStrand(includedStrand2.getName());
-        item3.setItemProperties(enuProps3);
-        item3.setFieldTest(false);
+        Item item3 = new ItemBuilder(itemId3)
+            .withStrand(includedStrand2.getName())
+            .withItemProperties(enuProps3)
+            .build();
 
         // Should be included in the itemPoolIds list, but wont be factored into other calculations because its an FT item
-        Item ftItem = new Item(ftItemId);
-        ftItem.setStrand(includedStrand2.getName());
-        ftItem.setItemProperties(ftProps);
-        ftItem.setFieldTest(true);
+        Item ftItem = new ItemBuilder(ftItemId)
+            .withStrand(includedStrand2.getName())
+            .withItemProperties(ftProps)
+            .withFieldTest(true)
+            .build();
 
         // This item will be included in the itemPoolIds list, but wont be factored into other calculations
-        Item excludedStrandItem = new Item(excludedStrandItemId);
-        excludedStrandItem.setItemProperties(excludedStrandItemProps);
-        excludedStrandItem.setStrand(excludedStrand.getName());       // This should be excluded from strand calculations
-        excludedStrandItem.setFieldTest(false);
+        Item excludedStrandItem = new ItemBuilder(excludedStrandItemId)
+            .withItemProperties(excludedStrandItemProps)
+            .withStrand(excludedStrand.getName())       // This should be excluded from strand calculations
+            .build();
 
         items.add(item1);
         items.add(item2);


### PR DESCRIPTION
This PR includes logic for selecting field test item group for a exam segment. 

The entrypoint for this code is the FieldTestServiceImpl.selectItemGroups() method, which is called by ExamSegmentServiceImpl.initializeExamSegments() [line 113 currently].

The selector implementation keeps a (thread safe and ordered) cached list for each segment, which is ordered by the number of group key usages (See EqualDistributionFieldTestItemGroupSelector.java). After updates to the counts are made, the list of group keys is resorted and the "least used" groups are placed at the front of the array list. This cache is flushed out daily, but ultimately should result in an approximately equal distribution of all field test item groups.

The purpose of the FieldTestServiceImpl.selectItemGroups() is to not only select the item groups that will be assigned to an exam, but also to calculate the position for the field test item groups in the exam (based on data in the itembank.tblsetofadminsubjects table). Much of the data that was being stored in the legacy ft_opportunityitem table has been scrapped, as it existed for debug and auditing purpose and was never read from again in the application.

Some minor updates to TDS_AssessmentService will accompany this PR.