### PR TITLE
Approve Student Exam Accommodations

### DIFF
--- a/client/src/main/java/tds/exam/ApprovalRequest.java
+++ b/client/src/main/java/tds/exam/ApprovalRequest.java
@@ -16,14 +16,10 @@ public class ApprovalRequest {
     @NotNull
     private UUID browserId;
 
-    @NotNull
-    private String clientName;
-
-    public ApprovalRequest(UUID examId, UUID sessionId, UUID browserId, String clientName) {
+    public ApprovalRequest(UUID examId, UUID sessionId, UUID browserId) {
         this.examId = examId;
         this.sessionId = sessionId;
         this.browserId = browserId;
-        this.clientName = clientName;
     }
 
     /**
@@ -53,16 +49,6 @@ public class ApprovalRequest {
         return browserId;
     }
 
-    /**
-     * @return The name of  the client that owns the exam.
-     * <p>
-     *     Examples include "SBAC" and "SBAC_PT".
-     * </p>
-     */
-    public String getClientName() {
-        return clientName;
-    }
-
     @Override
     public boolean equals(Object o) {
         if (this == o) return true;
@@ -72,8 +58,7 @@ public class ApprovalRequest {
 
         if (!getExamId().equals(that.getExamId())) return false;
         if (!getSessionId().equals(that.getSessionId())) return false;
-        if (!getBrowserId().equals(that.getBrowserId())) return false;
-        return getClientName().equals(that.getClientName());
+        return getBrowserId().equals(that.getBrowserId());
     }
 
     @Override
@@ -81,7 +66,6 @@ public class ApprovalRequest {
         int result = getExamId().hashCode();
         result = 31 * result + getSessionId().hashCode();
         result = 31 * result + getBrowserId().hashCode();
-        result = 31 * result + getClientName().hashCode();
         return result;
     }
 }

--- a/client/src/main/java/tds/exam/ApproveAccommodationsRequest.java
+++ b/client/src/main/java/tds/exam/ApproveAccommodationsRequest.java
@@ -1,0 +1,67 @@
+package tds.exam;
+
+import java.util.Map;
+import java.util.Set;
+import java.util.UUID;
+
+/**
+ * Request approval for {@link tds.exam.ExamAccommodation}s
+ */
+public class ApproveAccommodationsRequest {
+    private UUID sessionId;
+    private UUID browserId;
+    // Segment position -> Accommodation codes
+    private Map<Integer, Set<String>> accommodationCodes;
+    
+    /*
+        Private constructor for frameworks
+     */
+    private ApproveAccommodationsRequest() {}
+    
+    public ApproveAccommodationsRequest(UUID sessionId, UUID browserId, Map<Integer, Set<String>> accommodationCodes) {
+      this.sessionId = sessionId;
+      this.browserId = browserId;
+      this.accommodationCodes = accommodationCodes;
+    }
+  
+    /**
+     * @return the session id of the {@link tds.exam.ApproveAccommodationsRequest}
+     */
+    public UUID getSessionId() {
+      return sessionId;
+    }
+  
+    /**
+     * @return the browser id of the {@link tds.exam.ApproveAccommodationsRequest}
+     */
+    public UUID getBrowserId() {
+      return browserId;
+    }
+  
+    /**
+     * @return a mapping of the accomodation codes to their respective segment position
+     */
+    public Map<Integer, Set<String>> getAccommodationCodes() {
+      return accommodationCodes;
+    }
+  
+  @Override
+  public boolean equals(Object o) {
+    if (this == o) return true;
+    if (o == null || getClass() != o.getClass()) return false;
+    
+    ApproveAccommodationsRequest that = (ApproveAccommodationsRequest) o;
+    
+    if (!sessionId.equals(that.sessionId)) return false;
+    if (!browserId.equals(that.browserId)) return false;
+    return accommodationCodes.equals(that.accommodationCodes);
+  }
+  
+  @Override
+  public int hashCode() {
+    int result = sessionId.hashCode();
+    result = 31 * result + browserId.hashCode();
+    result = 31 * result + accommodationCodes.hashCode();
+    return result;
+  }
+}

--- a/service/src/main/java/tds/exam/services/ExamAccommodationService.java
+++ b/service/src/main/java/tds/exam/services/ExamAccommodationService.java
@@ -1,11 +1,16 @@
 package tds.exam.services;
 
 import java.util.List;
+import java.util.Optional;
 import java.util.UUID;
 
 import tds.assessment.Assessment;
+import tds.common.Response;
+import tds.common.ValidationError;
+import tds.exam.ApproveAccommodationsRequest;
 import tds.exam.Exam;
 import tds.exam.ExamAccommodation;
+import tds.exam.ExamApproval;
 
 /**
  * Handles interaction with {@link tds.exam.ExamAccommodation}s associated to an {@link tds.exam.Exam}
@@ -56,4 +61,13 @@ public interface ExamAccommodationService {
      * @return list of {@link tds.exam.ExamAccommodation}
      */
     List<ExamAccommodation> initializeAccommodationsOnPreviousExam(Exam exam, Assessment assessment, int segmentPosition, boolean restoreRts, String guestAccommodations);
+    
+    /**
+     * Approves {@link tds.exam.ExamAccommodation}s for an exam and set of accommodation codes.
+     *
+     * @param examId  the id of the {@link tds.exam.Exam} to approve accommodations for
+     * @param request the {@link tds.exam.ApproveAccommodationsRequest} containing request datazz
+     * @return an optional {@link tds.common.ValidationError}
+     */
+    Optional<ValidationError> approveAccommodations(UUID examId, ApproveAccommodationsRequest request);
 }

--- a/service/src/main/java/tds/exam/services/impl/ExamApprovalServiceImpl.java
+++ b/service/src/main/java/tds/exam/services/impl/ExamApprovalServiceImpl.java
@@ -68,8 +68,8 @@ public class ExamApprovalServiceImpl implements ExamApprovalService {
         }
 
         ExternalSessionConfiguration externalSessionConfig =
-            sessionService.findExternalSessionConfigurationByClientName(approvalRequest.getClientName())
-                .orElseThrow(() -> new IllegalStateException(String.format("External Session Configuration could not be found for client name %s", approvalRequest.getClientName())));
+            sessionService.findExternalSessionConfigurationByClientName(exam.getClientName())
+                .orElseThrow(() -> new IllegalStateException(String.format("External Session Configuration could not be found for client name %s", exam.getClientName())));
 
         // RULE:  If the environment is set to "simulation" or "development", there is no need to check anything else.
         if (externalSessionConfig.isInSimulationEnvironment()
@@ -93,8 +93,8 @@ public class ExamApprovalServiceImpl implements ExamApprovalService {
 
         // RULE:  Student should not be able to start an exam if the TA check-in window has expired.
         TimeLimitConfiguration timeLimitConfig =
-            timeLimitConfigurationService.findTimeLimitConfiguration(approvalRequest.getClientName(), exam.getAssessmentId())
-                .orElseThrow(() -> new IllegalArgumentException(String.format("Could not find time limit configuration for client name %s and assessment id %s", approvalRequest.getClientName(), exam.getAssessmentId())));
+            timeLimitConfigurationService.findTimeLimitConfiguration(exam.getClientName(), exam.getAssessmentId())
+                .orElseThrow(() -> new IllegalArgumentException(String.format("Could not find time limit configuration for client name %s and assessment id %s", exam.getClientName(), exam.getAssessmentId())));
 
         // The Proctor application periodically polls to indicate the session is still "alive" and the Proctor is still
         // hosting the session.  If the Proctor does not respond or otherwise maintain this keep-alive/"heartbeat",

--- a/service/src/main/java/tds/exam/services/impl/ExamServiceImpl.java
+++ b/service/src/main/java/tds/exam/services/impl/ExamServiceImpl.java
@@ -313,7 +313,7 @@ class ExamServiceImpl implements ExamService {
 
         /* StudentDLL [5269] / TestOpportunityServiceImpl [137] */
         Optional<ValidationError> maybeAccessViolation = examApprovalService.verifyAccess(new ApprovalRequest(examId, session.getId(),
-            exam.getBrowserId(), exam.getClientName()), exam);
+            exam.getBrowserId()), exam);
         if (maybeAccessViolation.isPresent()) {
             return new Response<ExamConfiguration>(maybeAccessViolation.get());
         }

--- a/service/src/main/java/tds/exam/web/endpoints/ExamAccommodationController.java
+++ b/service/src/main/java/tds/exam/web/endpoints/ExamAccommodationController.java
@@ -1,44 +1,71 @@
 package tds.exam.web.endpoints;
 
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.hateoas.Link;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.HttpStatus;
 import org.springframework.http.MediaType;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestMethod;
 import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 
 import java.util.List;
+import java.util.Optional;
 import java.util.UUID;
 
+import tds.common.ValidationError;
+import tds.common.web.resources.NoContentResponseResource;
+import tds.exam.ApproveAccommodationsRequest;
 import tds.exam.ExamAccommodation;
 import tds.exam.services.ExamAccommodationService;
+
+import static org.springframework.hateoas.mvc.ControllerLinkBuilder.linkTo;
+import static org.springframework.hateoas.mvc.ControllerLinkBuilder.methodOn;
 
 @RestController
 @RequestMapping("/exam")
 public class ExamAccommodationController {
     private final ExamAccommodationService examAccommodationService;
-
+    
     @Autowired
     public ExamAccommodationController(ExamAccommodationService examAccommodationService) {
         this.examAccommodationService = examAccommodationService;
     }
-
+    
     @RequestMapping(value = "/{examId}/{segmentId}/accommodations", method = RequestMethod.GET, produces = MediaType.APPLICATION_JSON_VALUE)
     ResponseEntity<List<ExamAccommodation>> findAccommodations(@PathVariable final UUID examId,
                                                                @PathVariable final String segmentId,
                                                                @RequestParam(name = "type", required = false) final String[] accommodationTypes) {
         return ResponseEntity.ok(examAccommodationService.findAccommodations(examId, segmentId, accommodationTypes));
     }
-
-    @RequestMapping(value = "/{examId}/accommodations")
+    
+    @RequestMapping(value = "/{examId}/accommodations", method = RequestMethod.GET)
     ResponseEntity<List<ExamAccommodation>> findAccommodations(@PathVariable final UUID examId) {
         return ResponseEntity.ok(examAccommodationService.findAllAccommodations(examId));
     }
-
+    
     @RequestMapping(value = "/{examId}/accommodations/approved")
     ResponseEntity<List<ExamAccommodation>> findApprovedAccommodations(@PathVariable final UUID examId) {
         return ResponseEntity.ok(examAccommodationService.findApprovedAccommodations(examId));
+    }
+    
+    @RequestMapping(value = "/{examId}/accommodations", method = RequestMethod.POST, produces = MediaType.APPLICATION_JSON_VALUE)
+    ResponseEntity<NoContentResponseResource> approveAccommodations(@PathVariable final UUID examId, @RequestBody ApproveAccommodationsRequest request) {
+        Optional<ValidationError> maybeError = examAccommodationService.approveAccommodations(examId, request);
+        
+        if (maybeError.isPresent()) {
+            NoContentResponseResource response = new NoContentResponseResource(maybeError.get());
+            return new ResponseEntity<>(response, HttpStatus.UNPROCESSABLE_ENTITY);
+        }
+        
+        Link link = linkTo(methodOn(ExamAccommodationController.class).findAccommodations(examId)).withSelfRel();
+        final HttpHeaders headers = new HttpHeaders();
+        headers.add("Location", link.getHref());
+        
+        return new ResponseEntity<>(headers, HttpStatus.NO_CONTENT);
     }
 }

--- a/service/src/main/java/tds/exam/web/endpoints/ExamApprovalController.java
+++ b/service/src/main/java/tds/exam/web/endpoints/ExamApprovalController.java
@@ -32,9 +32,8 @@ public class ExamApprovalController {
     @RequestMapping(value = "/{id}/approval", method = RequestMethod.GET, produces = MediaType.APPLICATION_JSON_VALUE)
     ResponseEntity<Response<ExamApproval>> getApproval(@PathVariable final UUID id,
                                                        @RequestParam final UUID sessionId,
-                                                       @RequestParam final UUID browserId,
-                                                       @RequestParam final String clientName) {
-        ApprovalRequest approvalRequest = new ApprovalRequest(id, sessionId, browserId, clientName);
+                                                       @RequestParam final UUID browserId) {
+        ApprovalRequest approvalRequest = new ApprovalRequest(id, sessionId, browserId);
         Response<ExamApproval> examApproval = examApprovalService.getApproval(approvalRequest);
 
         if (examApproval.hasError()) {

--- a/service/src/main/java/tds/exam/web/endpoints/ExamPageController.java
+++ b/service/src/main/java/tds/exam/web/endpoints/ExamPageController.java
@@ -31,9 +31,8 @@ public class ExamPageController {
     ResponseEntity<Response<ExamPage>> getPage(@PathVariable final UUID id,
                                                @PathVariable final int position,
                                                @RequestParam final UUID sessionId,
-                                               @RequestParam final UUID browserId,
-                                               @RequestParam final String clientName) {
-        ApprovalRequest approvalRequest = new ApprovalRequest(id, sessionId, browserId, clientName);
+                                               @RequestParam final UUID browserId) {
+        ApprovalRequest approvalRequest = new ApprovalRequest(id, sessionId, browserId);
         Response<ExamPage> page = examPageService.getPage(approvalRequest, position);
 
         if (page.hasError()) {

--- a/service/src/test/java/tds/exam/services/impl/ExamApprovalServiceImplTest.java
+++ b/service/src/test/java/tds/exam/services/impl/ExamApprovalServiceImplTest.java
@@ -66,6 +66,7 @@ public class ExamApprovalServiceImplTest {
                 .withId(examId)
                 .withSessionId(sessionId)
                 .withBrowserId(browserKey)
+                .withClientName(clientName)
                 .withAssessmentId(mockAssessmentId)
                 .withStatus(new ExamStatusCode(ExamStatusCode.STATUS_APPROVED, OPEN), Instant.now())
                 .build()));
@@ -87,7 +88,7 @@ public class ExamApprovalServiceImplTest {
                 .withTaCheckinTimeMinutes(20)
                 .build()));
 
-        ApprovalRequest approvalRequest = new ApprovalRequest(examId, sessionId, browserKey, clientName);
+        ApprovalRequest approvalRequest = new ApprovalRequest(examId, sessionId, browserKey);
 
         Response<ExamApproval> result = examApprovalService.getApproval(approvalRequest);
 
@@ -110,6 +111,7 @@ public class ExamApprovalServiceImplTest {
             .thenReturn(Optional.of(new Exam.Builder()
                 .withId(examId)
                 .withSessionId(sessionId)
+                .withClientName(clientName)
                 .withBrowserId(browserKey)
                 .withAssessmentId(mockAssessmentId)
                 .withStatus(new ExamStatusCode(STATUS_PENDING, OPEN), Instant.now())
@@ -132,7 +134,7 @@ public class ExamApprovalServiceImplTest {
                 .withTaCheckinTimeMinutes(20)
                 .build()));
 
-        ApprovalRequest approvalRequest = new ApprovalRequest(examId, sessionId, browserKey, clientName);
+        ApprovalRequest approvalRequest = new ApprovalRequest(examId, sessionId, browserKey);
 
         Response<ExamApproval> result = examApprovalService.getApproval(approvalRequest);
 
@@ -154,6 +156,7 @@ public class ExamApprovalServiceImplTest {
         when(mockExamQueryRepository.getExamById(examId))
             .thenReturn(Optional.of(new Exam.Builder()
                 .withId(examId)
+                .withClientName(clientName)
                 .withSessionId(sessionId)
                 .withBrowserId(browserKey)
                 .withAssessmentId(mockAssessmentId)
@@ -177,7 +180,7 @@ public class ExamApprovalServiceImplTest {
                 .withTaCheckinTimeMinutes(20)
                 .build()));
 
-        ApprovalRequest approvalRequest = new ApprovalRequest(examId, sessionId, browserKey, clientName);
+        ApprovalRequest approvalRequest = new ApprovalRequest(examId, sessionId, browserKey);
 
         Response<ExamApproval> result = examApprovalService.getApproval(approvalRequest);
 
@@ -200,6 +203,7 @@ public class ExamApprovalServiceImplTest {
             .thenReturn(Optional.of(new Exam.Builder()
                 .withId(examId)
                 .withSessionId(sessionId)
+                .withClientName(clientName)
                 .withBrowserId(browserKey)
                 .withAssessmentId(mockAssessmentId)
                 .withStatus(new ExamStatusCode(ExamStatusCode.STATUS_APPROVED, OPEN), Instant.now())
@@ -222,7 +226,7 @@ public class ExamApprovalServiceImplTest {
                 .withTaCheckinTimeMinutes(20)
                 .build()));
 
-        ApprovalRequest approvalRequest = new ApprovalRequest(examId, sessionId, browserKey, clientName);
+        ApprovalRequest approvalRequest = new ApprovalRequest(examId, sessionId, browserKey);
 
         Response<ExamApproval> result = examApprovalService.getApproval(approvalRequest);
 
@@ -245,6 +249,7 @@ public class ExamApprovalServiceImplTest {
             .thenReturn(Optional.of(new Exam.Builder()
                 .withId(examId)
                 .withSessionId(sessionId)
+                .withClientName(clientName)
                 .withBrowserId(UUID.randomUUID())
                 .withAssessmentId(mockAssessmentId)
                 .build()));
@@ -266,7 +271,7 @@ public class ExamApprovalServiceImplTest {
                 .withTaCheckinTimeMinutes(20)
                 .build()));
 
-        ApprovalRequest approvalRequest = new ApprovalRequest(examId, sessionId, browserKey, clientName);
+        ApprovalRequest approvalRequest = new ApprovalRequest(examId, sessionId, browserKey);
 
         Response<ExamApproval> result = examApprovalService.getApproval(approvalRequest);
 
@@ -287,6 +292,7 @@ public class ExamApprovalServiceImplTest {
             .thenReturn(Optional.of(new Exam.Builder()
                 .withId(examId)
                 .withSessionId(UUID.randomUUID())
+                .withClientName(clientName)
                 .withBrowserId(browserKey)
                 .withAssessmentId(mockAssessmentId)
                 .build()));
@@ -308,7 +314,7 @@ public class ExamApprovalServiceImplTest {
                 .withTaCheckinTimeMinutes(20)
                 .build()));
 
-        ApprovalRequest approvalRequest = new ApprovalRequest(examId, sessionId, browserKey, clientName);
+        ApprovalRequest approvalRequest = new ApprovalRequest(examId, sessionId, browserKey);
 
         Response<ExamApproval> result = examApprovalService.getApproval(approvalRequest);
 
@@ -328,6 +334,7 @@ public class ExamApprovalServiceImplTest {
         when(mockExamQueryRepository.getExamById(examId))
             .thenReturn(Optional.of(new Exam.Builder()
                 .withId(examId)
+                .withClientName(clientName)
                 .withSessionId(sessionId)
                 .withBrowserId(browserKey)
                 .withAssessmentId(mockAssessmentId)
@@ -350,7 +357,7 @@ public class ExamApprovalServiceImplTest {
                 .withTaCheckinTimeMinutes(20)
                 .build()));
 
-        ApprovalRequest approvalRequest = new ApprovalRequest(examId, sessionId, browserKey, clientName);
+        ApprovalRequest approvalRequest = new ApprovalRequest(examId, sessionId, browserKey);
 
         Response<ExamApproval> result = examApprovalService.getApproval(approvalRequest);
 
@@ -371,6 +378,7 @@ public class ExamApprovalServiceImplTest {
             .thenReturn(Optional.of(new Exam.Builder()
                 .withId(examId)
                 .withSessionId(sessionId)
+                .withClientName(clientName)
                 .withBrowserId(browserKey)
                 .withAssessmentId(mockAssessmentId)
                 .build()));
@@ -392,7 +400,7 @@ public class ExamApprovalServiceImplTest {
                 .withTaCheckinTimeMinutes(20)
                 .build()));
 
-        ApprovalRequest approvalRequest = new ApprovalRequest(examId, sessionId, browserKey, clientName);
+        ApprovalRequest approvalRequest = new ApprovalRequest(examId, sessionId, browserKey);
 
         Response<ExamApproval> result = examApprovalService.getApproval(approvalRequest);
 
@@ -429,7 +437,7 @@ public class ExamApprovalServiceImplTest {
                 .withTaCheckinTimeMinutes(20)
                 .build()));
 
-        ApprovalRequest approvalRequest = new ApprovalRequest(examId, sessionId, browserKey, clientName);
+        ApprovalRequest approvalRequest = new ApprovalRequest(examId, sessionId, browserKey);
 
         examApprovalService.getApproval(approvalRequest);
     }
@@ -446,6 +454,7 @@ public class ExamApprovalServiceImplTest {
         when(mockExamQueryRepository.getExamById(examId))
             .thenReturn(Optional.of(new Exam.Builder()
                 .withId(examId)
+                .withClientName(clientName)
                 .withSessionId(sessionId)
                 .withBrowserId(browserKey)
                 .withAssessmentId(mockAssessmentId)
@@ -461,7 +470,7 @@ public class ExamApprovalServiceImplTest {
                 .withTaCheckinTimeMinutes(20)
                 .build()));
 
-        ApprovalRequest approvalRequest = new ApprovalRequest(examId, sessionId, browserKey, clientName);
+        ApprovalRequest approvalRequest = new ApprovalRequest(examId, sessionId, browserKey);
 
         examApprovalService.getApproval(approvalRequest);
     }
@@ -479,6 +488,7 @@ public class ExamApprovalServiceImplTest {
             .thenReturn(Optional.of(new Exam.Builder()
                 .withId(examId)
                 .withSessionId(sessionId)
+                .withClientName(clientName)
                 .withBrowserId(browserKey)
                 .withAssessmentId(mockAssessmentId)
                 .build()));
@@ -500,7 +510,7 @@ public class ExamApprovalServiceImplTest {
                 .withTaCheckinTimeMinutes(20)
                 .build()));
 
-        ApprovalRequest approvalRequest = new ApprovalRequest(examId, sessionId, browserKey, clientName);
+        ApprovalRequest approvalRequest = new ApprovalRequest(examId, sessionId, browserKey);
 
         examApprovalService.getApproval(approvalRequest);
     }
@@ -517,6 +527,7 @@ public class ExamApprovalServiceImplTest {
         when(mockExamQueryRepository.getExamById(examId))
             .thenReturn(Optional.of(new Exam.Builder()
                 .withId(examId)
+                .withClientName(clientName)
                 .withSessionId(sessionId)
                 .withBrowserId(browserKey)
                 .withAssessmentId(mockAssessmentId)
@@ -535,7 +546,7 @@ public class ExamApprovalServiceImplTest {
         when(mockTimeLimitConfigurationService.findTimeLimitConfiguration(clientName, mockAssessmentId))
             .thenReturn(Optional.empty());
 
-        ApprovalRequest approvalRequest = new ApprovalRequest(examId, sessionId, browserKey, clientName);
+        ApprovalRequest approvalRequest = new ApprovalRequest(examId, sessionId, browserKey);
 
         examApprovalService.getApproval(approvalRequest);
     }

--- a/service/src/test/java/tds/exam/services/impl/ExamPageServiceImplTest.java
+++ b/service/src/test/java/tds/exam/services/impl/ExamPageServiceImplTest.java
@@ -109,7 +109,6 @@ public class ExamPageServiceImplTest {
         UUID mockExamId = UUID.randomUUID();
         UUID mockSessionId = UUID.randomUUID();
         UUID mockBrowserId = UUID.randomUUID();
-        String mockClientName = "UNIT_TEST";
 
         Instant respondedAtInstant = Instant.now().minus(200000);
         ExamItem mockFirstExamItem = new ExamItemBuilder()
@@ -138,10 +137,7 @@ public class ExamPageServiceImplTest {
             .withExamItems(mockExamItems)
             .build();
 
-        ApprovalRequest mockApprovalRequest = new ApprovalRequest(mockExamId,
-            mockSessionId,
-            mockBrowserId,
-            mockClientName);
+        ApprovalRequest mockApprovalRequest = new ApprovalRequest(mockExamId, mockSessionId, mockBrowserId);
 
         ExamApproval mockExamApproval = new ExamApproval(mockExamId,
             new ExamStatusCode(ExamStatusCode.STATUS_STARTED, ExamStatusStage.IN_PROGRESS),
@@ -169,11 +165,9 @@ public class ExamPageServiceImplTest {
         UUID mockExamId = UUID.randomUUID();
         UUID mockSessionId = UUID.randomUUID();
         UUID mockBrowserId = UUID.randomUUID();
-        String mockClientName = "UNIT_TEST";
         ApprovalRequest mockApprovalRequest = new ApprovalRequest(mockExamId,
             mockSessionId,
-            mockBrowserId,
-            mockClientName);
+            mockBrowserId);
 
         Response<ExamApproval> mockApprovalFailure = new Response<>(new ValidationError(ValidationErrorCode.EXAM_APPROVAL_SESSION_CLOSED, "The session is not available for testing, please check with your test administrator."));
 

--- a/service/src/test/java/tds/exam/web/endpoints/ExamAccommodationControllerTest.java
+++ b/service/src/test/java/tds/exam/web/endpoints/ExamAccommodationControllerTest.java
@@ -8,12 +8,21 @@ import org.mockito.Mock;
 import org.mockito.runners.MockitoJUnitRunner;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
+import org.springframework.mock.web.MockHttpServletRequest;
+import org.springframework.web.context.request.RequestContextHolder;
+import org.springframework.web.context.request.ServletRequestAttributes;
 
+import javax.servlet.http.HttpServletRequest;
 import java.util.ArrayList;
 import java.util.Collections;
+import java.util.HashMap;
 import java.util.List;
+import java.util.Optional;
 import java.util.UUID;
 
+import tds.common.ValidationError;
+import tds.common.web.resources.NoContentResponseResource;
+import tds.exam.ApproveAccommodationsRequest;
 import tds.exam.ExamAccommodation;
 import tds.exam.builder.ExamAccommodationBuilder;
 import tds.exam.services.ExamAccommodationService;
@@ -26,32 +35,35 @@ import static org.mockito.Mockito.when;
 @RunWith(MockitoJUnitRunner.class)
 public class ExamAccommodationControllerTest {
     private ExamAccommodationController controller;
-
+    
     @Mock
     private ExamAccommodationService mockExamAccommodationService;
-
+    
     @Before
     public void setUp() {
+        HttpServletRequest request = new MockHttpServletRequest();
+        ServletRequestAttributes requestAttributes = new ServletRequestAttributes(request);
+        RequestContextHolder.setRequestAttributes(requestAttributes);
         controller = new ExamAccommodationController(mockExamAccommodationService);
     }
-
+    
     @Test
     public void shouldGetASingleAccommodation() {
         List<ExamAccommodation> mockExamAccommodations = new ArrayList<>();
         mockExamAccommodations.add(new ExamAccommodationBuilder().build());
-
+        
         when(mockExamAccommodationService.findAccommodations(ExamAccommodationBuilder.SampleData.DEFAULT_EXAM_ID,
             ExamAccommodationBuilder.SampleData.DEFAULT_SEGMENT_KEY,
             ExamAccommodationBuilder.SampleData.DEFAULT_ACCOMMODATION_TYPE))
             .thenReturn(mockExamAccommodations);
-
+        
         ResponseEntity<List<ExamAccommodation>> response = controller.findAccommodations(ExamAccommodationBuilder.SampleData.DEFAULT_EXAM_ID,
             ExamAccommodationBuilder.SampleData.DEFAULT_SEGMENT_KEY,
             new String[]{ExamAccommodationBuilder.SampleData.DEFAULT_ACCOMMODATION_TYPE});
         verify(mockExamAccommodationService).findAccommodations(ExamAccommodationBuilder.SampleData.DEFAULT_EXAM_ID,
             ExamAccommodationBuilder.SampleData.DEFAULT_SEGMENT_KEY,
             ExamAccommodationBuilder.SampleData.DEFAULT_ACCOMMODATION_TYPE);
-
+        
         assertThat(response.getStatusCode()).isEqualTo(HttpStatus.OK);
         assertThat(response.getBody()).hasSize(1);
         assertThat(response.getBody().get(0).getExamId()).isEqualTo(ExamAccommodationBuilder.SampleData.DEFAULT_EXAM_ID);
@@ -60,7 +72,7 @@ public class ExamAccommodationControllerTest {
         assertThat(response.getBody().get(0).getCode()).isEqualTo(ExamAccommodationBuilder.SampleData.DEFAULT_ACCOMMODATION_CODE);
         assertThat(response.getBody().get(0).isApproved()).isTrue();
     }
-
+    
     @Test
     public void shouldGetTwoAccommodationsForTheSpecifiedAccommodationTypes() {
         List<ExamAccommodation> mockExamAccommodations = new ArrayList<>();
@@ -69,35 +81,35 @@ public class ExamAccommodationControllerTest {
             .withType("closed captioning")
             .withCode("TDS_ClosedCap0")
             .build());
-
+        
         when(mockExamAccommodationService.findAccommodations(ExamAccommodationBuilder.SampleData.DEFAULT_EXAM_ID,
             ExamAccommodationBuilder.SampleData.DEFAULT_SEGMENT_KEY,
             ExamAccommodationBuilder.SampleData.DEFAULT_ACCOMMODATION_TYPE,
             "closed captioning"))
             .thenReturn(mockExamAccommodations);
-
+        
         ResponseEntity<List<ExamAccommodation>> response = controller.findAccommodations(ExamAccommodationBuilder.SampleData.DEFAULT_EXAM_ID,
             ExamAccommodationBuilder.SampleData.DEFAULT_SEGMENT_KEY,
             new String[]{
                 ExamAccommodationBuilder.SampleData.DEFAULT_ACCOMMODATION_TYPE,
                 "closed captioning"});
-
+        
         assertThat(response.getStatusCode()).isEqualTo(HttpStatus.OK);
         assertThat(response.getBody()).hasSize(2);
-
+        
         ExamAccommodation firstResult = response.getBody().get(0);
         assertThat(firstResult.getExamId()).isEqualTo(ExamAccommodationBuilder.SampleData.DEFAULT_EXAM_ID);
         assertThat(firstResult.getSegmentKey()).isEqualTo(ExamAccommodationBuilder.SampleData.DEFAULT_SEGMENT_KEY);
         assertThat(firstResult.getCode()).isEqualTo(ExamAccommodationBuilder.SampleData.DEFAULT_ACCOMMODATION_CODE);
         assertThat(firstResult.isApproved()).isTrue();
-
+        
         ExamAccommodation secondResult = response.getBody().get(1);
         assertThat(secondResult.getExamId()).isEqualTo(ExamAccommodationBuilder.SampleData.DEFAULT_EXAM_ID);
         assertThat(secondResult.getSegmentKey()).isEqualTo(ExamAccommodationBuilder.SampleData.DEFAULT_SEGMENT_KEY);
         assertThat(secondResult.getCode()).isEqualTo("TDS_ClosedCap0");
         assertThat(secondResult.isApproved()).isTrue();
     }
-
+    
     @Test
     public void shouldIncludeDeniedAccommodations() {
         List<ExamAccommodation> mockExamAccommodations = new ArrayList<>();
@@ -107,68 +119,105 @@ public class ExamAccommodationControllerTest {
             .withCode("TDS_ClosedCap0")
             .withDeniedAt(Instant.now())
             .build());
-
+        
         when(mockExamAccommodationService.findAccommodations(ExamAccommodationBuilder.SampleData.DEFAULT_EXAM_ID,
             ExamAccommodationBuilder.SampleData.DEFAULT_SEGMENT_KEY,
             ExamAccommodationBuilder.SampleData.DEFAULT_ACCOMMODATION_TYPE,
             "closed captioning"))
             .thenReturn(mockExamAccommodations);
-
+        
         ResponseEntity<List<ExamAccommodation>> response = controller.findAccommodations(ExamAccommodationBuilder.SampleData.DEFAULT_EXAM_ID,
             ExamAccommodationBuilder.SampleData.DEFAULT_SEGMENT_KEY,
             new String[]{
                 ExamAccommodationBuilder.SampleData.DEFAULT_ACCOMMODATION_TYPE,
                 "closed captioning"});
-
+        
         assertThat(response.getStatusCode()).isEqualTo(HttpStatus.OK);
         assertThat(response.getBody()).hasSize(2);
-
+        
         ExamAccommodation firstResult = response.getBody().get(0);
         assertThat(firstResult.getExamId()).isEqualTo(ExamAccommodationBuilder.SampleData.DEFAULT_EXAM_ID);
         assertThat(firstResult.getSegmentKey()).isEqualTo(ExamAccommodationBuilder.SampleData.DEFAULT_SEGMENT_KEY);
         assertThat(firstResult.getCode()).isEqualTo(ExamAccommodationBuilder.SampleData.DEFAULT_ACCOMMODATION_CODE);
         assertThat(firstResult.isApproved()).isTrue();
-
+        
         ExamAccommodation secondResult = response.getBody().get(1);
         assertThat(secondResult.getExamId()).isEqualTo(ExamAccommodationBuilder.SampleData.DEFAULT_EXAM_ID);
         assertThat(secondResult.getSegmentKey()).isEqualTo(ExamAccommodationBuilder.SampleData.DEFAULT_SEGMENT_KEY);
         assertThat(secondResult.getCode()).isEqualTo("TDS_ClosedCap0");
         assertThat(secondResult.isApproved()).isFalse();
     }
-
+    
     @Test
     public void shouldReturnAllAccommodations() {
         UUID examId = UUID.randomUUID();
         ExamAccommodation examAccommodation = new ExamAccommodationBuilder()
             .withExamId(examId)
             .build();
-
+        
         when(mockExamAccommodationService.findAllAccommodations(examId)).thenReturn(Collections.singletonList(examAccommodation));
-
+        
         ResponseEntity<List<ExamAccommodation>> response = controller.findAccommodations(examId);
-
+        
         verify(mockExamAccommodationService).findAllAccommodations(examId);
         verifyNoMoreInteractions(mockExamAccommodationService);
-
+        
         assertThat(response.getStatusCode()).isEqualTo(HttpStatus.OK);
         assertThat(response.getBody()).containsExactly(examAccommodation);
     }
-
+    
     @Test
     public void shouldReturnApprovedAccommodations() {
         UUID examId = UUID.randomUUID();
         ExamAccommodation examAccommodation = new ExamAccommodationBuilder()
             .withExamId(examId)
             .build();
-
+        
         when(mockExamAccommodationService.findApprovedAccommodations(examId)).thenReturn(Collections.singletonList(examAccommodation));
-
+        
         ResponseEntity<List<ExamAccommodation>> response = controller.findApprovedAccommodations(examId);
-
+        
         verify(mockExamAccommodationService).findApprovedAccommodations(examId);
         verifyNoMoreInteractions(mockExamAccommodationService);
-
+        
         assertThat(response.getStatusCode()).isEqualTo(HttpStatus.OK);
         assertThat(response.getBody()).containsExactly(examAccommodation);
+    }
+    
+    @Test
+    public void shouldApproveAccommodationsAndReturnNoErrors() {
+        final UUID examId = UUID.randomUUID();
+        final UUID sessionId = UUID.randomUUID();
+        final UUID browserId = UUID.randomUUID();
+        ApproveAccommodationsRequest request = new ApproveAccommodationsRequest(sessionId, browserId, new HashMap<>());
+        
+        when(mockExamAccommodationService.approveAccommodations(examId, request)).thenReturn(Optional.empty());
+        
+        ResponseEntity<NoContentResponseResource> response = controller.approveAccommodations(examId, request);
+        
+        verify(mockExamAccommodationService).approveAccommodations(examId, request);
+        verifyNoMoreInteractions(mockExamAccommodationService);
+        
+        assertThat(response.getStatusCode()).isEqualTo(HttpStatus.NO_CONTENT);
+    }
+    
+    @Test
+    public void shouldReturnValidationError() {
+        final UUID examId = UUID.randomUUID();
+        final UUID sessionId = UUID.randomUUID();
+        final UUID browserId = UUID.randomUUID();
+        final String errCode = "Error code";
+        final String errMsg = "Error message";
+        ApproveAccommodationsRequest request = new ApproveAccommodationsRequest(sessionId, browserId, new HashMap<>());
+        
+        when(mockExamAccommodationService.approveAccommodations(examId, request)).thenReturn(Optional.of(new ValidationError(errCode, errMsg)));
+        
+        ResponseEntity<NoContentResponseResource> response = controller.approveAccommodations(examId, request);
+        
+        verify(mockExamAccommodationService).approveAccommodations(examId, request);
+        verifyNoMoreInteractions(mockExamAccommodationService);
+        
+        assertThat(response.getStatusCode()).isEqualTo(HttpStatus.UNPROCESSABLE_ENTITY);
+        assertThat(response.getBody().getErrors()).isNotEmpty();
     }
 }

--- a/service/src/test/java/tds/exam/web/endpoints/ExamApprovalControllerIntegrationTests.java
+++ b/service/src/test/java/tds/exam/web/endpoints/ExamApprovalControllerIntegrationTests.java
@@ -47,9 +47,8 @@ public class ExamApprovalControllerIntegrationTests {
         UUID examId = UUID.randomUUID();
         UUID sessionId = UUID.randomUUID();
         UUID browserId = UUID.randomUUID();
-        String clientName = "UNIT_TEST";
 
-        ApprovalRequest approvalRequest = new ApprovalRequest(examId, sessionId, browserId, clientName);
+        ApprovalRequest approvalRequest = new ApprovalRequest(examId, sessionId, browserId);
         ArgumentCaptor<ApprovalRequest> approvalRequestArgumentCaptor = ArgumentCaptor.forClass(ApprovalRequest.class);
         ExamApproval mockApproval = new ExamApproval(examId,
             new ExamStatusCode(ExamStatusCode.STATUS_APPROVED, ExamStatusStage.INACTIVE),
@@ -61,8 +60,7 @@ public class ExamApprovalControllerIntegrationTests {
         http.perform(get("/exam/{id}/approval", examId)
             .contentType(MediaType.APPLICATION_JSON)
             .param("sessionId", approvalRequest.getSessionId().toString())
-            .param("browserId", approvalRequest.getBrowserId().toString())
-            .param("clientName", approvalRequest.getClientName()))
+            .param("browserId", approvalRequest.getBrowserId().toString()))
             .andExpect(status().isOk())
             .andExpect(jsonPath("data").isNotEmpty())
             .andExpect(jsonPath("data.examId", is(examId.toString())))
@@ -76,9 +74,8 @@ public class ExamApprovalControllerIntegrationTests {
         UUID examId = UUID.randomUUID();
         UUID sessionId = UUID.randomUUID();
         UUID browserId = UUID.randomUUID();
-        String clientName = "UNIT_TEST";
 
-        ApprovalRequest approvalRequest = new ApprovalRequest(examId, sessionId, browserId, clientName);
+        ApprovalRequest approvalRequest = new ApprovalRequest(examId, sessionId, browserId);
         ArgumentCaptor<ApprovalRequest> approvalRequestArgumentCaptor = ArgumentCaptor.forClass(ApprovalRequest.class);
         ValidationError mockFailure = new ValidationError(ValidationErrorCode.EXAM_APPROVAL_SESSION_CLOSED, "session is closed");
 
@@ -88,8 +85,7 @@ public class ExamApprovalControllerIntegrationTests {
         http.perform(get("/exam/{id}/approval", examId)
             .contentType(MediaType.APPLICATION_JSON)
             .param("sessionId", approvalRequest.getSessionId().toString())
-            .param("browserId", approvalRequest.getBrowserId().toString())
-            .param("clientName", approvalRequest.getClientName()))
+            .param("browserId", approvalRequest.getBrowserId().toString()))
             .andExpect(status().isUnprocessableEntity())
             .andExpect(jsonPath("error").isNotEmpty())
             .andExpect(jsonPath("error.code", is(ValidationErrorCode.EXAM_APPROVAL_SESSION_CLOSED)))

--- a/service/src/test/java/tds/exam/web/endpoints/ExamApprovalControllerTest.java
+++ b/service/src/test/java/tds/exam/web/endpoints/ExamApprovalControllerTest.java
@@ -51,8 +51,7 @@ public class ExamApprovalControllerTest {
         UUID examId = UUID.randomUUID();
         UUID sessionId = UUID.randomUUID();
         UUID browserId = UUID.randomUUID();
-        String clientName = "UNIT_TEST";
-        ApprovalRequest approvalRequest = new ApprovalRequest(examId, sessionId, browserId, clientName);
+        ApprovalRequest approvalRequest = new ApprovalRequest(examId, sessionId, browserId);
 
         ExamApproval mockExamApproval = new ExamApproval(examId,
             new ExamStatusCode(STATUS_APPROVED,
@@ -63,8 +62,7 @@ public class ExamApprovalControllerTest {
         ResponseEntity<Response<ExamApproval>> response = controller.getApproval(
             approvalRequest.getExamId(),
             approvalRequest.getSessionId(),
-            approvalRequest.getBrowserId(),
-            approvalRequest.getClientName());
+            approvalRequest.getBrowserId());
         verify(mockExamApprovalService).getApproval(isA(ApprovalRequest.class));
 
         assertThat(response.getStatusCode()).isEqualTo(HttpStatus.OK);
@@ -79,8 +77,7 @@ public class ExamApprovalControllerTest {
         UUID examId = UUID.randomUUID();
         UUID sessionId = UUID.randomUUID();
         UUID browserId = UUID.randomUUID();
-        String clientName = "UNIT_TEST";
-        ApprovalRequest approvalRequest = new ApprovalRequest(examId, sessionId, browserId, clientName);
+        ApprovalRequest approvalRequest = new ApprovalRequest(examId, sessionId, browserId);
 
         Response<ExamApproval> errorResponse = new Response<ExamApproval>(new ValidationError(ValidationErrorCode.EXAM_APPROVAL_BROWSER_ID_MISMATCH, "foo"));
         when(mockExamApprovalService.getApproval(isA(ApprovalRequest.class))).thenReturn(errorResponse);
@@ -88,8 +85,7 @@ public class ExamApprovalControllerTest {
         ResponseEntity<Response<ExamApproval>> response = controller.getApproval(
             approvalRequest.getExamId(),
             approvalRequest.getSessionId(),
-            approvalRequest.getBrowserId(),
-            approvalRequest.getClientName());
+            approvalRequest.getBrowserId());
         verify(mockExamApprovalService).getApproval(isA(ApprovalRequest.class));
 
         assertThat(response.getStatusCode()).isEqualTo(HttpStatus.UNPROCESSABLE_ENTITY);

--- a/service/src/test/java/tds/exam/web/endpoints/ExamPageControllerIntegrationTests.java
+++ b/service/src/test/java/tds/exam/web/endpoints/ExamPageControllerIntegrationTests.java
@@ -59,8 +59,7 @@ public class ExamPageControllerIntegrationTests {
             .build();
         ApprovalRequest approvalRequest = new ApprovalRequest(examPage.getExamId(),
             UUID.randomUUID(),
-            UUID.randomUUID(),
-            "UNIT_TEST");
+            UUID.randomUUID());
 
         ArgumentCaptor<ApprovalRequest> approvalRequestArgumentCaptor = ArgumentCaptor.forClass(ApprovalRequest.class);
         when(mockExamPageService.getPage(isA(ApprovalRequest.class), isA(Integer.class)))
@@ -69,8 +68,7 @@ public class ExamPageControllerIntegrationTests {
         http.perform(get("/exam/{id}/page/{position}", examPage.getExamId(), examPage.getPagePosition())
             .contentType(MediaType.APPLICATION_JSON)
             .param("sessionId", approvalRequest.getSessionId().toString())
-            .param("browserId", approvalRequest.getBrowserId().toString())
-            .param("clientName", approvalRequest.getClientName()))
+            .param("browserId", approvalRequest.getBrowserId().toString()))
             .andExpect(status().isOk())
             .andExpect(jsonPath("data").isNotEmpty())
             .andExpect(jsonPath("data.id", is(examPage.getId().toString())))
@@ -116,8 +114,7 @@ public class ExamPageControllerIntegrationTests {
             .build();
         ApprovalRequest approvalRequest = new ApprovalRequest(examPage.getExamId(),
             UUID.randomUUID(),
-            UUID.randomUUID(),
-            "UNIT_TEST");
+            UUID.randomUUID());
 
         ArgumentCaptor<ApprovalRequest> approvalRequestArgumentCaptor = ArgumentCaptor.forClass(ApprovalRequest.class);
         when(mockExamPageService.getPage(isA(ApprovalRequest.class), isA(Integer.class)))
@@ -126,8 +123,7 @@ public class ExamPageControllerIntegrationTests {
         http.perform(get("/exam/{id}/page/{position}", examPage.getExamId(), examPage.getPagePosition())
             .contentType(MediaType.APPLICATION_JSON)
             .param("sessionId", approvalRequest.getSessionId().toString())
-            .param("browserId", approvalRequest.getBrowserId().toString())
-            .param("clientName", approvalRequest.getClientName()))
+            .param("browserId", approvalRequest.getBrowserId().toString()))
             .andExpect(status().isOk())
             .andExpect(jsonPath("data").isNotEmpty())
             .andExpect(jsonPath("data.id", is(examPage.getId().toString())))
@@ -162,8 +158,7 @@ public class ExamPageControllerIntegrationTests {
     public void shouldNotGetAnExamPageForAClosedSession() throws Exception {
         ApprovalRequest approvalRequest = new ApprovalRequest(UUID.randomUUID(),
             UUID.randomUUID(),
-            UUID.randomUUID(),
-            "UNIT_TEST");
+            UUID.randomUUID());
 
         ArgumentCaptor<ApprovalRequest> approvalRequestArgumentCaptor = ArgumentCaptor.forClass(ApprovalRequest.class);
         when(mockExamPageService.getPage(isA(ApprovalRequest.class), isA(Integer.class)))
@@ -172,8 +167,7 @@ public class ExamPageControllerIntegrationTests {
         http.perform(get("/exam/{id}/page/{position}", approvalRequest.getExamId(), 1)
             .contentType(MediaType.APPLICATION_JSON)
             .param("sessionId", approvalRequest.getSessionId().toString())
-            .param("browserId", approvalRequest.getBrowserId().toString())
-            .param("clientName", approvalRequest.getClientName()))
+            .param("browserId", approvalRequest.getBrowserId().toString()))
             .andExpect(status().isUnprocessableEntity())
             .andExpect(jsonPath("error").isNotEmpty())
             .andExpect(jsonPath("error.code", is("sessionClosed")))

--- a/service/src/test/java/tds/exam/web/endpoints/ExamPageControllerTest.java
+++ b/service/src/test/java/tds/exam/web/endpoints/ExamPageControllerTest.java
@@ -43,10 +43,9 @@ public class ExamPageControllerTest {
         UUID examId = UUID.randomUUID();
         UUID sessionId = UUID.randomUUID();
         UUID browserId = UUID.randomUUID();
-        String clientName = "UNIT_TEST";
         int pageNumber = 1;
 
-        ApprovalRequest mockApprovalRequest = new ApprovalRequest(examId, sessionId, browserId, clientName);
+        ApprovalRequest mockApprovalRequest = new ApprovalRequest(examId, sessionId, browserId);
 
         ExamItem mockFirstExamItem = new ExamItemBuilder()
             .withExamPageId(ExamPageBuilder.DEFAULT_ID)
@@ -68,7 +67,7 @@ public class ExamPageControllerTest {
         when(mockExamPageService.getPage(isA(ApprovalRequest.class), isA(Integer.class)))
             .thenReturn(mockExamPageResponse);
 
-        ResponseEntity<Response<ExamPage>> result = controller.getPage(examId, pageNumber, sessionId, browserId, clientName);
+        ResponseEntity<Response<ExamPage>> result = controller.getPage(examId, pageNumber, sessionId, browserId);
         verify(mockExamPageService).getPage(approvalRequestArgumentCaptor.capture(), isA(Integer.class));
 
         assertThat(approvalRequestArgumentCaptor.getValue()).isEqualTo(mockApprovalRequest);


### PR DESCRIPTION
This pull request includes an endpoint for approving student accommodations, particularly guest/practice test accommodations. 

The new endpoint is found in ExamAccommodationController.approveAccommodations(). The service method called by this method (in ExamAccommodationServiceImpl) is a port of StudentDLL.T_ApproveAccommodations_SP(), which begins at line 11429.

A separate PR will be created for TDS_Student that will cover the Student-related code that will ultimately call this method. The majority of the important logic, however, is contained in this PR.

The "clientname" field has been removed from ApprovalRequest (as it can be obtained by the Exam), which resulted in some changes to miscellaneous unit tests and other test-related code. 