### PR TITLE
Feature/field test select items - item "cohort" code

### DIFF
--- a/service/src/main/java/tds/exam/services/impl/FieldTestServiceImpl.java
+++ b/service/src/main/java/tds/exam/services/impl/FieldTestServiceImpl.java
@@ -127,7 +127,7 @@ public class FieldTestServiceImpl implements FieldTestService {
             the count of **field test** items in the group, while cohortItemCount is the total number of items (including
             BOTH field test and non-field test items) in the group.
          */
-        int cohortItemCount = 0;
+        int itemCount = 0;
         // Group all items in this assessment and for this language by groupKey
         Map<String, List<Item>> groupItems = currentSegment.getItems(exam.getLanguageCode()).stream()
             .collect(Collectors.groupingBy(Item::getGroupKey));
@@ -141,7 +141,7 @@ public class FieldTestServiceImpl implements FieldTestService {
          as many items as are necessary. In legacy code, every possible field test item group (sorted by least used) is returned */
         for (FieldTestItemGroup fieldTestItemGroup : selectedFieldTestItemGroups) {
             // Get counts of all items for the item group, field test or not
-            int cohortGroupCount = groupItems.containsKey(fieldTestItemGroup.getGroupKey())
+            int groupCount = groupItems.containsKey(fieldTestItemGroup.getGroupKey())
                 ? groupItems.get(fieldTestItemGroup.getGroupKey()).size() : 0;
 
             /* Skip [3248-3274] - This code is just selecting a single item group that is unassigned and not frequently used
@@ -152,7 +152,7 @@ public class FieldTestServiceImpl implements FieldTestService {
             // Skip this group if the cohortItemCount is greater than or equal to the maximum number of field test items for this segment
             // Ultimately we want to make sure that there aren't more items (including non-ft items) in the group
             // than what will fit into the exam.
-            if (cohortGroupCount == 0 || cohortItemCount >= maxItems) {
+            if (groupCount == 0 || itemCount >= maxItems) {
                 /* This break corresponds to [3301-3305] - instead of "continuing" the selection loop, we can just break out and stop selecting.
                 *  The legacy app simply continues to loop unnecessarily. At this point, cohortItemCount and maxItems will never change. */
                 break;
@@ -186,7 +186,7 @@ public class FieldTestServiceImpl implements FieldTestService {
                         .build()
                 );
 
-                cohortItemCount += cohortGroupCount;
+                itemCount += groupCount;
             }
         }
 

--- a/service/src/main/java/tds/exam/services/impl/FieldTestServiceImpl.java
+++ b/service/src/main/java/tds/exam/services/impl/FieldTestServiceImpl.java
@@ -149,15 +149,14 @@ public class FieldTestServiceImpl implements FieldTestService {
               Skip [3276-3285] - debug code */
             int ftItemCount = fieldTestItemGroup.getItemCount();
 
-            // Skip this group if the cohortItemCount is greater than or equal to the maximum number of items
+            // Skip this group if the cohortItemCount is greater than or equal to the maximum number of field test items for this segment
             // Ultimately we want to make sure that there aren't more items (including non-ft items) in the group
             // than what will fit into the exam.
             if (cohortGroupCount == 0 || cohortItemCount >= maxItems) {
-                continue;
-            }
-
-            /* [3307] */
-            if (ftItemCount > 0 && totalFtItemCount + ftItemCount <= maxItems) {
+                /* This break corresponds to [3301-3305] - instead of "continuing" the selection loop, we can just break out and stop selecting.
+                *  The legacy app simply continues to loop unnecessarily. At this point, cohortItemCount and maxItems will never change. */
+                break;
+            } else if (ftItemCount > 0 && totalFtItemCount + ftItemCount <= maxItems) { /* [3307] */
                 /* [3308 - 3314] */
                 int thisIntSize = ftItemCount == 1 ? 1 : intervalSize * (ftItemCount - 1);
 

--- a/service/src/main/java/tds/exam/services/impl/FieldTestServiceImpl.java
+++ b/service/src/main/java/tds/exam/services/impl/FieldTestServiceImpl.java
@@ -141,8 +141,7 @@ public class FieldTestServiceImpl implements FieldTestService {
          as many items as are necessary. In legacy code, every possible field test item group (sorted by least used) is returned */
         for (FieldTestItemGroup fieldTestItemGroup : selectedFieldTestItemGroups) {
             // Get counts of all items for the item group, field test or not
-            int groupCount = groupItems.containsKey(fieldTestItemGroup.getGroupKey())
-                ? groupItems.get(fieldTestItemGroup.getGroupKey()).size() : 0;
+            int groupCount = groupItems.get(fieldTestItemGroup.getGroupKey()).size();
 
             /* Skip [3248-3274] - This code is just selecting a single item group that is unassigned and not frequently used
               (as sorted by FT_Prioritize_2012())
@@ -152,7 +151,7 @@ public class FieldTestServiceImpl implements FieldTestService {
             // Skip this group if the cohortItemCount is greater than or equal to the maximum number of field test items for this segment
             // Ultimately we want to make sure that there aren't more items (including non-ft items) in the group
             // than what will fit into the exam.
-            if (groupCount == 0 || itemCount >= maxItems) {
+            if (itemCount >= maxItems) {
                 /* This break corresponds to [3301-3305] - instead of "continuing" the selection loop, we can just break out and stop selecting.
                 *  The legacy app simply continues to loop unnecessarily. At this point, cohortItemCount and maxItems will never change. */
                 break;

--- a/service/src/test/java/tds/exam/builder/FieldTestItemGroupBuilder.java
+++ b/service/src/test/java/tds/exam/builder/FieldTestItemGroupBuilder.java
@@ -11,7 +11,7 @@ public class FieldTestItemGroupBuilder {
     private String blockId = "A";
     private String languageCode = "ENU";
     private UUID examId = UUID.randomUUID();
-    private int numItems = 1;
+    private int itemCount = 1;
     private String segmentKey = "segment-key";
 
     public FieldTestItemGroupBuilder(String groupKey) {
@@ -25,7 +25,7 @@ public class FieldTestItemGroupBuilder {
             .withBlockId(blockId)
             .withExamId(examId)
             .withLanguageCode(languageCode)
-            .withItemCount(numItems)
+            .withItemCount(itemCount)
             .withSegmentKey(segmentKey)
             .build();
     }
@@ -40,8 +40,8 @@ public class FieldTestItemGroupBuilder {
         return this;
     }
 
-    public FieldTestItemGroupBuilder withNumItems(int numItems) {
-        this.numItems = numItems;
+    public FieldTestItemGroupBuilder withItemCount(int itemCount) {
+        this.itemCount = itemCount;
         return this;
     }
 

--- a/service/src/test/java/tds/exam/builder/SegmentBuilder.java
+++ b/service/src/test/java/tds/exam/builder/SegmentBuilder.java
@@ -5,6 +5,7 @@ import java.util.List;
 
 import tds.assessment.Algorithm;
 import tds.assessment.Form;
+import tds.assessment.Item;
 import tds.assessment.Segment;
 
 public class SegmentBuilder {
@@ -17,6 +18,7 @@ public class SegmentBuilder {
     private int maxItems = 10;
     private int position;
     private List<Form> forms = new ArrayList<>();
+    private List<Item> items = new ArrayList<>();
     private Integer fieldTestStartPosition = 3;
     private Integer fieldTestEndPosition = 10;
     private int fieldTestMaxItems = 4;
@@ -31,6 +33,7 @@ public class SegmentBuilder {
         segment.setMaxItems(maxItems);
         segment.setPosition(position);
         segment.setForms(forms);
+        segment.setItems(items);
         segment.setFieldTestMaxItems(fieldTestMaxItems);
         segment.setFieldTestMinItems(fieldTestMinItems);
         segment.setFieldTestEndPosition(fieldTestEndPosition);
@@ -70,6 +73,11 @@ public class SegmentBuilder {
 
     public SegmentBuilder withMaxItems(int maxItems) {
         this.maxItems = maxItems;
+        return this;
+    }
+
+    public SegmentBuilder withItems(List<Item> items) {
+        this.items = items;
         return this;
     }
 

--- a/service/src/test/java/tds/exam/services/impl/FieldTestServiceImplTest.java
+++ b/service/src/test/java/tds/exam/services/impl/FieldTestServiceImplTest.java
@@ -329,7 +329,7 @@ public class FieldTestServiceImplTest {
             .build();
         FieldTestItemGroup ftItemGroup1 = new FieldTestItemGroupBuilder("group-key-1")
             .withGroupId("group-id-1")
-            .withNumItems(1)
+            .withItemCount(1)
             .withExamId(exam.getId())
             .withSegmentKey(segment.getKey())
             .build();
@@ -337,20 +337,20 @@ public class FieldTestServiceImplTest {
             .withGroupId("group-id-2")
             .withExamId(exam.getId())
             .withSegmentKey(segment.getKey())
-            .withNumItems(1)
+            .withItemCount(1)
             .build();
         FieldTestItemGroup ftItemGroup3 = new FieldTestItemGroupBuilder("group-key-3")
             .withGroupId("group-id-3")
             .withExamId(exam.getId())
             .withSegmentKey(segment.getKey())
-            .withNumItems(1)
+            .withItemCount(1)
             .build();
         // This field test item group should be excluded (it is already selected for this exam)s
         FieldTestItemGroup ftItemGroup4 = new FieldTestItemGroupBuilder("group-key-4")
             .withGroupId("group-id-4")
             .withExamId(exam.getId())
             .withSegmentKey(segment.getKey())
-            .withNumItems(1)
+            .withItemCount(1)
             .build();
 
         when(mockFieldTestItemGroupQueryRepository.find(exam.getId(), segment.getKey()))
@@ -426,13 +426,13 @@ public class FieldTestServiceImplTest {
             .withGroupId("group-id-1")
             .withExamId(exam.getId())
             .withSegmentKey(segment.getKey())
-            .withNumItems(3)
+            .withItemCount(3)
             .build();
         FieldTestItemGroup ftItemGroup2 = new FieldTestItemGroupBuilder("group-key-2")
             .withGroupId("group-id-2")
             .withExamId(exam.getId())
             .withSegmentKey(segment.getKey())
-            .withNumItems(1)
+            .withItemCount(1)
             .build();
 
         when(mockFieldTestItemGroupQueryRepository.find(exam.getId(), segment.getKey()))
@@ -476,6 +476,72 @@ public class FieldTestServiceImplTest {
     }
 
     @Test
+    public void shouldSkipFirstGroupDueToTooManyItemsInGroup() {
+        Exam exam = new ExamBuilder().build();
+        final String assessmentKey = "assessment-key123";
+        // Four total items in item group (3 FT)
+        Item item1G1 = new ItemBuilder("item1group1")
+            .withGroupKey("group-key-1")
+            .withItemProperties(Arrays.asList(new ItemProperty("Language", "ENU")))
+            .build();
+        Item item2G1 = new ItemBuilder("item2group1")
+            .withGroupKey("group-key-1")
+            .withItemProperties(Arrays.asList(new ItemProperty("Language", "ENU")))
+            .build();
+        Item item3G1 = new ItemBuilder("item3group1")
+            .withGroupKey("group-key-1")
+            .withItemProperties(Arrays.asList(new ItemProperty("Language", "ENU")))
+            .build();
+        Item nonFieldTestItemG1 = new ItemBuilder("nonFtItem-group1")
+            .withGroupKey("group-key-1")
+            .withItemProperties(Arrays.asList(new ItemProperty("Language", "ENU")))
+            .build();
+        // One (FT) item in second group
+        Item item1G2 = new ItemBuilder("item1group2")
+            .withGroupKey("group-key-2")
+            .withItemProperties(Arrays.asList(new ItemProperty("Language", "ENU")))
+            .build();
+        Segment segment = new SegmentBuilder()
+            .withAssessmentKey(assessmentKey)
+            .withItems(Arrays.asList(item1G1, item2G1, item3G1, item1G2))
+            .withItems(Arrays.asList(item1G1, item2G1, item3G1, item1G2, nonFieldTestItemG1))
+            .withFieldTestStartPosition(3)
+            .withFieldTestEndPosition(7)
+            .withFieldTestMinItems(4)
+            .withSelectionAlgorithm(Algorithm.ADAPTIVE_2)
+            .withFieldTestMaxItems(4)
+            .build();
+        Assessment assessment = new AssessmentBuilder()
+            .withSegments(Arrays.asList(segment))
+            .build();
+        FieldTestItemGroup ftItemGroup1 = new FieldTestItemGroupBuilder("group-key-1")
+            .withGroupId("group-id-1")
+            .withItemCount(3)
+            .withExamId(exam.getId())
+            .withSegmentKey(segment.getKey())
+            .build();
+        FieldTestItemGroup ftItemGroup2 = new FieldTestItemGroupBuilder("group-key-2")
+            .withGroupId("group-id-2")
+            .withItemCount(1)
+            .withExamId(exam.getId())
+            .withSegmentKey(segment.getKey())
+            .build();
+        when(mockFieldTestItemGroupQueryRepository.find(exam.getId(), segment.getKey())).thenReturn(new ArrayList<>());
+        when(mockFieldTestItemGroupSelector.selectLeastUsedItemGroups(eq(exam), any(),
+            any(), eq(segment), eq(segment.getFieldTestMinItems())))
+            .thenReturn(Arrays.asList(ftItemGroup1, ftItemGroup2));
+        int totalItems = fieldTestService.selectItemGroups(exam, assessment, segment.getKey());
+        verify(mockFieldTestItemGroupQueryRepository).find(exam.getId(), segment.getKey());
+        verify(mockFieldTestItemGroupCommandRepository).insert(fieldTestItemGroupInsertCaptor.capture());
+        verify(mockFieldTestItemGroupSelector).selectLeastUsedItemGroups(eq(exam), any(),
+            eq(assessment), eq(segment), eq(segment.getFieldTestMinItems()));
+
+        List<FieldTestItemGroup> insertedItemGroups = fieldTestItemGroupInsertCaptor.getValue();
+
+        assertThat(insertedItemGroups).containsExactly(ftItemGroup2);
+    }
+
+    @Test
     public void shouldSelectAndInsertFieldTestItemGroupsMultiItems() {
         Exam exam = new ExamBuilder().build();
         final String assessmentKey = "assessment-key123";
@@ -491,10 +557,6 @@ public class FieldTestServiceImplTest {
             .withGroupKey("group-key-1")
             .withItemProperties(Arrays.asList(new ItemProperty("Language", "ENU")))
             .build();
-//        Item nonFieldTestItemG1 = new ItemBuilder("nonFtItem-group1")
-//            .withGroupKey("group-key-1")
-//            .withItemProperties(Arrays.asList(new ItemProperty("Language", "ENU")))
-//            .build();
         Item item1G2 = new ItemBuilder("item1group2")
             .withGroupKey("group-key-2")
             .withItemProperties(Arrays.asList(new ItemProperty("Language", "ENU")))
@@ -502,7 +564,7 @@ public class FieldTestServiceImplTest {
         Segment segment = new SegmentBuilder()
             .withAssessmentKey(assessmentKey)
             .withItems(Arrays.asList(item1G1, item2G1, item3G1, item1G2))
-//            .withItems(Arrays.asList(item1G1, item2G1, item3G1, item1G2, nonFieldTestItemG1))
+            .withItems(Arrays.asList(item1G1, item2G1, item3G1, item1G2))
             .withFieldTestStartPosition(3)
             .withFieldTestEndPosition(7)
             .withFieldTestMinItems(4)
@@ -514,13 +576,13 @@ public class FieldTestServiceImplTest {
             .build();
         FieldTestItemGroup ftItemGroup1 = new FieldTestItemGroupBuilder("group-key-1")
             .withGroupId("group-id-1")
-            .withNumItems(3)
+            .withItemCount(3)
             .withExamId(exam.getId())
             .withSegmentKey(segment.getKey())
             .build();
         FieldTestItemGroup ftItemGroup2 = new FieldTestItemGroupBuilder("group-key-2")
             .withGroupId("group-id-2")
-            .withNumItems(1)
+            .withItemCount(1)
             .withExamId(exam.getId())
             .withSegmentKey(segment.getKey())
             .build();

--- a/service/src/test/java/tds/exam/services/impl/FieldTestServiceImplTest.java
+++ b/service/src/test/java/tds/exam/services/impl/FieldTestServiceImplTest.java
@@ -22,6 +22,7 @@ import tds.exam.Exam;
 import tds.exam.builder.AssessmentBuilder;
 import tds.exam.builder.ExamBuilder;
 import tds.exam.builder.FieldTestItemGroupBuilder;
+import tds.exam.builder.ItemBuilder;
 import tds.exam.builder.SegmentBuilder;
 import tds.exam.models.FieldTestItemGroup;
 import tds.exam.repositories.FieldTestItemGroupCommandRepository;
@@ -478,11 +479,34 @@ public class FieldTestServiceImplTest {
     public void shouldSelectAndInsertFieldTestItemGroupsMultiItems() {
         Exam exam = new ExamBuilder().build();
         final String assessmentKey = "assessment-key123";
+        Item item1G1 = new ItemBuilder("item1group1")
+            .withGroupKey("group-key-1")
+            .withItemProperties(Arrays.asList(new ItemProperty("Language", "ENU")))
+            .build();
+        Item item2G1 = new ItemBuilder("item2group1")
+            .withGroupKey("group-key-1")
+            .withItemProperties(Arrays.asList(new ItemProperty("Language", "ENU")))
+            .build();
+        Item item3G1 = new ItemBuilder("item3group1")
+            .withGroupKey("group-key-1")
+            .withItemProperties(Arrays.asList(new ItemProperty("Language", "ENU")))
+            .build();
+//        Item nonFieldTestItemG1 = new ItemBuilder("nonFtItem-group1")
+//            .withGroupKey("group-key-1")
+//            .withItemProperties(Arrays.asList(new ItemProperty("Language", "ENU")))
+//            .build();
+        Item item1G2 = new ItemBuilder("item1group2")
+            .withGroupKey("group-key-2")
+            .withItemProperties(Arrays.asList(new ItemProperty("Language", "ENU")))
+            .build();
         Segment segment = new SegmentBuilder()
             .withAssessmentKey(assessmentKey)
+            .withItems(Arrays.asList(item1G1, item2G1, item3G1, item1G2))
+//            .withItems(Arrays.asList(item1G1, item2G1, item3G1, item1G2, nonFieldTestItemG1))
             .withFieldTestStartPosition(3)
             .withFieldTestEndPosition(7)
             .withFieldTestMinItems(4)
+            .withSelectionAlgorithm(Algorithm.ADAPTIVE_2)
             .withFieldTestMaxItems(4)
             .build();
         Assessment assessment = new AssessmentBuilder()


### PR DESCRIPTION
This is an addendum to the field test item group selection PR. I've attempted to explain the need for the changes as best as possible in the comments within the code (FieldTestServiceImpl.java, specifically).

In summary, we need to account for the possible case where there is an item group containing a combination of field test items and non-field test items. A field test item group should only be selected if the exam has enough "space" for it, and non-ft items also need to be factored into this comparison. 

The `shouldSkipGroupDueToTooManyItemsInFTGroup()` test case in `FieldTestServiceImplTest` covers a case where there is space for only the first item group (which contains three FT items, as well as an additional non-field test item,). In this case, the second field test item group cannot be selected as there is room for only four items.