### PR TITLE
Status transition validator util and test coverage. ExamService.pause…

### DIFF
--- a/client/src/main/java/tds/exam/ExamStatusCode.java
+++ b/client/src/main/java/tds/exam/ExamStatusCode.java
@@ -12,8 +12,14 @@ public class ExamStatusCode {
     public static final String STATUS_DENIED = "denied";
     public static final String STATUS_COMPLETED = "completed";
     public static final String STATUS_SCORED = "scored";
-    public static final String STAUTS_SEGMENT_ENTRY = "segmentEntry";
+    public static final String STATUS_SEGMENT_ENTRY = "segmentEntry";
     public static final String STATUS_SEGMENT_EXIT = "segmentExit";
+    public static final String STATUS_FORCE_COMPLETED = "forceCompleted";
+    public static final String STATUS_INVALIDATED = "invalidated";
+    public static final String STATUS_EXPIRED = "expired";
+    public static final String STATUS_SUBMITTED = "submitted";
+    public static final String STATUS_RESCORED = "rescored";
+    public static final String STATUS_REPORTED = "reported";
     public static final String STATUS_CLOSED = "closed";
     public static final String STATUS_DISABLED = "disabled";
 

--- a/service/src/main/java/tds/exam/services/ExamService.java
+++ b/service/src/main/java/tds/exam/services/ExamService.java
@@ -10,6 +10,7 @@ import tds.exam.ApprovalRequest;
 import tds.exam.Exam;
 import tds.exam.ExamApproval;
 import tds.exam.ExamConfiguration;
+import tds.exam.ExamStatusCode;
 import tds.exam.OpenExamRequest;
 import tds.session.Session;
 
@@ -64,13 +65,25 @@ public interface ExamService {
     Optional<Double> getInitialAbility(Exam exam, Assessment assessment);
 
     /**
-     * Change the {@link tds.exam.Exam}'s status to paused.
+     * Change the {@link tds.exam.Exam}'s status to a new status.
      *
-     * @param examId The id of the exam whose status is being changed
+     * @param examId             The id of the exam whose status is being changed
+     * @param newStatus          The {@link tds.exam.ExamStatusCode} to transition to
+     * @param statusChangeReason The reason why the {@link tds.exam.Exam} status is being updated
      * @return {@code Optional<ValidationError>} if the {@link tds.exam.Exam} cannot be updated from its current status
      * to the new status; otherwise {@code Optional.empty()}.\
      */
-    Optional<ValidationError> pauseExam(UUID examId);
+    Optional<ValidationError> updateExamStatus(UUID examId, ExamStatusCode newStatus, String statusChangeReason);
+
+    /**
+     * Change the {@link tds.exam.Exam}'s status to a new status.
+     *
+     * @param examId    The id of the exam whose status is being changed
+     * @param newStatus The {@link tds.exam.ExamStatusCode} to transition to
+     * @return {@code Optional<ValidationError>} if the {@link tds.exam.Exam} cannot be updated from its current status
+     * to the new status; otherwise {@code Optional.empty()}.\
+     */
+    Optional<ValidationError> updateExamStatus(UUID examId, ExamStatusCode newStatus);
 
     /**
      * Update the status of all {@link tds.exam.Exam}s in the specified {@link tds.session.Session} to "paused"

--- a/service/src/main/java/tds/exam/services/impl/ExamServiceImpl.java
+++ b/service/src/main/java/tds/exam/services/impl/ExamServiceImpl.java
@@ -259,7 +259,7 @@ class ExamServiceImpl implements ExamService {
 
         if (!StatusTransitionValidator.isValidTransition(exam.getStatus().getCode(), newStatus.getCode())) {
             return Optional.of(new ValidationError(ValidationErrorCode.EXAM_STATUS_TRANSITION_FAILURE,
-                String.format("Bad status transition from %s to %s", exam.getStatus().getCode(), newStatus.getCode())));
+                String.format("Transitioning exam status from %s to %s is not allowed", exam.getStatus().getCode(), newStatus.getCode())));
         }
 
         Exam updatedExam = new Exam.Builder()

--- a/service/src/main/java/tds/exam/services/impl/ExamServiceImpl.java
+++ b/service/src/main/java/tds/exam/services/impl/ExamServiceImpl.java
@@ -47,6 +47,7 @@ import tds.exam.services.ExamService;
 import tds.exam.services.SessionService;
 import tds.exam.services.StudentService;
 import tds.exam.services.TimeLimitConfigurationService;
+import tds.exam.utils.StatusTransitionValidator;
 import tds.session.ExternalSessionConfiguration;
 import tds.session.Session;
 import tds.student.RtsStudentPackageAttribute;
@@ -247,22 +248,27 @@ class ExamServiceImpl implements ExamService {
     }
 
     @Override
-    public Optional<ValidationError> pauseExam(UUID examId) {
+    public Optional<ValidationError> updateExamStatus(UUID examId, ExamStatusCode newStatus) {
+        return updateExamStatus(examId, newStatus, null);
+    }
+
+    @Override
+    public Optional<ValidationError> updateExamStatus(UUID examId, ExamStatusCode newStatus, String statusChangeReason) {
         Exam exam = examQueryRepository.getExamById(examId)
             .orElseThrow(() -> new NotFoundException(String.format("Exam could not be found for id %s", examId)));
 
-        if (!statusesThatCanTransitionToPaused.contains(exam.getStatus().getCode())) {
+        if (!StatusTransitionValidator.isValidTransition(exam.getStatus().getCode(), newStatus.getCode())) {
             return Optional.of(new ValidationError(ValidationErrorCode.EXAM_STATUS_TRANSITION_FAILURE,
-                String.format("Bad status transition from %s to %s", exam.getStatus().getCode(), ExamStatusCode.STATUS_PAUSED)));
+                String.format("Bad status transition from %s to %s", exam.getStatus().getCode(), newStatus.getCode())));
         }
 
-        // A status change reason is not required for pausing an exam.
-        Exam pausedExam = new Exam.Builder()
+        Exam updatedExam = new Exam.Builder()
             .fromExam(exam)
-            .withStatus(new ExamStatusCode(ExamStatusCode.STATUS_PAUSED, ExamStatusStage.INACTIVE), org.joda.time.Instant.now())
+            .withStatus(newStatus, org.joda.time.Instant.now())
+            .withStatusChangeReason(statusChangeReason)
             .build();
 
-        examCommandRepository.update(pausedExam);
+        examCommandRepository.update(updatedExam);
 
         return Optional.empty();
     }

--- a/service/src/main/java/tds/exam/utils/StatusTransitionValidator.java
+++ b/service/src/main/java/tds/exam/utils/StatusTransitionValidator.java
@@ -1,6 +1,7 @@
 package tds.exam.utils;
 
 import com.google.common.collect.ImmutableMap;
+import com.google.common.collect.Sets;
 
 import java.util.Arrays;
 import java.util.HashSet;
@@ -13,9 +14,13 @@ import tds.exam.ExamStatusCode;
  * A utility class for validating transitions between various exam states
  */
 public class StatusTransitionValidator {
+    // Create private constructor to ensure this class is never instantiated
+    private StatusTransitionValidator() {}
+
     // Build a map of current states -> valid next states
+    /* This logic is contained in the legacy application in CommonDLL._IsValidStatusTransition_FN() */
     private static final Map<String, Set<String>> stateMap = ImmutableMap.<String, Set<String>>builder()
-        .put(ExamStatusCode.STATUS_PENDING, new HashSet<>(Arrays.asList(
+        .put(ExamStatusCode.STATUS_PENDING, Sets.newHashSet(
             ExamStatusCode.STATUS_INITIALIZING,
             ExamStatusCode.STATUS_PENDING,
             ExamStatusCode.STATUS_DENIED,
@@ -24,8 +29,8 @@ public class StatusTransitionValidator {
             ExamStatusCode.STATUS_EXPIRED,
             ExamStatusCode.STATUS_INVALIDATED,
             ExamStatusCode.STATUS_FORCE_COMPLETED
-        )))
-        .put(ExamStatusCode.STATUS_SUSPENDED, new HashSet<>(Arrays.asList(
+        ))
+        .put(ExamStatusCode.STATUS_SUSPENDED, Sets.newHashSet(
             ExamStatusCode.STATUS_SUSPENDED,
             ExamStatusCode.STATUS_DENIED,
             ExamStatusCode.STATUS_APPROVED,
@@ -33,8 +38,8 @@ public class StatusTransitionValidator {
             ExamStatusCode.STATUS_EXPIRED,
             ExamStatusCode.STATUS_INVALIDATED,
             ExamStatusCode.STATUS_FORCE_COMPLETED
-        )))
-        .put(ExamStatusCode.STATUS_STARTED, new HashSet<>(Arrays.asList(
+        ))
+        .put(ExamStatusCode.STATUS_STARTED, Sets.newHashSet(
             ExamStatusCode.STATUS_STARTED,
             ExamStatusCode.STATUS_PAUSED,
             ExamStatusCode.STATUS_REVIEW,
@@ -44,8 +49,8 @@ public class StatusTransitionValidator {
             ExamStatusCode.STATUS_SEGMENT_ENTRY,
             ExamStatusCode.STATUS_SEGMENT_EXIT,
             ExamStatusCode.STATUS_FORCE_COMPLETED
-        )))
-        .put(ExamStatusCode.STATUS_APPROVED, new HashSet<>(Arrays.asList(
+        ))
+        .put(ExamStatusCode.STATUS_APPROVED, Sets.newHashSet(
             ExamStatusCode.STATUS_APPROVED,
             ExamStatusCode.STATUS_PENDING,
             ExamStatusCode.STATUS_STARTED,
@@ -53,8 +58,8 @@ public class StatusTransitionValidator {
             ExamStatusCode.STATUS_EXPIRED,
             ExamStatusCode.STATUS_INVALIDATED,
             ExamStatusCode.STATUS_FORCE_COMPLETED
-        )))
-        .put(ExamStatusCode.STATUS_REVIEW, new HashSet<>(Arrays.asList(
+        ))
+        .put(ExamStatusCode.STATUS_REVIEW, Sets.newHashSet(
             ExamStatusCode.STATUS_REVIEW,
             ExamStatusCode.STATUS_COMPLETED,
             ExamStatusCode.STATUS_PAUSED,
@@ -63,16 +68,16 @@ public class StatusTransitionValidator {
             ExamStatusCode.STATUS_FORCE_COMPLETED,
             ExamStatusCode.STATUS_SEGMENT_ENTRY,
             ExamStatusCode.STATUS_SEGMENT_EXIT
-        )))
-        .put(ExamStatusCode.STATUS_PAUSED, new HashSet<>(Arrays.asList(
+        ))
+        .put(ExamStatusCode.STATUS_PAUSED, Sets.newHashSet(
             ExamStatusCode.STATUS_PAUSED,
             ExamStatusCode.STATUS_PENDING,
             ExamStatusCode.STATUS_SUSPENDED,
             ExamStatusCode.STATUS_EXPIRED,
             ExamStatusCode.STATUS_INVALIDATED,
             ExamStatusCode.STATUS_FORCE_COMPLETED
-        )))
-        .put(ExamStatusCode.STATUS_DENIED, new HashSet<>(Arrays.asList(
+        ))
+        .put(ExamStatusCode.STATUS_DENIED, Sets.newHashSet(
             ExamStatusCode.STATUS_DENIED,
             ExamStatusCode.STATUS_PENDING,
             ExamStatusCode.STATUS_SUSPENDED,
@@ -80,57 +85,57 @@ public class StatusTransitionValidator {
             ExamStatusCode.STATUS_EXPIRED,
             ExamStatusCode.STATUS_INVALIDATED,
             ExamStatusCode.STATUS_FORCE_COMPLETED
-        )))
-        .put(ExamStatusCode.STATUS_COMPLETED, new HashSet<>(Arrays.asList(
+        ))
+        .put(ExamStatusCode.STATUS_COMPLETED, Sets.newHashSet(
             ExamStatusCode.STATUS_COMPLETED,
             ExamStatusCode.STATUS_SCORED,
             ExamStatusCode.STATUS_SUBMITTED,
             ExamStatusCode.STATUS_INVALIDATED
-        )))
-        .put(ExamStatusCode.STATUS_SCORED, new HashSet<>(Arrays.asList(
+        ))
+        .put(ExamStatusCode.STATUS_SCORED, Sets.newHashSet(
             ExamStatusCode.STATUS_RESCORED,
             ExamStatusCode.STATUS_SUBMITTED,
             ExamStatusCode.STATUS_INVALIDATED
-        )))
-        .put(ExamStatusCode.STATUS_SUBMITTED, new HashSet<>(Arrays.asList(
+        ))
+        .put(ExamStatusCode.STATUS_SUBMITTED, Sets.newHashSet(
             ExamStatusCode.STATUS_RESCORED,
             ExamStatusCode.STATUS_REPORTED,
             ExamStatusCode.STATUS_INVALIDATED
-        )))
-        .put(ExamStatusCode.STATUS_REPORTED, new HashSet<>(Arrays.asList(
+        ))
+        .put(ExamStatusCode.STATUS_REPORTED, Sets.newHashSet(
             ExamStatusCode.STATUS_RESCORED,
             ExamStatusCode.STATUS_INVALIDATED
-        )))
-        .put(ExamStatusCode.STATUS_EXPIRED, new HashSet<>(Arrays.asList(
+        ))
+        .put(ExamStatusCode.STATUS_EXPIRED, Sets.newHashSet(
             ExamStatusCode.STATUS_RESCORED,
             ExamStatusCode.STATUS_INVALIDATED
-        )))
-        .put(ExamStatusCode.STATUS_INVALIDATED, new HashSet<>(Arrays.asList(
+        ))
+        .put(ExamStatusCode.STATUS_INVALIDATED, Sets.newHashSet(
             ExamStatusCode.STATUS_RESCORED,
             ExamStatusCode.STATUS_INVALIDATED
-        )))
-        .put(ExamStatusCode.STATUS_RESCORED, new HashSet<>(Arrays.asList(
+        ))
+        .put(ExamStatusCode.STATUS_RESCORED, Sets.newHashSet(
             ExamStatusCode.STATUS_SCORED
-        )))
-        .put(ExamStatusCode.STATUS_SEGMENT_ENTRY, new HashSet<>(Arrays.asList(
+        ))
+        .put(ExamStatusCode.STATUS_SEGMENT_ENTRY, Sets.newHashSet(
             ExamStatusCode.STATUS_APPROVED,
             ExamStatusCode.STATUS_DENIED,
             ExamStatusCode.STATUS_EXPIRED,
             ExamStatusCode.STATUS_INVALIDATED,
             ExamStatusCode.STATUS_FORCE_COMPLETED
-        )))
-        .put(ExamStatusCode.STATUS_SEGMENT_EXIT, new HashSet<>(Arrays.asList(
+        ))
+        .put(ExamStatusCode.STATUS_SEGMENT_EXIT, Sets.newHashSet(
             ExamStatusCode.STATUS_APPROVED,
             ExamStatusCode.STATUS_DENIED,
             ExamStatusCode.STATUS_EXPIRED,
             ExamStatusCode.STATUS_INVALIDATED,
             ExamStatusCode.STATUS_FORCE_COMPLETED
-        )))
-        .put(ExamStatusCode.STATUS_FORCE_COMPLETED, new HashSet<>(Arrays.asList(
+        ))
+        .put(ExamStatusCode.STATUS_FORCE_COMPLETED, Sets.newHashSet(
             ExamStatusCode.STATUS_COMPLETED,
             ExamStatusCode.STATUS_SCORED
-        )))
-        .put(ExamStatusCode.STATUS_INITIALIZING, new HashSet<>(Arrays.asList(
+        ))
+        .put(ExamStatusCode.STATUS_INITIALIZING, Sets.newHashSet(
             ExamStatusCode.STATUS_INITIALIZING,
             ExamStatusCode.STATUS_PENDING,
             ExamStatusCode.STATUS_DENIED,
@@ -139,7 +144,7 @@ public class StatusTransitionValidator {
             ExamStatusCode.STATUS_EXPIRED,
             ExamStatusCode.STATUS_INVALIDATED,
             ExamStatusCode.STATUS_FORCE_COMPLETED
-        )))
+        ))
         .build();
 
     /**

--- a/service/src/main/java/tds/exam/utils/StatusTransitionValidator.java
+++ b/service/src/main/java/tds/exam/utils/StatusTransitionValidator.java
@@ -1,0 +1,155 @@
+package tds.exam.utils;
+
+import com.google.common.collect.ImmutableMap;
+
+import java.util.Arrays;
+import java.util.HashSet;
+import java.util.Map;
+import java.util.Set;
+
+import tds.exam.ExamStatusCode;
+
+/**
+ * A utility class for validating transitions between various exam states
+ */
+public class StatusTransitionValidator {
+    // Build a map of current states -> valid next states
+    private static final Map<String, Set<String>> stateMap = ImmutableMap.<String, Set<String>>builder()
+        .put(ExamStatusCode.STATUS_PENDING, new HashSet<>(Arrays.asList(
+            ExamStatusCode.STATUS_INITIALIZING,
+            ExamStatusCode.STATUS_PENDING,
+            ExamStatusCode.STATUS_DENIED,
+            ExamStatusCode.STATUS_APPROVED,
+            ExamStatusCode.STATUS_PAUSED,
+            ExamStatusCode.STATUS_EXPIRED,
+            ExamStatusCode.STATUS_INVALIDATED,
+            ExamStatusCode.STATUS_FORCE_COMPLETED
+        )))
+        .put(ExamStatusCode.STATUS_SUSPENDED, new HashSet<>(Arrays.asList(
+            ExamStatusCode.STATUS_SUSPENDED,
+            ExamStatusCode.STATUS_DENIED,
+            ExamStatusCode.STATUS_APPROVED,
+            ExamStatusCode.STATUS_PAUSED,
+            ExamStatusCode.STATUS_EXPIRED,
+            ExamStatusCode.STATUS_INVALIDATED,
+            ExamStatusCode.STATUS_FORCE_COMPLETED
+        )))
+        .put(ExamStatusCode.STATUS_STARTED, new HashSet<>(Arrays.asList(
+            ExamStatusCode.STATUS_STARTED,
+            ExamStatusCode.STATUS_PAUSED,
+            ExamStatusCode.STATUS_REVIEW,
+            ExamStatusCode.STATUS_COMPLETED,
+            ExamStatusCode.STATUS_EXPIRED,
+            ExamStatusCode.STATUS_INVALIDATED,
+            ExamStatusCode.STATUS_SEGMENT_ENTRY,
+            ExamStatusCode.STATUS_SEGMENT_EXIT,
+            ExamStatusCode.STATUS_FORCE_COMPLETED
+        )))
+        .put(ExamStatusCode.STATUS_APPROVED, new HashSet<>(Arrays.asList(
+            ExamStatusCode.STATUS_APPROVED,
+            ExamStatusCode.STATUS_PENDING,
+            ExamStatusCode.STATUS_STARTED,
+            ExamStatusCode.STATUS_PAUSED,
+            ExamStatusCode.STATUS_EXPIRED,
+            ExamStatusCode.STATUS_INVALIDATED,
+            ExamStatusCode.STATUS_FORCE_COMPLETED
+        )))
+        .put(ExamStatusCode.STATUS_REVIEW, new HashSet<>(Arrays.asList(
+            ExamStatusCode.STATUS_REVIEW,
+            ExamStatusCode.STATUS_COMPLETED,
+            ExamStatusCode.STATUS_PAUSED,
+            ExamStatusCode.STATUS_EXPIRED,
+            ExamStatusCode.STATUS_INVALIDATED,
+            ExamStatusCode.STATUS_FORCE_COMPLETED,
+            ExamStatusCode.STATUS_SEGMENT_ENTRY,
+            ExamStatusCode.STATUS_SEGMENT_EXIT
+        )))
+        .put(ExamStatusCode.STATUS_PAUSED, new HashSet<>(Arrays.asList(
+            ExamStatusCode.STATUS_PAUSED,
+            ExamStatusCode.STATUS_PENDING,
+            ExamStatusCode.STATUS_SUSPENDED,
+            ExamStatusCode.STATUS_EXPIRED,
+            ExamStatusCode.STATUS_INVALIDATED,
+            ExamStatusCode.STATUS_FORCE_COMPLETED
+        )))
+        .put(ExamStatusCode.STATUS_DENIED, new HashSet<>(Arrays.asList(
+            ExamStatusCode.STATUS_DENIED,
+            ExamStatusCode.STATUS_PENDING,
+            ExamStatusCode.STATUS_SUSPENDED,
+            ExamStatusCode.STATUS_PAUSED,
+            ExamStatusCode.STATUS_EXPIRED,
+            ExamStatusCode.STATUS_INVALIDATED,
+            ExamStatusCode.STATUS_FORCE_COMPLETED
+        )))
+        .put(ExamStatusCode.STATUS_COMPLETED, new HashSet<>(Arrays.asList(
+            ExamStatusCode.STATUS_COMPLETED,
+            ExamStatusCode.STATUS_SCORED,
+            ExamStatusCode.STATUS_SUBMITTED,
+            ExamStatusCode.STATUS_INVALIDATED
+        )))
+        .put(ExamStatusCode.STATUS_SCORED, new HashSet<>(Arrays.asList(
+            ExamStatusCode.STATUS_RESCORED,
+            ExamStatusCode.STATUS_SUBMITTED,
+            ExamStatusCode.STATUS_INVALIDATED
+        )))
+        .put(ExamStatusCode.STATUS_SUBMITTED, new HashSet<>(Arrays.asList(
+            ExamStatusCode.STATUS_RESCORED,
+            ExamStatusCode.STATUS_REPORTED,
+            ExamStatusCode.STATUS_INVALIDATED
+        )))
+        .put(ExamStatusCode.STATUS_REPORTED, new HashSet<>(Arrays.asList(
+            ExamStatusCode.STATUS_RESCORED,
+            ExamStatusCode.STATUS_INVALIDATED
+        )))
+        .put(ExamStatusCode.STATUS_EXPIRED, new HashSet<>(Arrays.asList(
+            ExamStatusCode.STATUS_RESCORED,
+            ExamStatusCode.STATUS_INVALIDATED
+        )))
+        .put(ExamStatusCode.STATUS_INVALIDATED, new HashSet<>(Arrays.asList(
+            ExamStatusCode.STATUS_RESCORED,
+            ExamStatusCode.STATUS_INVALIDATED
+        )))
+        .put(ExamStatusCode.STATUS_RESCORED, new HashSet<>(Arrays.asList(
+            ExamStatusCode.STATUS_SCORED
+        )))
+        .put(ExamStatusCode.STATUS_SEGMENT_ENTRY, new HashSet<>(Arrays.asList(
+            ExamStatusCode.STATUS_APPROVED,
+            ExamStatusCode.STATUS_DENIED,
+            ExamStatusCode.STATUS_EXPIRED,
+            ExamStatusCode.STATUS_INVALIDATED,
+            ExamStatusCode.STATUS_FORCE_COMPLETED
+        )))
+        .put(ExamStatusCode.STATUS_SEGMENT_EXIT, new HashSet<>(Arrays.asList(
+            ExamStatusCode.STATUS_APPROVED,
+            ExamStatusCode.STATUS_DENIED,
+            ExamStatusCode.STATUS_EXPIRED,
+            ExamStatusCode.STATUS_INVALIDATED,
+            ExamStatusCode.STATUS_FORCE_COMPLETED
+        )))
+        .put(ExamStatusCode.STATUS_FORCE_COMPLETED, new HashSet<>(Arrays.asList(
+            ExamStatusCode.STATUS_COMPLETED,
+            ExamStatusCode.STATUS_SCORED
+        )))
+        .put(ExamStatusCode.STATUS_INITIALIZING, new HashSet<>(Arrays.asList(
+            ExamStatusCode.STATUS_INITIALIZING,
+            ExamStatusCode.STATUS_PENDING,
+            ExamStatusCode.STATUS_DENIED,
+            ExamStatusCode.STATUS_APPROVED,
+            ExamStatusCode.STATUS_PAUSED,
+            ExamStatusCode.STATUS_EXPIRED,
+            ExamStatusCode.STATUS_INVALIDATED,
+            ExamStatusCode.STATUS_FORCE_COMPLETED
+        )))
+        .build();
+
+    /**
+     * Validates that an exam can transition between the currentStatus and newStatus
+     *
+     * @param currentStatus the status the exam is currently in
+     * @param newStatus     The status the exam is being transitioned to
+     * @return true if this a valid transition - false otherwise
+     */
+    public static boolean isValidTransition(String currentStatus, String newStatus) {
+        return stateMap.get(currentStatus) != null && stateMap.get(currentStatus).contains(newStatus);
+    }
+}

--- a/service/src/main/java/tds/exam/web/endpoints/ExamController.java
+++ b/service/src/main/java/tds/exam/web/endpoints/ExamController.java
@@ -25,6 +25,8 @@ import tds.exam.ApprovalRequest;
 import tds.exam.Exam;
 import tds.exam.ExamApproval;
 import tds.exam.ExamConfiguration;
+import tds.exam.ExamStatusCode;
+import tds.exam.ExamStatusStage;
 import tds.exam.OpenExamRequest;
 import tds.exam.services.ExamService;
 
@@ -92,7 +94,8 @@ public class ExamController {
 
     @RequestMapping(value = "/{examId}/pause", method = RequestMethod.PUT, produces = MediaType.APPLICATION_JSON_VALUE)
     ResponseEntity<NoContentResponseResource> pauseExam(@PathVariable final UUID examId) {
-        final Optional<ValidationError> maybeStatusTransitionFailure = examService.pauseExam(examId);
+        final Optional<ValidationError> maybeStatusTransitionFailure = examService.updateExamStatus(examId,
+            new ExamStatusCode(ExamStatusCode.STATUS_PAUSED, ExamStatusStage.INACTIVE));
 
         if (maybeStatusTransitionFailure.isPresent()) {
             NoContentResponseResource response = new NoContentResponseResource(maybeStatusTransitionFailure.get());

--- a/service/src/test/java/tds/exam/services/impl/ExamServiceImplTest.java
+++ b/service/src/test/java/tds/exam/services/impl/ExamServiceImplTest.java
@@ -1173,7 +1173,8 @@ public class ExamServiceImplTest {
         when(mockExamQueryRepository.getExamById(examId))
             .thenReturn(Optional.of(mockExam));
 
-        Optional<ValidationError> maybeStatusTransitionFailure = examService.pauseExam(examId);
+        Optional<ValidationError> maybeStatusTransitionFailure = examService.updateExamStatus(examId,
+            new ExamStatusCode(ExamStatusCode.STATUS_PAUSED, ExamStatusStage.INACTIVE));
 
         assertThat(maybeStatusTransitionFailure).isNotPresent();
     }
@@ -1189,7 +1190,8 @@ public class ExamServiceImplTest {
         when(mockExamQueryRepository.getExamById(examId))
             .thenReturn(Optional.of(mockExam));
 
-        Optional<ValidationError> maybeStatusTransitionFailure = examService.pauseExam(examId);
+        Optional<ValidationError> maybeStatusTransitionFailure = examService.updateExamStatus(examId,
+            new ExamStatusCode(ExamStatusCode.STATUS_PAUSED, ExamStatusStage.INACTIVE));
 
         assertThat(maybeStatusTransitionFailure).isPresent();
         ValidationError statusTransitionFailure = maybeStatusTransitionFailure.get();
@@ -1617,12 +1619,12 @@ public class ExamServiceImplTest {
     }
 
     @Test(expected = NotFoundException.class)
-    public void shouldThrowIllegalArgumentExceptionWhenPausingAnExamThatCannotBeFound() {
+    public void shouldThrowIllegalArgumentExceptionWhenUpdatingStatusOnAnExamThatCannotBeFound() {
         UUID examId = UUID.randomUUID();
 
         when(mockExamQueryRepository.getExamById(examId)).thenReturn(Optional.empty());
 
-        examService.pauseExam(examId);
+        examService.updateExamStatus(examId, new ExamStatusCode(ExamStatusCode.STATUS_FAILED, ExamStatusStage.CLOSED));
     }
 
     @Test

--- a/service/src/test/java/tds/exam/utils/StatusTransitionValidatorTest.java
+++ b/service/src/test/java/tds/exam/utils/StatusTransitionValidatorTest.java
@@ -1,0 +1,38 @@
+package tds.exam.utils;
+
+import org.junit.Test;
+
+import tds.exam.ExamStatusCode;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+public class StatusTransitionValidatorTest {
+
+    @Test
+    public void shouldReturnFalseForInvalidTransitionFromPausedToStarted() {
+        // cannot go straight from paused -> started
+        boolean isValid = StatusTransitionValidator.isValidTransition(ExamStatusCode.STATUS_PAUSED, ExamStatusCode.STATUS_STARTED);
+        assertThat(isValid).isFalse();
+    }
+
+    @Test
+    public void shouldReturnTrueForValidTransitionsFromPausedToStarted() {
+        // go from paused -> pending (approval) -> approved -> started
+        boolean isValid = StatusTransitionValidator.isValidTransition(ExamStatusCode.STATUS_PAUSED, ExamStatusCode.STATUS_PENDING);
+        assertThat(isValid).isTrue();
+        isValid = StatusTransitionValidator.isValidTransition(ExamStatusCode.STATUS_PENDING, ExamStatusCode.STATUS_APPROVED);
+        assertThat(isValid).isTrue();
+        isValid = StatusTransitionValidator.isValidTransition(ExamStatusCode.STATUS_APPROVED, ExamStatusCode.STATUS_STARTED);
+        assertThat(isValid).isTrue();
+    }
+
+    @Test
+    public void shouldReturnFalseForTryingToStartDeniedExam() {
+        boolean isValid = StatusTransitionValidator.isValidTransition(ExamStatusCode.STATUS_PAUSED, ExamStatusCode.STATUS_PENDING);
+        assertThat(isValid).isTrue();
+        isValid = StatusTransitionValidator.isValidTransition(ExamStatusCode.STATUS_PENDING, ExamStatusCode.STATUS_DENIED);
+        assertThat(isValid).isTrue();
+        isValid = StatusTransitionValidator.isValidTransition(ExamStatusCode.STATUS_DENIED, ExamStatusCode.STATUS_STARTED);
+        assertThat(isValid).isFalse();
+    }
+}

--- a/service/src/test/java/tds/exam/web/endpoints/ExamControllerIntegrationTests.java
+++ b/service/src/test/java/tds/exam/web/endpoints/ExamControllerIntegrationTests.java
@@ -17,6 +17,8 @@ import java.util.UUID;
 import tds.common.ValidationError;
 import tds.common.web.advice.ExceptionAdvice;
 import tds.exam.Exam;
+import tds.exam.ExamStatusCode;
+import tds.exam.ExamStatusStage;
 import tds.exam.builder.ExamBuilder;
 import tds.exam.error.ValidationErrorCode;
 import tds.exam.services.ExamService;
@@ -73,21 +75,23 @@ public class ExamControllerIntegrationTests {
     public void shouldPauseAnExam() throws Exception {
         UUID examId = UUID.randomUUID();
 
-        when(mockExamService.pauseExam(examId)).thenReturn(Optional.empty());
+        when(mockExamService.updateExamStatus(examId,
+            new ExamStatusCode(ExamStatusCode.STATUS_PAUSED, ExamStatusStage.INACTIVE))).thenReturn(Optional.empty());
 
         http.perform(put(new URI(String.format("/exam/%s/pause", examId)))
             .contentType(MediaType.APPLICATION_JSON))
             .andExpect(status().isNoContent())
             .andExpect(header().string("Location", String.format("http://localhost/exam/%s", examId)));
 
-        verify(mockExamService).pauseExam(examId);
+        verify(mockExamService).updateExamStatus(examId,
+            new ExamStatusCode(ExamStatusCode.STATUS_PAUSED, ExamStatusStage.INACTIVE));
     }
 
     @Test
     public void shouldReturnAnErrorWhenAttemptingToPauseAnExamInAnInvalidTransitionState() throws Exception {
         UUID examId = UUID.randomUUID();
 
-        when(mockExamService.pauseExam(examId))
+        when(mockExamService.updateExamStatus(examId, new ExamStatusCode(ExamStatusCode.STATUS_PAUSED, ExamStatusStage.INACTIVE)))
             .thenReturn(Optional.of(new ValidationError(ValidationErrorCode.EXAM_STATUS_TRANSITION_FAILURE, "Bad transition from foo to bar")));
 
         http.perform(put(new URI(String.format("/exam/%s/pause", examId)))

--- a/service/src/test/java/tds/exam/web/endpoints/ExamControllerTest.java
+++ b/service/src/test/java/tds/exam/web/endpoints/ExamControllerTest.java
@@ -191,11 +191,11 @@ public class ExamControllerTest {
     public void shouldPauseAnExam() throws Exception {
         UUID examId = UUID.randomUUID();
 
-        when(mockExamService.pauseExam(examId)).thenReturn(Optional.empty());
+        when(mockExamService.updateExamStatus(examId, new ExamStatusCode(ExamStatusCode.STATUS_PAUSED, ExamStatusStage.INACTIVE))).thenReturn(Optional.empty());
 
         ResponseEntity<?> response = controller.pauseExam(examId);
 
-        verify(mockExamService).pauseExam(examId);
+        verify(mockExamService).updateExamStatus(examId, new ExamStatusCode(ExamStatusCode.STATUS_PAUSED, ExamStatusStage.INACTIVE));
 
         assertThat(response.getStatusCode()).isEqualTo(HttpStatus.NO_CONTENT);
         assertThat(response.getHeaders()).hasSize(1);
@@ -204,15 +204,15 @@ public class ExamControllerTest {
     }
 
     @Test
-    public void shouldNotPauseAnExam() {
+    public void shouldNotUpdateAnExamStatus() {
         UUID examId = UUID.randomUUID();
 
-        when(mockExamService.pauseExam(examId))
+        when(mockExamService.updateExamStatus(examId, new ExamStatusCode(ExamStatusCode.STATUS_PAUSED, ExamStatusStage.INACTIVE)))
             .thenReturn(Optional.of(new ValidationError(ValidationErrorCode.EXAM_STATUS_TRANSITION_FAILURE, "Bad transition from foo to bar")));
 
         ResponseEntity<NoContentResponseResource> response = controller.pauseExam(examId);
 
-        verify(mockExamService).pauseExam(examId);
+        verify(mockExamService).updateExamStatus(examId, new ExamStatusCode(ExamStatusCode.STATUS_PAUSED, ExamStatusStage.INACTIVE));
 
         assertThat(response.getStatusCode()).isEqualTo(HttpStatus.UNPROCESSABLE_ENTITY);
         assertThat(response.getBody().getErrors()).hasSize(1);


### PR DESCRIPTION
Created a new StatusTransitionValidator utility class for managing the validation of exam state/status changes. Most of this class is composed of a static immutable map that maps currentStatus -> set of valid next statuses. In ExamService, pauseExam() has been renamed and made more generic.

I included some test coverage for the validator, but I did not create tests for every possible test case as there are hundreds.

The mappings in the legacy application are contained within **CommonDLL._IsValidStatusTransition_FN() - Line 465** in a very large case statement. 