### PR TITLE
Feature/accommodations in assessment

### DIFF
--- a/service/src/main/java/tds/exam/services/AssessmentService.java
+++ b/service/src/main/java/tds/exam/services/AssessmentService.java
@@ -1,8 +1,12 @@
 package tds.exam.services;
 
+import java.util.List;
 import java.util.Optional;
 
+import tds.accommodation.Accommodation;
 import tds.assessment.Assessment;
+import tds.assessment.AssessmentWindow;
+import tds.session.ExternalSessionConfiguration;
 
 /**
  * Service handles assessment interaction
@@ -16,4 +20,34 @@ public interface AssessmentService {
      * @return {@link tds.assessment.Assessment the assessment}
      */
     Optional<Assessment> findAssessment(String clientName, String key);
+
+    /**
+     * Finds the assessment windows for an exam
+     *
+     * @param clientName    environment's client name
+     * @param assessmentId  the assessment id for the assessment
+     * @param studentId     identifier to the student
+     * @param configuration {@link tds.session.ExternalSessionConfiguration} for the environment
+     * @return array of {@link tds.assessment.AssessmentWindow}
+     */
+    List<AssessmentWindow> findAssessmentWindows(String clientName, String assessmentId, long studentId, ExternalSessionConfiguration configuration);
+
+    /**
+     * Finds the {@link tds.accommodation.Accommodation} for the assessment key
+     *
+     * @param clientName    the client name associated with the assessment
+     * @param assessmentKey the assessment key
+     * @return {@link tds.accommodation.Accommodation} for the assessment key
+     */
+    List<Accommodation> findAssessmentAccommodationsByAssessmentKey(final String clientName, final String assessmentKey);
+
+    /**
+     * Finds the {@link tds.accommodation.Accommodation} for the assessment id
+     *
+     * @param clientName   the client name associated with the assessment
+     * @param assessmentId the assessment id
+     * @return {@link tds.accommodation.Accommodation} for the assessment id
+     */
+    List<Accommodation> findAssessmentAccommodationsByAssessmentId(final String clientName, final String assessmentId);
+
 }

--- a/service/src/main/java/tds/exam/services/ConfigService.java
+++ b/service/src/main/java/tds/exam/services/ConfigService.java
@@ -1,28 +1,13 @@
 package tds.exam.services;
 
-import java.util.List;
 import java.util.Optional;
 
-import tds.accommodation.Accommodation;
-import tds.assessment.AssessmentWindow;
 import tds.config.ClientSystemFlag;
-import tds.session.ExternalSessionConfiguration;
 
 /**
  * A service that handles configuration interaction.
  */
 public interface ConfigService {
-    /**
-     * Finds the assessment windows for an exam
-     *
-     * @param clientName    environment's client name
-     * @param assessmentId  the assessment id for the assessment
-     * @param studentId     identifier to the student
-     * @param configuration {@link tds.session.ExternalSessionConfiguration} for the environment
-     * @return array of {@link tds.assessment.AssessmentWindow}
-     */
-    List<AssessmentWindow> findAssessmentWindows(String clientName, String assessmentId, long studentId, ExternalSessionConfiguration configuration);
-
     /**
      * Finds the {@link tds.config.ClientSystemFlag} for client
      *
@@ -31,21 +16,4 @@ public interface ConfigService {
      * @return {@link tds.config.ClientSystemFlag} if found otherwise empty
      */
     Optional<ClientSystemFlag> findClientSystemFlag(final String clientName, final String auditObject);
-
-    /**
-     * Finds the {@link tds.accommodation.Accommodation} for the assessment key
-     *
-     * @param clientName the client name associated with the assessment
-     * @param assessmentKey the assessment key
-     * @return {@link tds.accommodation.Accommodation} for the assessment key
-     */
-    List<Accommodation> findAssessmentAccommodationsByAssessmentKey(final String clientName, final String assessmentKey);
-
-    /**
-     * Finds the {@link tds.accommodation.Accommodation} for the assessment id
-     * @param clientName the client name associated with the assessment
-     * @param assessmentId the assessment id
-     * @return {@link tds.accommodation.Accommodation} for the assessment id
-     */
-    List<Accommodation> findAssessmentAccommodationsByAssessmentId(final String clientName, final String assessmentId);
 }

--- a/service/src/main/java/tds/exam/services/ConfigService.java
+++ b/service/src/main/java/tds/exam/services/ConfigService.java
@@ -3,8 +3,8 @@ package tds.exam.services;
 import java.util.List;
 import java.util.Optional;
 
-import tds.config.Accommodation;
-import tds.config.AssessmentWindow;
+import tds.accommodation.Accommodation;
+import tds.assessment.AssessmentWindow;
 import tds.config.ClientSystemFlag;
 import tds.session.ExternalSessionConfiguration;
 
@@ -19,7 +19,7 @@ public interface ConfigService {
      * @param assessmentId  the assessment id for the assessment
      * @param studentId     identifier to the student
      * @param configuration {@link tds.session.ExternalSessionConfiguration} for the environment
-     * @return array of {@link tds.config.AssessmentWindow}
+     * @return array of {@link tds.assessment.AssessmentWindow}
      */
     List<AssessmentWindow> findAssessmentWindows(String clientName, String assessmentId, long studentId, ExternalSessionConfiguration configuration);
 
@@ -33,19 +33,19 @@ public interface ConfigService {
     Optional<ClientSystemFlag> findClientSystemFlag(final String clientName, final String auditObject);
 
     /**
-     * Finds the {@link tds.config.Accommodation} for the assessment key
+     * Finds the {@link tds.accommodation.Accommodation} for the assessment key
      *
      * @param clientName the client name associated with the assessment
      * @param assessmentKey the assessment key
-     * @return {@link tds.config.Accommodation} for the assessment key
+     * @return {@link tds.accommodation.Accommodation} for the assessment key
      */
     List<Accommodation> findAssessmentAccommodationsByAssessmentKey(final String clientName, final String assessmentKey);
 
     /**
-     * Finds the {@link tds.config.Accommodation} for the assessment id
+     * Finds the {@link tds.accommodation.Accommodation} for the assessment id
      * @param clientName the client name associated with the assessment
      * @param assessmentId the assessment id
-     * @return {@link tds.config.Accommodation} for the assessment id
+     * @return {@link tds.accommodation.Accommodation} for the assessment id
      */
     List<Accommodation> findAssessmentAccommodationsByAssessmentId(final String clientName, final String assessmentId);
 }

--- a/service/src/main/java/tds/exam/services/impl/AssessmentServiceImpl.java
+++ b/service/src/main/java/tds/exam/services/impl/AssessmentServiceImpl.java
@@ -2,18 +2,25 @@ package tds.exam.services.impl;
 
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.cache.annotation.Cacheable;
+import org.springframework.core.ParameterizedTypeReference;
+import org.springframework.http.HttpMethod;
 import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
 import org.springframework.stereotype.Service;
 import org.springframework.web.client.HttpClientErrorException;
 import org.springframework.web.client.RestTemplate;
 import org.springframework.web.util.UriComponentsBuilder;
 
+import java.util.List;
 import java.util.Optional;
 
+import tds.accommodation.Accommodation;
 import tds.assessment.Assessment;
+import tds.assessment.AssessmentWindow;
 import tds.common.cache.CacheType;
 import tds.exam.configuration.ExamServiceProperties;
 import tds.exam.services.AssessmentService;
+import tds.session.ExternalSessionConfiguration;
 
 @Service
 class AssessmentServiceImpl implements AssessmentService {
@@ -45,4 +52,60 @@ class AssessmentServiceImpl implements AssessmentService {
 
         return maybeAssessment;
     }
+
+    @Override
+    @Cacheable(CacheType.MEDIUM_TERM)
+    public List<AssessmentWindow> findAssessmentWindows(String clientName,
+                                                        String assessmentId,
+                                                        long studentId,
+                                                        ExternalSessionConfiguration configuration) {
+        UriComponentsBuilder builder =
+            UriComponentsBuilder
+                .fromHttpUrl(String.format("%s/%s/assessments/%s/windows/student/%d",
+                    examServiceProperties.getAssessmentUrl(),
+                    clientName,
+                    assessmentId,
+                    studentId));
+
+        builder.queryParam("shiftWindowStart", configuration.getShiftWindowStart());
+        builder.queryParam("shiftWindowEnd", configuration.getShiftWindowEnd());
+        builder.queryParam("shiftFormStart", configuration.getShiftFormStart());
+        builder.queryParam("shiftFormEnd", configuration.getShiftFormEnd());
+
+        ResponseEntity<List<AssessmentWindow>> responseEntity = restTemplate.exchange(builder.toUriString(),
+            HttpMethod.GET, null, new ParameterizedTypeReference<List<AssessmentWindow>>() {
+            });
+
+        return responseEntity.getBody();
+    }
+
+    @Override
+    public List<Accommodation> findAssessmentAccommodationsByAssessmentKey(final String clientName, final String assessmentKey) {
+        UriComponentsBuilder builder =
+            UriComponentsBuilder
+                .fromHttpUrl(String.format("%s/%s/accommodations", examServiceProperties.getAssessmentUrl(), clientName))
+                .queryParam("assessmentKey", assessmentKey);
+
+        ResponseEntity<List<Accommodation>> responseEntity = restTemplate.exchange(builder.toUriString(),
+            HttpMethod.GET, null, new ParameterizedTypeReference<List<Accommodation>>() {
+            });
+
+        return responseEntity.getBody();
+    }
+
+    @Override
+    public List<Accommodation> findAssessmentAccommodationsByAssessmentId(String clientName, String assessmentId) {
+        UriComponentsBuilder builder =
+            UriComponentsBuilder
+                .fromHttpUrl(String.format("%s/%s/accommodations", examServiceProperties.getAssessmentUrl(), clientName))
+                .queryParam("assessmentId", assessmentId);
+
+
+        ResponseEntity<List<Accommodation>> responseEntity = restTemplate.exchange(builder.toUriString(),
+            HttpMethod.GET, null, new ParameterizedTypeReference<List<Accommodation>>() {
+            });
+
+        return responseEntity.getBody();
+    }
+
 }

--- a/service/src/main/java/tds/exam/services/impl/ConfigServiceImpl.java
+++ b/service/src/main/java/tds/exam/services/impl/ConfigServiceImpl.java
@@ -2,25 +2,18 @@ package tds.exam.services.impl;
 
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.cache.annotation.Cacheable;
-import org.springframework.core.ParameterizedTypeReference;
-import org.springframework.http.HttpMethod;
 import org.springframework.http.HttpStatus;
-import org.springframework.http.ResponseEntity;
 import org.springframework.stereotype.Service;
 import org.springframework.web.client.HttpClientErrorException;
 import org.springframework.web.client.RestTemplate;
 import org.springframework.web.util.UriComponentsBuilder;
 
-import java.util.List;
 import java.util.Optional;
 
-import tds.accommodation.Accommodation;
-import tds.assessment.AssessmentWindow;
 import tds.common.cache.CacheType;
 import tds.config.ClientSystemFlag;
 import tds.exam.configuration.ExamServiceProperties;
 import tds.exam.services.ConfigService;
-import tds.session.ExternalSessionConfiguration;
 
 /**
  * Service for retrieving data from the Config Session Microservice
@@ -34,33 +27,6 @@ class ConfigServiceImpl implements ConfigService {
     public ConfigServiceImpl(RestTemplate restTemplate, ExamServiceProperties examServiceProperties) {
         this.restTemplate = restTemplate;
         this.examServiceProperties = examServiceProperties;
-    }
-
-    @Override
-    @Cacheable(CacheType.MEDIUM_TERM)
-    public List<AssessmentWindow> findAssessmentWindows(String clientName,
-                                                        String assessmentId,
-                                                        long studentId,
-                                                        ExternalSessionConfiguration configuration) {
-
-        UriComponentsBuilder builder =
-            UriComponentsBuilder
-                .fromHttpUrl(String.format("%s/assessment-windows/%s/%s/student/%d",
-                    examServiceProperties.getConfigUrl(),
-                    clientName,
-                    assessmentId,
-                    studentId));
-
-        builder.queryParam("shiftWindowStart", configuration.getShiftWindowStart());
-        builder.queryParam("shiftWindowEnd", configuration.getShiftWindowEnd());
-        builder.queryParam("shiftFormStart", configuration.getShiftFormStart());
-        builder.queryParam("shiftFormEnd", configuration.getShiftFormEnd());
-
-        ResponseEntity<List<AssessmentWindow>> responseEntity = restTemplate.exchange(builder.toUriString(),
-            HttpMethod.GET, null, new ParameterizedTypeReference<List<AssessmentWindow>>() {
-            });
-
-        return responseEntity.getBody();
     }
 
     @Override
@@ -81,31 +47,5 @@ class ConfigServiceImpl implements ConfigService {
         }
 
         return maybeClientSystemFlag;
-    }
-
-    @Override
-    public List<Accommodation> findAssessmentAccommodationsByAssessmentKey(final String clientName, final String assessmentKey) {
-        UriComponentsBuilder builder =
-            UriComponentsBuilder
-                .fromHttpUrl(String.format("%s/%s/accommodations/%s", examServiceProperties.getConfigUrl(), clientName, assessmentKey));
-
-        ResponseEntity<List<Accommodation>> responseEntity = restTemplate.exchange(builder.toUriString(),
-            HttpMethod.GET, null, new ParameterizedTypeReference<List<Accommodation>>() {
-            });
-
-        return responseEntity.getBody();
-    }
-
-    @Override
-    public List<Accommodation> findAssessmentAccommodationsByAssessmentId(String clientName, String assessmentId) {
-        UriComponentsBuilder builder =
-            UriComponentsBuilder
-                .fromHttpUrl(String.format("%s/%s/accommodations?assessmentId=%s", examServiceProperties.getConfigUrl(), clientName, assessmentId));
-
-        ResponseEntity<List<Accommodation>> responseEntity = restTemplate.exchange(builder.toUriString(),
-            HttpMethod.GET, null, new ParameterizedTypeReference<List<Accommodation>>() {
-            });
-
-        return responseEntity.getBody();
     }
 }

--- a/service/src/main/java/tds/exam/services/impl/ConfigServiceImpl.java
+++ b/service/src/main/java/tds/exam/services/impl/ConfigServiceImpl.java
@@ -14,9 +14,9 @@ import org.springframework.web.util.UriComponentsBuilder;
 import java.util.List;
 import java.util.Optional;
 
+import tds.accommodation.Accommodation;
+import tds.assessment.AssessmentWindow;
 import tds.common.cache.CacheType;
-import tds.config.Accommodation;
-import tds.config.AssessmentWindow;
 import tds.config.ClientSystemFlag;
 import tds.exam.configuration.ExamServiceProperties;
 import tds.exam.services.ConfigService;

--- a/service/src/main/java/tds/exam/services/impl/ExamAccommodationServiceImpl.java
+++ b/service/src/main/java/tds/exam/services/impl/ExamAccommodationServiceImpl.java
@@ -12,8 +12,8 @@ import java.util.Set;
 import java.util.UUID;
 import java.util.stream.Collectors;
 
+import tds.accommodation.Accommodation;
 import tds.assessment.Assessment;
-import tds.config.Accommodation;
 import tds.exam.Exam;
 import tds.exam.ExamAccommodation;
 import tds.exam.repositories.ExamAccommodationCommandRepository;

--- a/service/src/main/java/tds/exam/services/impl/ExamAccommodationServiceImpl.java
+++ b/service/src/main/java/tds/exam/services/impl/ExamAccommodationServiceImpl.java
@@ -18,7 +18,7 @@ import tds.exam.Exam;
 import tds.exam.ExamAccommodation;
 import tds.exam.repositories.ExamAccommodationCommandRepository;
 import tds.exam.repositories.ExamAccommodationQueryRepository;
-import tds.exam.services.ConfigService;
+import tds.exam.services.AssessmentService;
 import tds.exam.services.ExamAccommodationService;
 
 import static org.apache.commons.lang3.StringUtils.isEmpty;
@@ -32,13 +32,15 @@ class ExamAccommodationServiceImpl implements ExamAccommodationService {
 
     private final ExamAccommodationQueryRepository examAccommodationQueryRepository;
     private final ExamAccommodationCommandRepository examAccommodationCommandRepository;
-    private final ConfigService configService;
+    private final AssessmentService assessmentService;
 
     @Autowired
-    public ExamAccommodationServiceImpl(ExamAccommodationQueryRepository examAccommodationQueryRepository, ExamAccommodationCommandRepository examAccommodationCommandRepository, ConfigService configService) {
+    public ExamAccommodationServiceImpl(ExamAccommodationQueryRepository examAccommodationQueryRepository,
+                                        ExamAccommodationCommandRepository examAccommodationCommandRepository,
+                                        AssessmentService assessmentService) {
         this.examAccommodationQueryRepository = examAccommodationQueryRepository;
         this.examAccommodationCommandRepository = examAccommodationCommandRepository;
-        this.configService = configService;
+        this.assessmentService = assessmentService;
     }
 
     @Override
@@ -58,7 +60,7 @@ class ExamAccommodationServiceImpl implements ExamAccommodationService {
 
         // StudentDLL fetches the key accommodations via CommonDLL.TestKeyAccommodations_FN which this call replicates.  The legacy application leverages
         // temporary tables for most of its data structures which is unnecessary in this case so a collection is returned.
-        List<Accommodation> assessmentAccommodations = configService.findAssessmentAccommodationsByAssessmentKey(exam.getClientName(), exam.getAssessmentKey());
+        List<Accommodation> assessmentAccommodations = assessmentService.findAssessmentAccommodationsByAssessmentKey(exam.getClientName(), exam.getAssessmentKey());
 
         // StudentDLL line 6645 - the query filters the results of the temporary table fetched above by these two values.
         // It was decided the record usage and report usage values that are also queried are not actually used.
@@ -170,7 +172,7 @@ class ExamAccommodationServiceImpl implements ExamAccommodationService {
 
         // CommonDLL line 2593 fetches the key accommodations via CommonDLL.TestKeyAccommodations_FN which this call replicates.  The legacy application leverages
         // temporary tables for most of its data structures which is unnecessary in this case so a collection is returned.
-        List<Accommodation> assessmentAccommodations = configService.findAssessmentAccommodationsByAssessmentKey(exam.getClientName(), exam.getAssessmentKey());
+        List<Accommodation> assessmentAccommodations = assessmentService.findAssessmentAccommodationsByAssessmentKey(exam.getClientName(), exam.getAssessmentKey());
 
         /*
         This is the accumulation of many different queries on lines CommonDLL.UpdateOpportunityAccommodations_SP()

--- a/service/src/main/java/tds/exam/services/impl/ExamServiceImpl.java
+++ b/service/src/main/java/tds/exam/services/impl/ExamServiceImpl.java
@@ -18,11 +18,11 @@ import java.util.function.Supplier;
 import java.util.stream.Collectors;
 
 import tds.assessment.Assessment;
+import tds.assessment.AssessmentWindow;
 import tds.common.Response;
 import tds.common.ValidationError;
 import tds.common.data.legacy.LegacyComparer;
 import tds.common.web.exceptions.NotFoundException;
-import tds.config.AssessmentWindow;
 import tds.config.ClientSystemFlag;
 import tds.config.TimeLimitConfiguration;
 import tds.exam.ApprovalRequest;

--- a/service/src/main/java/tds/exam/services/impl/ExamServiceImpl.java
+++ b/service/src/main/java/tds/exam/services/impl/ExamServiceImpl.java
@@ -518,7 +518,7 @@ class ExamServiceImpl implements ExamService {
         }
 
         //OpenTestServiceImpl lines 317 - 341
-        List<AssessmentWindow> assessmentWindows = configService.findAssessmentWindows(
+        List<AssessmentWindow> assessmentWindows = assessmentService.findAssessmentWindows(
             openExamRequest.getClientName(),
             assessment.getAssessmentId(),
             openExamRequest.getStudentId(),

--- a/service/src/test/java/tds/exam/builder/AccommodationBuilder.java
+++ b/service/src/test/java/tds/exam/builder/AccommodationBuilder.java
@@ -1,6 +1,6 @@
 package tds.exam.builder;
 
-import tds.config.Accommodation;
+import tds.accommodation.Accommodation;
 
 public class AccommodationBuilder {
     private Accommodation.Builder builder;

--- a/service/src/test/java/tds/exam/services/impl/AssessmentServiceImplTest.java
+++ b/service/src/test/java/tds/exam/services/impl/AssessmentServiceImplTest.java
@@ -2,35 +2,47 @@ package tds.exam.services.impl;
 
 import org.junit.Before;
 import org.junit.Test;
+import org.springframework.core.ParameterizedTypeReference;
 import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
 import org.springframework.web.client.HttpClientErrorException;
 import org.springframework.web.client.RestClientException;
 import org.springframework.web.client.RestTemplate;
+import org.springframework.web.util.UriComponentsBuilder;
 
 import java.util.ArrayList;
+import java.util.Collections;
 import java.util.List;
 import java.util.Optional;
 
+import tds.accommodation.Accommodation;
 import tds.assessment.Algorithm;
 import tds.assessment.Assessment;
+import tds.assessment.AssessmentWindow;
 import tds.assessment.Segment;
+import tds.exam.builder.ExternalSessionConfigurationBuilder;
 import tds.exam.configuration.ExamServiceProperties;
 import tds.exam.services.AssessmentService;
+import tds.session.ExternalSessionConfiguration;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Matchers.isA;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
+import static org.springframework.http.HttpMethod.GET;
 
 public class AssessmentServiceImplTest {
+    private static final String BASE_URL = "http://localhost:8080/";
     private RestTemplate restTemplate;
     private AssessmentService assessmentService;
+
 
     @Before
     public void setUp() {
         restTemplate = mock(RestTemplate.class);
         ExamServiceProperties properties = new ExamServiceProperties();
-        properties.setAssessmentUrl("http://localhost:8080");
+        properties.setAssessmentUrl(BASE_URL);
         assessmentService = new AssessmentServiceImpl(restTemplate, properties);
     }
 
@@ -50,25 +62,93 @@ public class AssessmentServiceImplTest {
         assessment.setSelectionAlgorithm(Algorithm.VIRTUAL);
         assessment.setStartAbility(100);
 
-        when(restTemplate.getForObject("http://localhost:8080/clientname/assessments/key", Assessment.class)).thenReturn(assessment);
+        when(restTemplate.getForObject(BASE_URL + "clientname/assessments/key", Assessment.class)).thenReturn(assessment);
         Optional<Assessment> maybeAssessment = assessmentService.findAssessment("clientname", "key");
-        verify(restTemplate).getForObject("http://localhost:8080/clientname/assessments/key", Assessment.class);
+        verify(restTemplate).getForObject(BASE_URL + "clientname/assessments/key", Assessment.class);
 
         assertThat(maybeAssessment.get()).isEqualTo(assessment);
     }
 
     @Test
     public void shouldReturnEmptyWhenSetOfAdminSubjectNotFound() {
-        when(restTemplate.getForObject("http://localhost:8080/clientname/assessments/key", Assessment.class)).thenThrow(new HttpClientErrorException(HttpStatus.NOT_FOUND));
+        when(restTemplate.getForObject(isA(String.class), isA(Class.class))).thenThrow(new HttpClientErrorException(HttpStatus.NOT_FOUND));
         Optional<Assessment> maybeAssessment = assessmentService.findAssessment("clientname", "key");
-        verify(restTemplate).getForObject("http://localhost:8080/clientname/assessments/key", Assessment.class);
 
         assertThat(maybeAssessment).isNotPresent();
     }
 
-    @Test (expected = RestClientException.class)
+    @Test(expected = RestClientException.class)
     public void shouldThrowIfStatusNotNotFoundWhenUnexpectedErrorFindingSetOfAdminSubject() {
-        when(restTemplate.getForObject("http://localhost:8080/clientname/assessments/key", Assessment.class)).thenThrow(new HttpClientErrorException(HttpStatus.BAD_REQUEST));
+        when(restTemplate.getForObject(isA(String.class), isA(Class.class))).thenThrow(new HttpClientErrorException(HttpStatus.BAD_REQUEST));
         assessmentService.findAssessment("clientname", "key");
+    }
+
+    @Test
+    public void shouldFindAssessmentWindows() {
+        AssessmentWindow window = new AssessmentWindow.Builder().build();
+        String url = UriComponentsBuilder
+            .fromHttpUrl(String.format("%s/%s/assessments/%s/windows/student/%d",
+                BASE_URL,
+                "SBAC_PT",
+                "ELA 11",
+                23))
+            .queryParam("shiftWindowStart", 1)
+            .queryParam("shiftWindowEnd", 2)
+            .queryParam("shiftFormStart", 10)
+            .queryParam("shiftFormEnd", 11)
+            .toUriString();
+
+        ExternalSessionConfiguration config = new ExternalSessionConfigurationBuilder()
+            .withShiftWindowStart(1)
+            .withShiftWindowEnd(2)
+            .withShiftFormStart(10)
+            .withShiftFormEnd(11)
+            .build();
+
+        ResponseEntity<List<AssessmentWindow>> entity = new ResponseEntity<>(Collections.singletonList(window), HttpStatus.OK);
+
+        when(restTemplate.exchange(url, GET, null, new ParameterizedTypeReference<List<AssessmentWindow>>() {
+        }))
+            .thenReturn(entity);
+
+        List<AssessmentWindow> windows = assessmentService.findAssessmentWindows("SBAC_PT", "ELA 11", 23, config);
+
+        assertThat(windows).containsExactly(window);
+    }
+
+    @Test
+    public void shouldFindAssessmentAccommodationsByKey() {
+        Accommodation accommodation = new Accommodation.Builder().build();
+        ResponseEntity<List<Accommodation>> entity = new ResponseEntity<>(Collections.singletonList(accommodation), HttpStatus.OK);
+
+        String url = UriComponentsBuilder
+            .fromHttpUrl(String.format("%s/SBAC/accommodations", BASE_URL))
+            .queryParam("assessmentKey", "key")
+            .toUriString();
+
+        when(restTemplate.exchange(url, GET, null, new ParameterizedTypeReference<List<Accommodation>>() {
+        })).thenReturn(entity);
+
+        List<Accommodation> accommodations = assessmentService.findAssessmentAccommodationsByAssessmentKey("SBAC", "key");
+
+        assertThat(accommodations).containsExactly(accommodation);
+    }
+
+    @Test
+    public void shouldFindAssessmentAccommodationsById() {
+        Accommodation accommodation = new Accommodation.Builder().build();
+        ResponseEntity<List<Accommodation>> entity = new ResponseEntity<>(Collections.singletonList(accommodation), HttpStatus.OK);
+
+        String url = UriComponentsBuilder
+            .fromHttpUrl(String.format("%s/SBAC/accommodations", BASE_URL))
+            .queryParam("assessmentId", "id")
+            .toUriString();
+
+        when(restTemplate.exchange(url, GET, null, new ParameterizedTypeReference<List<Accommodation>>() {
+        })).thenReturn(entity);
+
+        List<Accommodation> accommodations = assessmentService.findAssessmentAccommodationsByAssessmentId("SBAC", "id");
+
+        assertThat(accommodations).containsExactly(accommodation);
     }
 }

--- a/service/src/test/java/tds/exam/services/impl/ConfigServiceImplTest.java
+++ b/service/src/test/java/tds/exam/services/impl/ConfigServiceImplTest.java
@@ -14,8 +14,8 @@ import java.util.Collections;
 import java.util.List;
 import java.util.Optional;
 
-import tds.config.Accommodation;
-import tds.config.AssessmentWindow;
+import tds.accommodation.Accommodation;
+import tds.assessment.AssessmentWindow;
 import tds.config.ClientSystemFlag;
 import tds.exam.builder.ExternalSessionConfigurationBuilder;
 import tds.exam.configuration.ExamServiceProperties;

--- a/service/src/test/java/tds/exam/services/impl/ConfigServiceImplTest.java
+++ b/service/src/test/java/tds/exam/services/impl/ConfigServiceImplTest.java
@@ -2,30 +2,20 @@ package tds.exam.services.impl;
 
 import org.junit.Before;
 import org.junit.Test;
-import org.springframework.core.ParameterizedTypeReference;
 import org.springframework.http.HttpStatus;
-import org.springframework.http.ResponseEntity;
 import org.springframework.web.client.HttpClientErrorException;
 import org.springframework.web.client.RestClientException;
 import org.springframework.web.client.RestTemplate;
-import org.springframework.web.util.UriComponentsBuilder;
 
-import java.util.Collections;
-import java.util.List;
 import java.util.Optional;
 
-import tds.accommodation.Accommodation;
-import tds.assessment.AssessmentWindow;
 import tds.config.ClientSystemFlag;
-import tds.exam.builder.ExternalSessionConfigurationBuilder;
 import tds.exam.configuration.ExamServiceProperties;
 import tds.exam.services.ConfigService;
-import tds.session.ExternalSessionConfiguration;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
-import static org.springframework.http.HttpMethod.GET;
 
 /**
  * Class for testing the {@link ConfigService}
@@ -45,40 +35,6 @@ public class ConfigServiceImplTest {
         properties.setConfigUrl(BASE_URL);
         configService = new ConfigServiceImpl(restTemplate, properties);
     }
-
-    @Test
-    public void shouldFindAssessmentWindows() {
-        AssessmentWindow window = new AssessmentWindow.Builder().build();
-        String url = UriComponentsBuilder
-            .fromHttpUrl(String.format("%s/assessment-windows/%s/%s/student/%d",
-                BASE_URL,
-                "SBAC_PT",
-                "ELA 11",
-                23))
-            .queryParam("shiftWindowStart", 1)
-            .queryParam("shiftWindowEnd", 2)
-            .queryParam("shiftFormStart", 10)
-            .queryParam("shiftFormEnd", 11)
-            .toUriString();
-
-        ExternalSessionConfiguration config = new ExternalSessionConfigurationBuilder()
-            .withShiftWindowStart(1)
-            .withShiftWindowEnd(2)
-            .withShiftFormStart(10)
-            .withShiftFormEnd(11)
-            .build();
-
-        ResponseEntity<List<AssessmentWindow>> entity = new ResponseEntity<>(Collections.singletonList(window), HttpStatus.OK);
-
-        when(restTemplate.exchange(url, GET, null, new ParameterizedTypeReference<List<AssessmentWindow>>() {
-        }))
-            .thenReturn(entity);
-
-        List<AssessmentWindow> windows = configService.findAssessmentWindows("SBAC_PT", "ELA 11", 23, config);
-
-        assertThat(windows).containsExactly(window);
-    }
-
 
     @Test
     public void shouldFindClientSystemFlag() {
@@ -104,29 +60,5 @@ public class ConfigServiceImplTest {
         configService.findClientSystemFlag(CLIENT_NAME, ATTRIBUTE_OBJECT);
     }
 
-    @Test
-    public void shouldFindAssessmentAccommodationsByKey() {
-        Accommodation accommodation = new Accommodation.Builder().build();
-        ResponseEntity<List<Accommodation>> entity = new ResponseEntity<>(Collections.singletonList(accommodation), HttpStatus.OK);
 
-        when(restTemplate.exchange(String.format("%s/SBAC/accommodations/key", BASE_URL), GET, null, new ParameterizedTypeReference<List<Accommodation>>() {
-        })).thenReturn(entity);
-
-        List<Accommodation> accommodations = configService.findAssessmentAccommodationsByAssessmentKey("SBAC", "key");
-
-        assertThat(accommodations).containsExactly(accommodation);
-    }
-
-    @Test
-    public void shouldFindAssessmentAccommodationsById() {
-        Accommodation accommodation = new Accommodation.Builder().build();
-        ResponseEntity<List<Accommodation>> entity = new ResponseEntity<>(Collections.singletonList(accommodation), HttpStatus.OK);
-
-        when(restTemplate.exchange(String.format("%s/SBAC/accommodations?assessmentId=id", BASE_URL), GET, null, new ParameterizedTypeReference<List<Accommodation>>() {
-        })).thenReturn(entity);
-
-        List<Accommodation> accommodations = configService.findAssessmentAccommodationsByAssessmentId("SBAC", "id");
-
-        assertThat(accommodations).containsExactly(accommodation);
-    }
 }

--- a/service/src/test/java/tds/exam/services/impl/ExamAccommodationServiceImplTest.java
+++ b/service/src/test/java/tds/exam/services/impl/ExamAccommodationServiceImplTest.java
@@ -14,8 +14,8 @@ import java.util.Arrays;
 import java.util.Collections;
 import java.util.List;
 
+import tds.accommodation.Accommodation;
 import tds.assessment.Assessment;
-import tds.config.Accommodation;
 import tds.exam.Exam;
 import tds.exam.ExamAccommodation;
 import tds.exam.builder.AccommodationBuilder;

--- a/service/src/test/java/tds/exam/services/impl/ExamAccommodationServiceImplTest.java
+++ b/service/src/test/java/tds/exam/services/impl/ExamAccommodationServiceImplTest.java
@@ -24,7 +24,7 @@ import tds.exam.builder.ExamAccommodationBuilder;
 import tds.exam.builder.ExamBuilder;
 import tds.exam.repositories.ExamAccommodationCommandRepository;
 import tds.exam.repositories.ExamAccommodationQueryRepository;
-import tds.exam.services.ConfigService;
+import tds.exam.services.AssessmentService;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.Mockito.verify;
@@ -41,14 +41,14 @@ public class ExamAccommodationServiceImplTest {
     private ExamAccommodationCommandRepository mockExamAccommodationCommandRepository;
 
     @Mock
-    private ConfigService mockConfigService;
+    private AssessmentService mockAssessmentService;
 
     @Captor
     private ArgumentCaptor<List<ExamAccommodation>> examAccommodationInsertCaptor;
 
     @Before
     public void setUp() {
-        examAccommodationService = new ExamAccommodationServiceImpl(mockExamAccommodationQueryRepository, mockExamAccommodationCommandRepository, mockConfigService);
+        examAccommodationService = new ExamAccommodationServiceImpl(mockExamAccommodationQueryRepository, mockExamAccommodationCommandRepository, mockAssessmentService);
     }
 
     @Test
@@ -138,7 +138,7 @@ public class ExamAccommodationServiceImplTest {
             .withDependsOnToolType("dependingSoCool")
             .build();
 
-        when(mockConfigService.findAssessmentAccommodationsByAssessmentKey(exam.getClientName(), exam.getAssessmentKey())).thenReturn(Arrays.asList(accommodation, nonDefaultAccommodation, dependsOnToolTypeAccommodation));
+        when(mockAssessmentService.findAssessmentAccommodationsByAssessmentKey(exam.getClientName(), exam.getAssessmentKey())).thenReturn(Arrays.asList(accommodation, nonDefaultAccommodation, dependsOnToolTypeAccommodation));
         examAccommodationService.initializeExamAccommodations(exam);
         verify(mockExamAccommodationCommandRepository).insert(examAccommodationInsertCaptor.capture());
 
@@ -244,7 +244,7 @@ public class ExamAccommodationServiceImplTest {
             .build();
 
 
-        when(mockConfigService.findAssessmentAccommodationsByAssessmentKey(exam.getClientName(), assessment.getKey())).thenReturn(assessmentAccommodations);
+        when(mockAssessmentService.findAssessmentAccommodationsByAssessmentKey(exam.getClientName(), assessment.getKey())).thenReturn(assessmentAccommodations);
         when(mockExamAccommodationQueryRepository.findAccommodations(exam.getId())).thenReturn(Arrays.asList(existingFrenchExamAccommodation, existingEnglishExamAccommodation));
 
         examAccommodationService.initializeAccommodationsOnPreviousExam(exam, assessment, 0, false, guestAccommodations);

--- a/service/src/test/java/tds/exam/services/impl/ExamServiceImplTest.java
+++ b/service/src/test/java/tds/exam/services/impl/ExamServiceImplTest.java
@@ -271,7 +271,7 @@ public class ExamServiceImplTest {
         when(mockAssessmentService.findAssessment(openExamRequest.getClientName(), openExamRequest.getAssessmentKey())).thenReturn(Optional.of(assessment));
         when(mockExamQueryRepository.getLastAvailableExam(openExamRequest.getStudentId(), assessment.getAssessmentId(), openExamRequest.getClientName())).thenReturn(Optional.empty());
         when(mockSessionService.findExternalSessionConfigurationByClientName(openExamRequest.getClientName())).thenReturn(Optional.of(extSessionConfig));
-        when(mockConfigService.findAssessmentWindows(openExamRequest.getClientName(), assessment.getAssessmentId(), openExamRequest.getStudentId(), extSessionConfig))
+        when(mockAssessmentService.findAssessmentWindows(openExamRequest.getClientName(), assessment.getAssessmentId(), openExamRequest.getStudentId(), extSessionConfig))
             .thenReturn(Collections.singletonList(window));
         when(mockTimeLimitConfigurationService.findTimeLimitConfiguration(openExamRequest.getClientName(), openExamRequest.getAssessmentKey())).thenReturn(Optional.of(configuration));
         when(mockExamStatusQueryRepository.findExamStatusCode(STATUS_PENDING)).thenReturn(new ExamStatusCode(STATUS_PENDING, OPEN));
@@ -335,9 +335,9 @@ public class ExamServiceImplTest {
         when(mockStudentService.getStudentById(openExamRequest.getStudentId())).thenReturn(Optional.empty());
         when(mockAssessmentService.findAssessment(openExamRequest.getClientName(), openExamRequest.getAssessmentKey())).thenReturn(Optional.of(assessment));
         when(mockExamQueryRepository.getLastAvailableExam(openExamRequest.getStudentId(), assessment.getAssessmentId(), openExamRequest.getClientName())).thenReturn(Optional.empty());
-        when(mockConfigService.findAssessmentWindows(openExamRequest.getClientName(), assessment.getAssessmentId(), openExamRequest.getStudentId(), extSessionConfig))
+        when(mockAssessmentService.findAssessmentWindows(openExamRequest.getClientName(), assessment.getAssessmentId(), openExamRequest.getStudentId(), extSessionConfig))
             .thenReturn(Collections.singletonList(window));
-        when(mockConfigService.findAssessmentAccommodationsByAssessmentKey(openExamRequest.getClientName(), openExamRequest.getAssessmentKey()))
+        when(mockAssessmentService.findAssessmentAccommodationsByAssessmentKey(openExamRequest.getClientName(), openExamRequest.getAssessmentKey()))
             .thenReturn(Collections.singletonList(accommodation));
         when(mockTimeLimitConfigurationService.findTimeLimitConfiguration(openExamRequest.getClientName(), openExamRequest.getAssessmentKey())).thenReturn(Optional.of(configuration));
         when(mockExamStatusQueryRepository.findExamStatusCode(STATUS_APPROVED)).thenReturn(new ExamStatusCode(STATUS_APPROVED, OPEN));
@@ -381,7 +381,7 @@ public class ExamServiceImplTest {
         when(mockSessionService.findExternalSessionConfigurationByClientName(openExamRequest.getClientName())).thenReturn(Optional.of(extSessionConfig));
         when(mockStudentService.findStudentPackageAttributes(openExamRequest.getStudentId(), openExamRequest.getClientName(), EXTERNAL_ID, ENTITY_NAME, ACCOMMODATIONS))
             .thenReturn(Arrays.asList(externalIdAttribute, entityNameAttribute));
-        when(mockConfigService.findAssessmentWindows(openExamRequest.getClientName(), assessment.getAssessmentId(), openExamRequest.getStudentId(), extSessionConfig))
+        when(mockAssessmentService.findAssessmentWindows(openExamRequest.getClientName(), assessment.getAssessmentId(), openExamRequest.getStudentId(), extSessionConfig))
             .thenReturn(Collections.singletonList(window));
         when(mockTimeLimitConfigurationService.findTimeLimitConfiguration(openExamRequest.getClientName(), openExamRequest.getAssessmentKey())).thenReturn(Optional.of(configuration));
         when(mockExamStatusQueryRepository.findExamStatusCode(STATUS_PENDING)).thenReturn(new ExamStatusCode(STATUS_PENDING, OPEN));
@@ -436,7 +436,7 @@ public class ExamServiceImplTest {
         when(mockSessionService.findSessionById(previousSession.getId())).thenReturn(Optional.of(previousSession));
         when(mockSessionService.findExternalSessionConfigurationByClientName(request.getClientName())).thenReturn(Optional.of(externalSessionConfiguration));
         when(mockSessionService.findExternalSessionConfigurationByClientName(request.getClientName())).thenReturn(Optional.of(externalSessionConfiguration));
-        when(mockConfigService.findAssessmentAccommodationsByAssessmentKey(request.getClientName(), request.getAssessmentKey())).thenReturn(Collections.emptyList());
+        when(mockAssessmentService.findAssessmentAccommodationsByAssessmentKey(request.getClientName(), request.getAssessmentKey())).thenReturn(Collections.emptyList());
         when(mockExamStatusQueryRepository.findExamStatusCode(STATUS_PENDING)).thenReturn(new ExamStatusCode(STATUS_PENDING, OPEN));
         when(mockConfigService.findClientSystemFlag(request.getClientName(), RESTORE_ACCOMMODATIONS_TYPE)).thenReturn(Optional.of(restoreAccommodations));
 

--- a/service/src/test/java/tds/exam/services/impl/ExamServiceImplTest.java
+++ b/service/src/test/java/tds/exam/services/impl/ExamServiceImplTest.java
@@ -23,13 +23,13 @@ import java.util.Optional;
 import java.util.Set;
 import java.util.UUID;
 
+import tds.accommodation.Accommodation;
 import tds.assessment.Algorithm;
 import tds.assessment.Assessment;
+import tds.assessment.AssessmentWindow;
 import tds.common.Response;
 import tds.common.ValidationError;
 import tds.common.web.exceptions.NotFoundException;
-import tds.config.Accommodation;
-import tds.config.AssessmentWindow;
 import tds.config.ClientSystemFlag;
 import tds.config.TimeLimitConfiguration;
 import tds.exam.ApprovalRequest;


### PR DESCRIPTION
There were some issues when communicating with assessment service from config service in docker.

The endpoints that were required assessment service always belonged in assessment service after we decided to build endpoints based on intent rather than strictly by DB.  Rather than investigate the docker issues I moved the endpoints since that was on the TODO list.

I need this for other work so I'll be merging this code but will make follow up changes depending on review.