### PR TITLE
Feature/format system messages

### DIFF
--- a/service/src/main/java/tds/exam/services/ConfigService.java
+++ b/service/src/main/java/tds/exam/services/ConfigService.java
@@ -1,5 +1,6 @@
 package tds.exam.services;
 
+import java.util.HashMap;
 import java.util.Optional;
 
 import tds.config.ClientSystemFlag;
@@ -16,4 +17,30 @@ public interface ConfigService {
      * @return {@link tds.config.ClientSystemFlag} if found otherwise empty
      */
     Optional<ClientSystemFlag> findClientSystemFlag(final String clientName, final String auditObject);
+
+    /**
+     * Get the message string for this client that is translated for the language specified.
+     *
+     * @param clientName   The client name
+     * @param messageKey   The message key found in the {@code configs.tds_coremessageobject} table in the {@code appkey} column
+     * @param languageCode The language code to translate the message into
+     * @param context      The context for the message found in the {@code configs.tds_coremessageobject} table in the {@code context} column
+     * @param replacements Key value pairs that are used to replace the data in the templated message
+     * @return The message string with placeholders included
+     */
+    String getSystemMessage(String clientName, String messageKey, String languageCode, String context, Object[] replacements);
+
+    /**
+     * Get the message string for this client that is translated for the language specified.
+     *
+     * @param clientName   The client name
+     * @param messageKey   The message key found in the {@code configs.tds_coremessageobject} table in the {@code appkey} column
+     * @param languageCode The language code to translate the message into
+     * @param context      The context for the message found in the {@code configs.tds_coremessageobject} table in the {@code context} column
+     * @param subject      A subject code used to find a more specific message.  NULL will match on all
+     * @param grade        A grade level used to find a more specific message.  NULL will match on all
+     * @param replacements Key value pairs that are used to replace the data in the templated message
+     * @return The message string with placeholders included
+     */
+    String getSystemMessage(String clientName, String messageKey, String languageCode, String context, String subject, String grade, Object[] replacements);
 }

--- a/service/src/main/java/tds/exam/services/ConfigService.java
+++ b/service/src/main/java/tds/exam/services/ConfigService.java
@@ -19,28 +19,39 @@ public interface ConfigService {
     Optional<ClientSystemFlag> findClientSystemFlag(final String clientName, final String auditObject);
 
     /**
-     * Get the message string for this client that is translated for the language specified.
+     * Get the message string for this client with the default language.
      *
      * @param clientName   The client name
+     * @param context      The context for the message key
      * @param messageKey   The message key found in the {@code configs.tds_coremessageobject} table in the {@code appkey} column
-     * @param languageCode The language code to translate the message into
-     * @param context      The context for the message found in the {@code configs.tds_coremessageobject} table in the {@code context} column
      * @param replacements Key value pairs that are used to replace the data in the templated message
      * @return The message string with placeholders included
      */
-    String getSystemMessage(String clientName, String messageKey, String languageCode, String context, Object[] replacements);
+    String getFormattedMessage(String clientName, String context, String messageKey, Object... replacements);
 
     /**
      * Get the message string for this client that is translated for the language specified.
      *
      * @param clientName   The client name
+     * @param context      The context for the message key
      * @param messageKey   The message key found in the {@code configs.tds_coremessageobject} table in the {@code appkey} column
      * @param languageCode The language code to translate the message into
-     * @param context      The context for the message found in the {@code configs.tds_coremessageobject} table in the {@code context} column
+     * @param replacements Key value pairs that are used to replace the data in the templated message
+     * @return The message string with placeholders included
+     */
+    String getFormattedMessage(String clientName, String context, String messageKey, String languageCode, Object... replacements);
+
+    /**
+     * Get the message string for this client that is translated for the language specified, filtering by grade and subject
+     *
+     * @param clientName   The client name
+     * @param context      The context for the message key
+     * @param messageKey   The message key found in the {@code configs.tds_coremessageobject} table in the {@code appkey} column
+     * @param languageCode The language code to translate the message into
      * @param subject      A subject code used to find a more specific message.  NULL will match on all
      * @param grade        A grade level used to find a more specific message.  NULL will match on all
      * @param replacements Key value pairs that are used to replace the data in the templated message
      * @return The message string with placeholders included
      */
-    String getSystemMessage(String clientName, String messageKey, String languageCode, String context, String subject, String grade, Object[] replacements);
+    String getFormattedMessage(String clientName, String context, String messageKey, String languageCode, String subject, String grade, Object... replacements);
 }

--- a/service/src/main/java/tds/exam/services/impl/ConfigServiceImpl.java
+++ b/service/src/main/java/tds/exam/services/impl/ConfigServiceImpl.java
@@ -25,6 +25,8 @@ import static tds.exam.configuration.SupportApplicationConfiguration.CONFIG_APP_
  */
 @Service
 class ConfigServiceImpl implements ConfigService {
+    private static final String DEFAULT_LANGUAGE = "ENU";
+
     private final RestTemplate restTemplate;
     private final ExamServiceProperties examServiceProperties;
 
@@ -59,12 +61,20 @@ class ConfigServiceImpl implements ConfigService {
     }
 
     @Override
-    public String getSystemMessage(String clientName, String messageKey, String languageCode, String context, Object[] replacements) {
-        return getSystemMessage(clientName, messageKey, languageCode, context, null, null, replacements);
+    @Cacheable(CacheType.LONG_TERM)
+    public String getFormattedMessage(String clientName, String context, String messageKey, Object... replacements) {
+        return getFormattedMessage(clientName, context, messageKey, DEFAULT_LANGUAGE, replacements);
     }
 
     @Override
-    public String getSystemMessage(String clientName, String messageKey, String languageCode, String context, String subject, String grade, Object[] replacements) {
+    @Cacheable(CacheType.LONG_TERM)
+    public String getFormattedMessage(String clientName, String context, String messageKey, String languageCode, Object... replacements) {
+        return getFormattedMessage(clientName, context, messageKey, languageCode, null, null, replacements);
+    }
+
+    @Override
+    @Cacheable(CacheType.LONG_TERM)
+    public String getFormattedMessage(String clientName, String context, String messageKey, String languageCode, String subject, String grade, Object... replacements) {
         UriComponentsBuilder builder =
             UriComponentsBuilder
                 .fromHttpUrl(String.format("%s/%s/messages/%s/%s/%s/%s",
@@ -74,8 +84,8 @@ class ConfigServiceImpl implements ConfigService {
                     context,
                     messageKey,
                     languageCode))
-            .queryParam("grade", grade)
-            .queryParam("subject", subject);
+                .queryParam("grade", grade)
+                .queryParam("subject", subject);
 
         String messageTemplate;
         try {

--- a/service/src/main/java/tds/exam/services/impl/ConfigServiceImpl.java
+++ b/service/src/main/java/tds/exam/services/impl/ConfigServiceImpl.java
@@ -89,7 +89,7 @@ class ConfigServiceImpl implements ConfigService {
 
         String messageTemplate;
         try {
-            messageTemplate = restTemplate.getForObject(builder.buildAndExpand().toUri(), String.class);
+            messageTemplate = restTemplate.getForObject(builder.build().toUri(), String.class);
         } catch (HttpClientErrorException hce) {
             // If there is an HTTP error we can return the messageKey which is the english message version, since it is
             //  better to return a message in English than error out.  This is a suitable recovery.

--- a/service/src/main/java/tds/exam/services/impl/ExamServiceImpl.java
+++ b/service/src/main/java/tds/exam/services/impl/ExamServiceImpl.java
@@ -673,7 +673,6 @@ class ExamServiceImpl implements ExamService {
         if (previousExam != null) {
             //This is done with a query in the legacy application but we can just check the status of the previous exam fetched in a previous step.
             if (!ExamStatusStage.CLOSED.equals(previousExam.getStatus().getStage())) {
-                // TODO: find if this is an existing message to translate?
                 return Optional.of(new ValidationError(ValidationErrorCode.PREVIOUS_EXAM_NOT_CLOSED, "Previous exam is not closed"));
             }
 

--- a/service/src/main/java/tds/exam/services/impl/ExamServiceImpl.java
+++ b/service/src/main/java/tds/exam/services/impl/ExamServiceImpl.java
@@ -7,7 +7,9 @@ import org.springframework.stereotype.Service;
 
 import java.time.Duration;
 import java.time.Instant;
+import java.time.temporal.ChronoUnit;
 import java.util.Arrays;
+import java.util.Date;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Optional;
@@ -476,7 +478,14 @@ class ExamServiceImpl implements ExamService {
 
         //OpenTestServiceImpl line 367 - 368 validation check.  no window no exam
         if (!maybeWindow.isPresent()) {
-            return new Response<>(new ValidationError(NO_OPEN_ASSESSMENT_WINDOW, "Could not find an open assessment window"));
+            return new Response<>(new ValidationError(
+                NO_OPEN_ASSESSMENT_WINDOW,
+                configService.getFormattedMessage(
+                    clientName,
+                    "_OpenNewOpportunity",
+                    "There is no active testing window for this student at this time"
+                )
+            ));
         }
 
         AssessmentWindow assessmentWindow = maybeWindow.get();
@@ -642,7 +651,10 @@ class ExamServiceImpl implements ExamService {
         }
 
         //Port of Student.DLL line 5593
-        return Optional.of(new ValidationError(ValidationErrorCode.CURRENT_EXAM_OPEN, "Current exam is active"));
+        return Optional.of(new ValidationError(
+            ValidationErrorCode.CURRENT_EXAM_OPEN,
+            configService.getFormattedMessage(currentSession.getClientName(),"_CanOpenTestOpportunity", "Current opportunity is active")
+        ));
     }
 
     private Optional<ValidationError> canCreateNewExam(String clientName, OpenExamRequest openExamRequest, Exam previousExam, ExternalSessionConfiguration externalSessionConfiguration) {
@@ -661,6 +673,7 @@ class ExamServiceImpl implements ExamService {
         if (previousExam != null) {
             //This is done with a query in the legacy application but we can just check the status of the previous exam fetched in a previous step.
             if (!ExamStatusStage.CLOSED.equals(previousExam.getStatus().getStage())) {
+                // TODO: find if this is an existing message to translate?
                 return Optional.of(new ValidationError(ValidationErrorCode.PREVIOUS_EXAM_NOT_CLOSED, "Previous exam is not closed"));
             }
 
@@ -677,9 +690,18 @@ class ExamServiceImpl implements ExamService {
                 daysSinceLastExamThreshold) {
                 return Optional.empty();
             } else if (LegacyComparer.greaterOrEqual(previousExam.getAttempts(), openExamRequest.getMaxAttempts())) {
-                return Optional.of(new ValidationError(ValidationErrorCode.MAX_OPPORTUNITY_EXCEEDED, "Max number of attempts for exam exceeded"));
+                return Optional.of(new ValidationError(
+                    ValidationErrorCode.MAX_OPPORTUNITY_EXCEEDED,
+                    configService.getFormattedMessage(clientName, "_CanOpenTestOpportunity", "All opportunities have been used for this test")
+                ));
             } else {
-                return Optional.of(new ValidationError(ValidationErrorCode.NOT_ENOUGH_DAYS_PASSED, String.format("Next exam cannot be started until %s days pass since last exam", numberOfDaysToDelay)));
+                Instant examCompletedAt = convertJodaInstant(previousExam.getCompletedAt());
+                Instant nextAvailableDate = examCompletedAt.plus(numberOfDaysToDelay, ChronoUnit.DAYS);
+
+                return Optional.of(new ValidationError(
+                    ValidationErrorCode.NOT_ENOUGH_DAYS_PASSED,
+                    configService.getFormattedMessage(clientName, "_CanOpenTestOpportunity", "Your next test opportunity is not yet available.", nextAvailableDate)
+                ));
             }
         }
 

--- a/service/src/test/java/tds/exam/services/impl/ConfigServiceImplTest.java
+++ b/service/src/test/java/tds/exam/services/impl/ConfigServiceImplTest.java
@@ -32,7 +32,7 @@ public class ConfigServiceImplTest {
     private static final String MESSAGE_KEY = "Replacement message";
     private static final String MESSAGE_TEXT = "Replace {0} and {1}.";
     private static final String LANGUAGE_CODE = "ENU";
-    private static final String CONTEXT = "Context";
+    private static final String CONTEXT = "_ContextMethod";
 
     private RestTemplate restTemplate;
     private ConfigService configService;
@@ -92,7 +92,7 @@ public class ConfigServiceImplTest {
                 .queryParam("subject", null);
 
         when(restTemplate.getForObject(builder.build().toUri(), String.class)).thenReturn(MESSAGE_TEXT);
-        String systemMessage = configService.getSystemMessage(CLIENT_NAME, MESSAGE_KEY, LANGUAGE_CODE, CONTEXT, replacements);
+        String systemMessage = configService.getFormattedMessage(CLIENT_NAME, CONTEXT, MESSAGE_KEY, LANGUAGE_CODE, replacements);
 
         assertThat(systemMessage).isEqualTo(expectedMessage);
     }
@@ -112,7 +112,7 @@ public class ConfigServiceImplTest {
                 .queryParam("subject", null);
 
         when(restTemplate.getForObject(builder.build().toUri(), String.class)).thenThrow(new HttpClientErrorException(HttpStatus.NOT_FOUND));
-        String systemMessage = configService.getSystemMessage(CLIENT_NAME, MESSAGE_KEY, LANGUAGE_CODE, CONTEXT, new Object[] {1, "2"});
+        String systemMessage = configService.getFormattedMessage(CLIENT_NAME, CONTEXT, MESSAGE_KEY, LANGUAGE_CODE, new Object[] {1, "2"});
 
         assertThat(systemMessage).isEqualTo(MESSAGE_KEY);
     }

--- a/service/src/test/java/tds/exam/services/impl/ExamServiceImplTest.java
+++ b/service/src/test/java/tds/exam/services/impl/ExamServiceImplTest.java
@@ -68,6 +68,7 @@ import tds.student.RtsStudentPackageAttribute;
 import tds.student.Student;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Matchers.any;
 import static org.mockito.Matchers.isA;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
@@ -151,6 +152,12 @@ public class ExamServiceImplTest {
             mockExamStatusQueryRepository,
             mockExamAccommodationService,
             mockExamApprovalService);
+
+        // Calls to get formatted message are throughout the exam service
+        // Since we aren't testing that it returns anything specific in these tests I each option here for simplicity
+        when(mockConfigService.getFormattedMessage(any(), any(), any())).thenReturn("Formatted message");
+        when(mockConfigService.getFormattedMessage(any(), any(), any(), any())).thenReturn("Formatted message");
+        when(mockConfigService.getFormattedMessage(any(), any(), any(), any(), any(), any(), any())).thenReturn("Formatted message");
     }
 
     @After
@@ -247,6 +254,7 @@ public class ExamServiceImplTest {
         assertThat(examResponse.hasError()).isTrue();
 
         ValidationError validationError = examResponse.getError().get();
+        verify(mockConfigService).getFormattedMessage("SBAC_PT", "_CanOpenTestOpportunity", "Current opportunity is active");
         assertThat(validationError.getCode()).isEqualTo(ValidationErrorCode.CURRENT_EXAM_OPEN);
     }
 


### PR DESCRIPTION
This creates a method for formatting localized messages from the DB.  It includes getting the message from the ConfigService endpoint and then doing the replacements, if any.

ValidationErrors from the legacy app that were included in the ExamService have been updated.  Some messages appear to be new and not in the database, and for those I've left them returning the message as it currently was.  We will want to consider if we should add these to the message translations tables in the future.