### PR TITLE
Bugfix/build ur iproperly

### DIFF
--- a/service/pom.xml
+++ b/service/pom.xml
@@ -57,10 +57,6 @@
         <!-- Spring -->
         <dependency>
             <groupId>org.springframework.boot</groupId>
-            <artifactId>spring-boot-starter</artifactId>
-        </dependency>
-        <dependency>
-            <groupId>org.springframework.boot</groupId>
             <artifactId>spring-boot-starter-hateoas</artifactId>
             <exclusions>
                 <exclusion>

--- a/service/src/main/java/tds/exam/services/impl/AssessmentServiceImpl.java
+++ b/service/src/main/java/tds/exam/services/impl/AssessmentServiceImpl.java
@@ -11,6 +11,7 @@ import org.springframework.web.client.HttpClientErrorException;
 import org.springframework.web.client.RestTemplate;
 import org.springframework.web.util.UriComponentsBuilder;
 
+import java.net.URI;
 import java.util.List;
 import java.util.Optional;
 
@@ -38,17 +39,17 @@ class AssessmentServiceImpl implements AssessmentService {
     @Override
     @Cacheable(CacheType.LONG_TERM)
     public Optional<Assessment> findAssessment(final String clientName, final String key) {
-        UriComponentsBuilder builder =
+        URI uri =
             UriComponentsBuilder
                 .fromHttpUrl(String.format("%s/%s/%s/%s",
                     examServiceProperties.getAssessmentUrl(),
                     clientName,
                     ASSESSMENT_APP_CONTEXT,
-                    key));
+                    key)).build().toUri();
 
         Optional<Assessment> maybeAssessment = Optional.empty();
         try {
-            final Assessment assessment = restTemplate.getForObject(builder.toUriString(), Assessment.class);
+            final Assessment assessment = restTemplate.getForObject(uri, Assessment.class);
             maybeAssessment = Optional.of(assessment);
         } catch (HttpClientErrorException hce) {
             if (hce.getStatusCode() != HttpStatus.NOT_FOUND) {
@@ -79,7 +80,7 @@ class AssessmentServiceImpl implements AssessmentService {
         builder.queryParam("shiftFormStart", configuration.getShiftFormStart());
         builder.queryParam("shiftFormEnd", configuration.getShiftFormEnd());
 
-        ResponseEntity<List<AssessmentWindow>> responseEntity = restTemplate.exchange(builder.toUriString(),
+        ResponseEntity<List<AssessmentWindow>> responseEntity = restTemplate.exchange(builder.build().toUri(),
             HttpMethod.GET, null, new ParameterizedTypeReference<List<AssessmentWindow>>() {
             });
 
@@ -96,7 +97,7 @@ class AssessmentServiceImpl implements AssessmentService {
                     ASSESSMENT_APP_CONTEXT))
                 .queryParam("assessmentKey", assessmentKey);
 
-        ResponseEntity<List<Accommodation>> responseEntity = restTemplate.exchange(builder.toUriString(),
+        ResponseEntity<List<Accommodation>> responseEntity = restTemplate.exchange(builder.build().toUri(),
             HttpMethod.GET, null, new ParameterizedTypeReference<List<Accommodation>>() {
             });
 
@@ -114,7 +115,7 @@ class AssessmentServiceImpl implements AssessmentService {
                 .queryParam("assessmentId", assessmentId);
 
 
-        ResponseEntity<List<Accommodation>> responseEntity = restTemplate.exchange(builder.toUriString(),
+        ResponseEntity<List<Accommodation>> responseEntity = restTemplate.exchange(builder.build().toUri(),
             HttpMethod.GET, null, new ParameterizedTypeReference<List<Accommodation>>() {
             });
 

--- a/service/src/main/java/tds/exam/services/impl/ConfigServiceImpl.java
+++ b/service/src/main/java/tds/exam/services/impl/ConfigServiceImpl.java
@@ -44,7 +44,7 @@ class ConfigServiceImpl implements ConfigService {
 
         Optional<ClientSystemFlag> maybeClientSystemFlag = Optional.empty();
         try {
-            final ClientSystemFlag clientSystemFlag = restTemplate.getForObject(builder.toUriString(), ClientSystemFlag.class);
+            final ClientSystemFlag clientSystemFlag = restTemplate.getForObject(builder.build().toUri(), ClientSystemFlag.class);
             maybeClientSystemFlag = Optional.of(clientSystemFlag);
         } catch (HttpClientErrorException hce) {
             if (hce.getStatusCode() != HttpStatus.NOT_FOUND) {

--- a/service/src/main/java/tds/exam/services/impl/SessionServiceImpl.java
+++ b/service/src/main/java/tds/exam/services/impl/SessionServiceImpl.java
@@ -44,7 +44,7 @@ class SessionServiceImpl implements SessionService {
 
         Optional<Session> maybeSession = Optional.empty();
         try {
-            final Session session = restTemplate.getForObject(builder.toUriString(), Session.class);
+            final Session session = restTemplate.getForObject(builder.build().toUri(), Session.class);
             maybeSession = Optional.of(session);
         } catch (HttpClientErrorException hce) {
             if (hce.getStatusCode() != HttpStatus.NOT_FOUND) {
@@ -67,7 +67,7 @@ class SessionServiceImpl implements SessionService {
 
         Optional<ExternalSessionConfiguration> maybeExternalSessionConfig = Optional.empty();
         try {
-            final ExternalSessionConfiguration externalSessionConfiguration = restTemplate.getForObject(builder.toUriString(), ExternalSessionConfiguration.class);
+            final ExternalSessionConfiguration externalSessionConfiguration = restTemplate.getForObject(builder.build().toUri(), ExternalSessionConfiguration.class);
             maybeExternalSessionConfig = Optional.of(externalSessionConfiguration);
         } catch (HttpClientErrorException hce) {
             if (hce.getStatusCode() != HttpStatus.NOT_FOUND) {
@@ -89,7 +89,7 @@ class SessionServiceImpl implements SessionService {
         Optional<PauseSessionResponse> maybePauseSessionResponse = Optional.empty();
 
         try {
-            final PauseSessionResponse pauseSessionResponse = restTemplate.getForObject(builder.toUriString(), PauseSessionResponse.class);
+            final PauseSessionResponse pauseSessionResponse = restTemplate.getForObject(builder.build().toUri(), PauseSessionResponse.class);
             maybePauseSessionResponse = Optional.of(pauseSessionResponse);
         } catch (HttpClientErrorException hce) {
             if (hce.getStatusCode() != HttpStatus.NOT_FOUND) {
@@ -113,7 +113,7 @@ class SessionServiceImpl implements SessionService {
         Optional<SessionAssessment> maybeSessionAssessment = Optional.empty();
 
         try {
-            final SessionAssessment sessionAssessment = restTemplate.getForObject(builder.toUriString(), SessionAssessment.class);
+            final SessionAssessment sessionAssessment = restTemplate.getForObject(builder.build().toUri(), SessionAssessment.class);
             maybeSessionAssessment = Optional.of(sessionAssessment);
         } catch (HttpClientErrorException hce) {
             if (hce.getStatusCode() != HttpStatus.NOT_FOUND) {

--- a/service/src/main/java/tds/exam/services/impl/StudentServiceImpl.java
+++ b/service/src/main/java/tds/exam/services/impl/StudentServiceImpl.java
@@ -42,7 +42,7 @@ class StudentServiceImpl implements StudentService {
 
         Optional<Student> maybeStudent = Optional.empty();
         try {
-            final Student student = restTemplate.getForObject(builder.toUriString(), Student.class);
+            final Student student = restTemplate.getForObject(builder.build().toUri(), Student.class);
             maybeStudent = Optional.of(student);
         } catch (HttpClientErrorException hce) {
             if (hce.getStatusCode() != HttpStatus.NOT_FOUND) {
@@ -66,7 +66,7 @@ class StudentServiceImpl implements StudentService {
                     String.join(",", (CharSequence[]) attributeNames))
                 );
 
-        ResponseEntity<List<RtsStudentPackageAttribute>> responseEntity = restTemplate.exchange(builder.toUriString(),
+        ResponseEntity<List<RtsStudentPackageAttribute>> responseEntity = restTemplate.exchange(builder.build().toUri(),
             HttpMethod.GET, null, new ParameterizedTypeReference<List<RtsStudentPackageAttribute>>() {
         });
 

--- a/service/src/main/java/tds/exam/services/impl/TimeLimitConfigurationServiceImpl.java
+++ b/service/src/main/java/tds/exam/services/impl/TimeLimitConfigurationServiceImpl.java
@@ -38,7 +38,7 @@ class TimeLimitConfigurationServiceImpl implements TimeLimitConfigurationService
         Optional<TimeLimitConfiguration> maybeTimeLimitConfig = Optional.empty();
         try {
             final TimeLimitConfiguration timeLimitConfiguration =
-                    restTemplate.getForObject(uriBuilder.toUriString(), TimeLimitConfiguration.class);
+                    restTemplate.getForObject(uriBuilder.build().toUri(), TimeLimitConfiguration.class);
             maybeTimeLimitConfig = Optional.of(timeLimitConfiguration);
         } catch (HttpClientErrorException e) {
             if (e.getStatusCode() != HttpStatus.NOT_FOUND) {

--- a/service/src/test/java/tds/exam/services/impl/AssessmentServiceImplIntegrationTests.java
+++ b/service/src/test/java/tds/exam/services/impl/AssessmentServiceImplIntegrationTests.java
@@ -8,6 +8,8 @@ import org.springframework.boot.test.mock.mockito.MockBean;
 import org.springframework.test.context.junit4.SpringJUnit4ClassRunner;
 import org.springframework.web.client.RestTemplate;
 
+import java.net.URI;
+import java.net.URISyntaxException;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Optional;
@@ -40,7 +42,7 @@ public class AssessmentServiceImplIntegrationTests {
     private AssessmentService assessmentService;
 
     @Test
-    public void shouldReturnCachedAssessment() {
+    public void shouldReturnCachedAssessment() throws URISyntaxException {
 
 
         List<Segment> segments = new ArrayList<>();
@@ -57,11 +59,13 @@ public class AssessmentServiceImplIntegrationTests {
         assessment.setSelectionAlgorithm(Algorithm.VIRTUAL);
         assessment.setStartAbility(100);
 
+        URI url = new URI("http://localhost:8080/clientname/assessments/key");
+
         when(properties.getAssessmentUrl()).thenReturn("http://localhost:8080");
-        when(mockRestTemplate.getForObject("http://localhost:8080/clientname/assessments/key", Assessment.class)).thenReturn(assessment);
+        when(mockRestTemplate.getForObject(url, Assessment.class)).thenReturn(assessment);
         Optional<Assessment> maybeAssessment1 = assessmentService.findAssessment("clientname", "key");
         Optional<Assessment> maybeAssessment2 = assessmentService.findAssessment("clientname", "key");
-        verify(mockRestTemplate, times(1)).getForObject("http://localhost:8080/clientname/assessments/key", Assessment.class);
+        verify(mockRestTemplate, times(1)).getForObject(url, Assessment.class);
         assertThat(maybeAssessment1).isEqualTo(maybeAssessment2);
     }
 }

--- a/service/src/test/java/tds/exam/services/impl/AssessmentServiceImplTest.java
+++ b/service/src/test/java/tds/exam/services/impl/AssessmentServiceImplTest.java
@@ -10,6 +10,8 @@ import org.springframework.web.client.RestClientException;
 import org.springframework.web.client.RestTemplate;
 import org.springframework.web.util.UriComponentsBuilder;
 
+import java.net.URI;
+import java.net.URISyntaxException;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
@@ -47,7 +49,7 @@ public class AssessmentServiceImplTest {
     }
 
     @Test
-    public void shouldFindSetOfAdminSubjectsByKey() {
+    public void shouldFindAssessmentByKey() throws URISyntaxException {
         List<Segment> segments = new ArrayList<>();
         Segment segment = new Segment("segkey", Algorithm.FIXED_FORM);
         segment.setSegmentId("segid");
@@ -62,31 +64,33 @@ public class AssessmentServiceImplTest {
         assessment.setSelectionAlgorithm(Algorithm.VIRTUAL);
         assessment.setStartAbility(100);
 
-        when(restTemplate.getForObject(BASE_URL + "clientname/assessments/key", Assessment.class)).thenReturn(assessment);
+        URI uri = new URI(BASE_URL + "clientname/assessments/key");
+
+        when(restTemplate.getForObject(uri, Assessment.class)).thenReturn(assessment);
         Optional<Assessment> maybeAssessment = assessmentService.findAssessment("clientname", "key");
-        verify(restTemplate).getForObject(BASE_URL + "clientname/assessments/key", Assessment.class);
+        verify(restTemplate).getForObject(uri, Assessment.class);
 
         assertThat(maybeAssessment.get()).isEqualTo(assessment);
     }
 
     @Test
-    public void shouldReturnEmptyWhenSetOfAdminSubjectNotFound() {
-        when(restTemplate.getForObject(isA(String.class), isA(Class.class))).thenThrow(new HttpClientErrorException(HttpStatus.NOT_FOUND));
+    public void shouldReturnEmptyWhenAssessmentNotFound() {
+        when(restTemplate.getForObject(isA(URI.class), isA(Class.class))).thenThrow(new HttpClientErrorException(HttpStatus.NOT_FOUND));
         Optional<Assessment> maybeAssessment = assessmentService.findAssessment("clientname", "key");
 
         assertThat(maybeAssessment).isNotPresent();
     }
 
     @Test(expected = RestClientException.class)
-    public void shouldThrowIfStatusNotNotFoundWhenUnexpectedErrorFindingSetOfAdminSubject() {
-        when(restTemplate.getForObject(isA(String.class), isA(Class.class))).thenThrow(new HttpClientErrorException(HttpStatus.BAD_REQUEST));
+    public void shouldThrowIfStatusNotNotFoundWhenUnexpectedErrorFindingAssessment() {
+        when(restTemplate.getForObject(isA(URI.class), isA(Class.class))).thenThrow(new HttpClientErrorException(HttpStatus.BAD_REQUEST));
         assessmentService.findAssessment("clientname", "key");
     }
 
     @Test
     public void shouldFindAssessmentWindows() {
         AssessmentWindow window = new AssessmentWindow.Builder().build();
-        String url = UriComponentsBuilder
+        URI url = UriComponentsBuilder
             .fromHttpUrl(String.format("%s/%s/%s/%s/windows/student/%d",
                 BASE_URL,
                 "SBAC_PT",
@@ -97,7 +101,8 @@ public class AssessmentServiceImplTest {
             .queryParam("shiftWindowEnd", 2)
             .queryParam("shiftFormStart", 10)
             .queryParam("shiftFormEnd", 11)
-            .toUriString();
+            .build()
+            .toUri();
 
         ExternalSessionConfiguration config = new ExternalSessionConfigurationBuilder()
             .withShiftWindowStart(1)
@@ -122,10 +127,11 @@ public class AssessmentServiceImplTest {
         Accommodation accommodation = new Accommodation.Builder().build();
         ResponseEntity<List<Accommodation>> entity = new ResponseEntity<>(Collections.singletonList(accommodation), HttpStatus.OK);
 
-        String url = UriComponentsBuilder
+        URI url = UriComponentsBuilder
             .fromHttpUrl(String.format("%s/SBAC/assessments/accommodations", BASE_URL))
             .queryParam("assessmentKey", "key")
-            .toUriString();
+            .build()
+            .toUri();
 
         when(restTemplate.exchange(url, GET, null, new ParameterizedTypeReference<List<Accommodation>>() {
         })).thenReturn(entity);
@@ -140,10 +146,11 @@ public class AssessmentServiceImplTest {
         Accommodation accommodation = new Accommodation.Builder().build();
         ResponseEntity<List<Accommodation>> entity = new ResponseEntity<>(Collections.singletonList(accommodation), HttpStatus.OK);
 
-        String url = UriComponentsBuilder
+        URI url = UriComponentsBuilder
             .fromHttpUrl(String.format("%s/SBAC/assessments/accommodations", BASE_URL))
             .queryParam("assessmentId", "id")
-            .toUriString();
+            .build()
+            .toUri();
 
         when(restTemplate.exchange(url, GET, null, new ParameterizedTypeReference<List<Accommodation>>() {
         })).thenReturn(entity);

--- a/service/src/test/java/tds/exam/services/impl/ConfigServiceImplTest.java
+++ b/service/src/test/java/tds/exam/services/impl/ConfigServiceImplTest.java
@@ -7,6 +7,8 @@ import org.springframework.web.client.HttpClientErrorException;
 import org.springframework.web.client.RestClientException;
 import org.springframework.web.client.RestTemplate;
 
+import java.net.URI;
+import java.net.URISyntaxException;
 import java.util.Optional;
 
 import tds.config.ClientSystemFlag;
@@ -38,26 +40,31 @@ public class ConfigServiceImplTest {
     }
 
     @Test
-    public void shouldFindClientSystemFlag() {
+    public void shouldFindClientSystemFlag() throws URISyntaxException {
         ClientSystemFlag flag = new ClientSystemFlag.Builder().withAuditObject(ATTRIBUTE_OBJECT).build();
 
-        when(restTemplate.getForObject(String.format("%s/%s/client-system-flags/%s/%s", BASE_URL, CONFIG_APP_CONTEXT, CLIENT_NAME, ATTRIBUTE_OBJECT), ClientSystemFlag.class)).thenReturn(flag);
+        URI url = new URI(String.format("%s/%s/client-system-flags/%s/%s", BASE_URL, CONFIG_APP_CONTEXT, CLIENT_NAME, ATTRIBUTE_OBJECT));
+
+        when(restTemplate.getForObject(url, ClientSystemFlag.class)).thenReturn(flag);
         Optional<ClientSystemFlag> maybeClientSystemFlag = configService.findClientSystemFlag(CLIENT_NAME, ATTRIBUTE_OBJECT);
 
         assertThat(maybeClientSystemFlag.get()).isEqualTo(flag);
     }
 
     @Test
-    public void shouldReturnEmptyWhenClientSystemFlagNotFound() {
-        when(restTemplate.getForObject(String.format("%s/%s/client-system-flags/%s/%s", BASE_URL, CONFIG_APP_CONTEXT, CLIENT_NAME, ATTRIBUTE_OBJECT), ClientSystemFlag.class)).thenThrow(new HttpClientErrorException(HttpStatus.NOT_FOUND));
+    public void shouldReturnEmptyWhenClientSystemFlagNotFound() throws URISyntaxException {
+        URI url = new URI(String.format("%s/%s/client-system-flags/%s/%s", BASE_URL, CONFIG_APP_CONTEXT, CLIENT_NAME, ATTRIBUTE_OBJECT));
+
+        when(restTemplate.getForObject(url, ClientSystemFlag.class)).thenThrow(new HttpClientErrorException(HttpStatus.NOT_FOUND));
         Optional<ClientSystemFlag> maybeClientSystemFlag = configService.findClientSystemFlag(CLIENT_NAME, ATTRIBUTE_OBJECT);
 
         assertThat(maybeClientSystemFlag).isNotPresent();
     }
 
     @Test(expected = RestClientException.class)
-    public void shouldThrowIfStatusNotNotFoundWhenUnexpectedErrorFindingClientSystemFlag() {
-        when(restTemplate.getForObject(String.format("%s/%s/client-system-flags/%s/%s", BASE_URL, CONFIG_APP_CONTEXT, CLIENT_NAME, ATTRIBUTE_OBJECT), ClientSystemFlag.class)).thenThrow(new HttpClientErrorException(HttpStatus.BAD_REQUEST));
+    public void shouldThrowIfStatusNotNotFoundWhenUnexpectedErrorFindingClientSystemFlag() throws URISyntaxException {
+        URI url = new URI(String.format("%s/%s/client-system-flags/%s/%s", BASE_URL, CONFIG_APP_CONTEXT, CLIENT_NAME, ATTRIBUTE_OBJECT));
+        when(restTemplate.getForObject(url, ClientSystemFlag.class)).thenThrow(new HttpClientErrorException(HttpStatus.BAD_REQUEST));
         configService.findClientSystemFlag(CLIENT_NAME, ATTRIBUTE_OBJECT);
     }
 }

--- a/service/src/test/java/tds/exam/services/impl/ExamServiceImplTest.java
+++ b/service/src/test/java/tds/exam/services/impl/ExamServiceImplTest.java
@@ -167,7 +167,7 @@ public class ExamServiceImplTest {
 
         when(mockSessionService.findExternalSessionConfigurationByClientName("SBAC_PT")).thenReturn(Optional.of(extSessionConfig));
         when(mockSessionService.findSessionById(openExamRequest.getSessionId())).thenReturn(Optional.empty());
-        when(mockStudentService.getStudentById(openExamRequest.getStudentId())).thenReturn(Optional.of(new Student(1, "testId", "CA", "clientName")));
+        when(mockStudentService.getStudentById(openExamRequest.getStudentId())).thenReturn(Optional.of(new Student.Builder(1, "testId").build()));
 
         examService.openExam(openExamRequest);
     }
@@ -218,7 +218,7 @@ public class ExamServiceImplTest {
             .withId(UUID.randomUUID())
             .build();
 
-        Student student = new Student(1, "testId", "CA", "clientName");
+        Student student = new Student.Builder(1, "testId").build();
 
         Exam previousExam = new Exam.Builder()
             .withId(UUID.randomUUID())
@@ -366,7 +366,11 @@ public class ExamServiceImplTest {
         Session currentSession = new SessionBuilder()
             .build();
 
-        Student student = new Student(1, "loginSSD", "CA", "SBAC_PT");
+        Student student = new Student.Builder(1, "clientName")
+            .withStateCode("CA")
+            .withLoginSSID("loginSSID")
+            .build();
+
         Assessment assessment = new AssessmentBuilder().build();
         ExternalSessionConfiguration extSessionConfig = new ExternalSessionConfigurationBuilder().build();
         AssessmentWindow window = new AssessmentWindow.Builder()
@@ -414,7 +418,10 @@ public class ExamServiceImplTest {
         Session currentSession = new SessionBuilder()
             .build();
 
-        Student student = new Student(1, "loginSSD", "CA", "SBAC_PT");
+        Student student = new Student.Builder(1, "clientName")
+            .withStateCode("CA")
+            .withLoginSSID("loginSSID")
+            .build();
         Assessment assessment = new AssessmentBuilder().build();
         ExternalSessionConfiguration extSessionConfig = new ExternalSessionConfigurationBuilder().build();
         AssessmentWindow window = new AssessmentWindow.Builder()
@@ -470,7 +477,10 @@ public class ExamServiceImplTest {
             .withId(UUID.randomUUID())
             .build();
 
-        Student student = new Student(1, "loginSSD", "CA", "SBAC_PT");
+        Student student = new Student.Builder(1, "clientName")
+            .withStateCode("CA")
+            .withLoginSSID("loginSSID")
+            .build();
 
         Instant approvedStatusDate = org.joda.time.Instant.now().minus(5000);
         Exam previousExam = new Exam.Builder()
@@ -532,7 +542,10 @@ public class ExamServiceImplTest {
             .withStatus("closed")
             .build();
 
-        Student student = new Student(request.getStudentId(), "testId", "CA", "SBAC_PT");
+        Student student = new Student.Builder(1, "clientName")
+            .withStateCode("CA")
+            .withLoginSSID("loginSSID")
+            .build();
 
         Instant approvedStatusDate = org.joda.time.Instant.now().minus(5000);
         Exam previousExam = new Exam.Builder()
@@ -581,7 +594,10 @@ public class ExamServiceImplTest {
             .withId(request.getSessionId())
             .build();
 
-        Student student = new Student(1, "testId", "CA", "SBAC_PT");
+        Student student = new Student.Builder(1, "clientName")
+            .withStateCode("CA")
+            .withLoginSSID("loginSSID")
+            .build();
 
         Instant approvedStatusDate = org.joda.time.Instant.now().minus(5000);
         Exam previousExam = new Exam.Builder()
@@ -640,7 +656,10 @@ public class ExamServiceImplTest {
             .withDateEnd(Instant.now().minus(Days.days(1).toStandardDuration()))
             .build();
 
-        Student student = new Student(1, "testId", "CA", "clientName");
+        Student student = new Student.Builder(1, "clientName")
+            .withStateCode("CA")
+            .withLoginSSID("loginSSID")
+            .build();
 
         Instant approvedStatusDate = org.joda.time.Instant.now().minus(5000);
         Exam previousExam = new Exam.Builder()

--- a/service/src/test/java/tds/exam/services/impl/SessionServiceImplTest.java
+++ b/service/src/test/java/tds/exam/services/impl/SessionServiceImplTest.java
@@ -13,6 +13,8 @@ import org.springframework.web.client.RestClientException;
 import org.springframework.web.client.RestTemplate;
 import org.springframework.web.util.UriComponentsBuilder;
 
+import java.net.URI;
+import java.net.URISyntaxException;
 import java.util.Optional;
 import java.util.UUID;
 
@@ -50,13 +52,13 @@ public class SessionServiceImplTest {
     }
 
     @Test
-    public void shouldReturnSession() {
+    public void shouldReturnSession() throws URISyntaxException {
         UUID sessionUUID = UUID.randomUUID();
         Session session = new Session.Builder()
             .withId(sessionUUID)
             .build();
 
-        String url = String.format("%s/%s/%s", BASE_URL, SESSION_APP_CONTEXT, sessionUUID);
+        URI url = new URI(String.format("%s/%s/%s", BASE_URL, SESSION_APP_CONTEXT, sessionUUID));
 
         when(restTemplate.getForObject(url, Session.class)).thenReturn(session);
         Optional<Session> maybeSession = sessionService.findSessionById(sessionUUID);
@@ -67,9 +69,9 @@ public class SessionServiceImplTest {
     }
 
     @Test
-    public void shouldReturnEmptySessionWhenStatusIsNotFound() {
+    public void shouldReturnEmptySessionWhenStatusIsNotFound() throws URISyntaxException {
         UUID sessionUUID = UUID.randomUUID();
-        String url = String.format("%s/%s/%s", BASE_URL, SESSION_APP_CONTEXT, sessionUUID);
+        URI url = new URI(String.format("%s/%s/%s", BASE_URL, SESSION_APP_CONTEXT, sessionUUID));
         when(restTemplate.getForObject(url, Session.class)).thenThrow(new HttpClientErrorException(HttpStatus.NOT_FOUND));
         Optional<Session> maybeSession = sessionService.findSessionById(sessionUUID);
         verify(restTemplate).getForObject(url, Session.class);
@@ -78,7 +80,7 @@ public class SessionServiceImplTest {
     }
 
     @Test
-    public void shouldPauseASession() {
+    public void shouldPauseASession() throws URISyntaxException {
         String sessionStatus = "closed";
         Session mockSession = new Session.Builder()
             .withId(UUID.randomUUID())
@@ -86,7 +88,7 @@ public class SessionServiceImplTest {
             .withDateChanged(Instant.now())
             .withDateEnd(Instant.now())
             .build();
-        String url = String.format("%s/%s/%s/pause", BASE_URL, SESSION_APP_CONTEXT, mockSession.getId());
+        URI url = new URI(String.format("%s/%s/%s/pause", BASE_URL, SESSION_APP_CONTEXT, mockSession.getId()));
         when(restTemplate.getForObject(url, PauseSessionResponse.class)).thenReturn(new PauseSessionResponse(mockSession));
 
         Optional<PauseSessionResponse> maybePauseResponse = sessionService.pause(mockSession.getId(), sessionStatus);
@@ -96,9 +98,9 @@ public class SessionServiceImplTest {
     }
 
     @Test
-    public void shouldReturnOptionalEmptyWhenAttemptingToPauseASessionThatIsNotFound() {
+    public void shouldReturnOptionalEmptyWhenAttemptingToPauseASessionThatIsNotFound() throws URISyntaxException {
         UUID sessionId = UUID.randomUUID();
-        String url = String.format("%s/%s/%s/pause", BASE_URL, SESSION_APP_CONTEXT, sessionId);
+        URI url = new URI(String.format("%s/%s/%s/pause", BASE_URL, SESSION_APP_CONTEXT, sessionId));
         when(restTemplate.getForObject(url, PauseSessionResponse.class)).thenThrow(new HttpClientErrorException(HttpStatus.NOT_FOUND));
 
         Optional<PauseSessionResponse> maybePauseResponse = sessionService.pause(sessionId, "closed");
@@ -107,17 +109,17 @@ public class SessionServiceImplTest {
     }
 
     @Test(expected = RestClientException.class)
-    public void shouldThrowWhenSessionErrorIsNotNotFound() {
+    public void shouldThrowWhenSessionErrorIsNotNotFound() throws URISyntaxException {
         UUID sessionUUID = UUID.randomUUID();
-        String url = String.format("%s/%s/%s", BASE_URL, SESSION_APP_CONTEXT, sessionUUID);
+        URI url = new URI(String.format("%s/%s/%s", BASE_URL, SESSION_APP_CONTEXT, sessionUUID));
         when(restTemplate.getForObject(url, Session.class)).thenThrow(new HttpClientErrorException(HttpStatus.BAD_REQUEST));
         sessionService.findSessionById(sessionUUID);
     }
 
 
     @Test
-    public void shouldReturnExternalSessionConfigForClientName() {
-        String url = BASE_URL + "/" + SESSION_APP_CONTEXT + "/external-config/SBAC";
+    public void shouldReturnExternalSessionConfigForClientName() throws URISyntaxException {
+        URI url = new URI(BASE_URL + "/" + SESSION_APP_CONTEXT + "/external-config/SBAC");
         ExternalSessionConfiguration externalSessionConfiguration = new ExternalSessionConfigurationBuilder().withClientName("SBAC").build();
         when(restTemplate.getForObject(url, ExternalSessionConfiguration.class)).thenReturn(externalSessionConfiguration);
         Optional<ExternalSessionConfiguration> maybeExternalSessionConfiguration = sessionService.findExternalSessionConfigurationByClientName("SBAC");
@@ -127,8 +129,8 @@ public class SessionServiceImplTest {
     }
 
     @Test
-    public void shouldReturnEmptyExternalSessionConfigForClientNameWhenNotFound() {
-        String url = String.format("%s/%s/%s", BASE_URL, SESSION_APP_CONTEXT, "external-config/SBAC");
+    public void shouldReturnEmptyExternalSessionConfigForClientNameWhenNotFound() throws URISyntaxException {
+        URI url = new URI(String.format("%s/%s/%s", BASE_URL, SESSION_APP_CONTEXT, "external-config/SBAC"));
         when(restTemplate.getForObject(url, ExternalSessionConfiguration.class)).thenThrow(new HttpClientErrorException(HttpStatus.NOT_FOUND));
         Optional<ExternalSessionConfiguration> maybeExternalSessionConfiguration = sessionService.findExternalSessionConfigurationByClientName("SBAC");
         verify(restTemplate).getForObject(url, ExternalSessionConfiguration.class);
@@ -137,8 +139,8 @@ public class SessionServiceImplTest {
     }
 
     @Test(expected = RestClientException.class)
-    public void shouldThrowIfStatusNotNotFoundFetchingExternalSessionConfigurationByClientName() {
-        String url = String.format("%s/%s/%s", BASE_URL, SESSION_APP_CONTEXT, "external-config/SBAC");
+    public void shouldThrowIfStatusNotNotFoundFetchingExternalSessionConfigurationByClientName() throws URISyntaxException {
+        URI url = new URI(String.format("%s/%s/%s", BASE_URL, SESSION_APP_CONTEXT, "external-config/SBAC"));
         when(restTemplate.getForObject(url, ExternalSessionConfiguration.class)).thenThrow(new HttpClientErrorException(HttpStatus.BAD_REQUEST));
         sessionService.findExternalSessionConfigurationByClientName("SBAC");
     }
@@ -147,9 +149,10 @@ public class SessionServiceImplTest {
     public void shouldReturnSessionAssessment() {
         UUID sessionId = UUID.randomUUID();
 
-        String url = UriComponentsBuilder
+        URI url = UriComponentsBuilder
             .fromHttpUrl(String.format("%s/%s/%s/assessment/%s", BASE_URL, SESSION_APP_CONTEXT, sessionId, "(SBAC) ELA 11 2015 - 2016"))
-            .toUriString();
+            .build()
+            .toUri();
 
         SessionAssessment sessionAssessment = new SessionAssessment(sessionId, "ELA 11", "(SBAC) ELA 11 2015 - 2016");
         when(restTemplate.getForObject(url, SessionAssessment.class)).thenReturn(sessionAssessment);
@@ -163,9 +166,10 @@ public class SessionServiceImplTest {
     public void shouldReturnEmptySessionAssessmentWhenNotFound() {
         UUID sessionId = UUID.randomUUID();
 
-        String url = UriComponentsBuilder
+        URI url = UriComponentsBuilder
             .fromHttpUrl(String.format("%s/%s/%s/assessment/%s", BASE_URL, SESSION_APP_CONTEXT, sessionId, "(SBAC) ELA 11 2015 - 2016"))
-            .toUriString();
+            .build()
+            .toUri();
 
         when(restTemplate.getForObject(url, SessionAssessment.class)).thenThrow(new HttpClientErrorException(HttpStatus.NOT_FOUND));
         Optional<SessionAssessment> maybeSessionAssessment = sessionService.findSessionAssessment(sessionId, "(SBAC) ELA 11 2015 - 2016");
@@ -177,9 +181,10 @@ public class SessionServiceImplTest {
     @Test(expected = RestClientException.class)
     public void shouldThrowIfStatusNotNotFoundFetchingSessionAssessment() {
         UUID sessionId = UUID.randomUUID();
-        String url = UriComponentsBuilder
+        URI url = UriComponentsBuilder
             .fromHttpUrl(String.format("%s/%s/%s/assessment/%s", BASE_URL, SESSION_APP_CONTEXT, sessionId, "(SBAC) ELA 11 2015 - 2016"))
-            .toUriString();
+            .build()
+            .toUri();
         when(restTemplate.getForObject(url, SessionAssessment.class)).thenThrow(new HttpClientErrorException(HttpStatus.BAD_REQUEST));
         sessionService.findSessionAssessment(sessionId, "(SBAC) ELA 11 2015 - 2016");
     }

--- a/service/src/test/java/tds/exam/services/impl/TimeLimitConfigurationServiceImplTest.java
+++ b/service/src/test/java/tds/exam/services/impl/TimeLimitConfigurationServiceImplTest.java
@@ -10,6 +10,8 @@ import org.springframework.http.HttpStatus;
 import org.springframework.web.client.HttpClientErrorException;
 import org.springframework.web.client.RestTemplate;
 
+import java.net.URI;
+import java.net.URISyntaxException;
 import java.util.Optional;
 
 import tds.config.TimeLimitConfiguration;
@@ -41,9 +43,9 @@ public class TimeLimitConfigurationServiceImplTest {
     }
 
     @Test
-    public void shouldFindTimeLimitConfiguration() {
+    public void shouldFindTimeLimitConfiguration() throws URISyntaxException {
         TimeLimitConfiguration timeLimitConfiguration = new TimeLimitConfiguration.Builder().build();
-        String url = String.format("%s/%s/time-limits/%s/%s", BASE_URL, CONFIG_APP_CONTEXT, "client", "assessmentId");
+        URI url = new URI(String.format("%s/%s/time-limits/%s/%s", BASE_URL, CONFIG_APP_CONTEXT, "client", "assessmentId"));
         when(restTemplate.getForObject(url, TimeLimitConfiguration.class)).thenReturn(timeLimitConfiguration);
         Optional<TimeLimitConfiguration> maybeTimeLimit = timeLimitConfigurationService.findTimeLimitConfiguration("client", "assessmentId");
         verify(restTemplate).getForObject(url, TimeLimitConfiguration.class);
@@ -52,8 +54,8 @@ public class TimeLimitConfigurationServiceImplTest {
     }
 
     @Test
-    public void shouldReturnEmptyTimeLimitConfiguration() {
-        String url = String.format("%s/%s/time-limits/%s/%s", BASE_URL, CONFIG_APP_CONTEXT, "client", "assessmentId");
+    public void shouldReturnEmptyTimeLimitConfiguration() throws URISyntaxException {
+        URI url = new URI(String.format("%s/%s/time-limits/%s/%s", BASE_URL, CONFIG_APP_CONTEXT, "client", "assessmentId"));
         when(restTemplate.getForObject(url, TimeLimitConfiguration.class)).thenThrow(new HttpClientErrorException(HttpStatus.NOT_FOUND));
         Optional<TimeLimitConfiguration> maybeTimeLimit = timeLimitConfigurationService.findTimeLimitConfiguration("client", "assessmentId");
         verify(restTemplate).getForObject(url, TimeLimitConfiguration.class);


### PR DESCRIPTION
This was a tricky one to track down.  It came down to the way we were building our URLs.  We were building the URLs with `toUriString` which RestTemplate would encode again resulting in the wrong assessment key string.

Moved all services to pass in the URI into the RestTemplate rather than rely on it to do the encoding.