### PR TITLE
Feature/student attrs

### DIFF
--- a/client/src/main/java/tds/exam/ExamineeAttribute.java
+++ b/client/src/main/java/tds/exam/ExamineeAttribute.java
@@ -116,4 +116,30 @@ public class ExamineeAttribute {
     public Instant getCreatedAt() {
         return createdAt;
     }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) return true;
+        if (!(o instanceof ExamineeAttribute)) return false;
+
+        ExamineeAttribute that = (ExamineeAttribute) o;
+
+        if (getId() != that.getId()) return false;
+        if (!getExamId().equals(that.getExamId())) return false;
+        if (getContext() != that.getContext()) return false;
+        if (!getName().equals(that.getName())) return false;
+        if (!getValue().equals(that.getValue())) return false;
+        return getCreatedAt().equals(that.getCreatedAt());
+    }
+
+    @Override
+    public int hashCode() {
+        int result = (int) (getId() ^ (getId() >>> 32));
+        result = 31 * result + getExamId().hashCode();
+        result = 31 * result + getContext().hashCode();
+        result = 31 * result + getName().hashCode();
+        result = 31 * result + getValue().hashCode();
+        result = 31 * result + getCreatedAt().hashCode();
+        return result;
+    }
 }

--- a/client/src/main/java/tds/exam/ExamineeAttribute.java
+++ b/client/src/main/java/tds/exam/ExamineeAttribute.java
@@ -1,0 +1,119 @@
+package tds.exam;
+
+import org.joda.time.Instant;
+
+import java.util.UUID;
+
+/**
+ * Represents an attribute from the student package
+ */
+public class ExamineeAttribute {
+    private long id;
+    private UUID examId;
+    private ExamineeContext context;
+    private String name;
+    private String value;
+    private Instant createdAt;
+
+    /**
+     * Private constructor for frameworks
+     */
+    private ExamineeAttribute() {
+    }
+
+    public ExamineeAttribute(Builder builder) {
+        this.id = builder.id;
+        this.examId = builder.examId;
+        this.context = builder.context;
+        this.name = builder.name;
+        this.value = builder.value;
+        this.createdAt = builder.createdAt;
+    }
+
+    public static class Builder {
+        private long id;
+        private UUID examId;
+        private ExamineeContext context;
+        private String name;
+        private String value;
+        private Instant createdAt;
+
+        public Builder withId(long id) {
+            this.id = id;
+            return this;
+        }
+
+        public Builder withExamId(UUID examId) {
+            this.examId = examId;
+            return this;
+        }
+
+        public Builder withContext(ExamineeContext context) {
+            this.context = context;
+            return this;
+        }
+
+        public Builder withName(String name) {
+            this.name = name;
+            return this;
+        }
+
+        public Builder withValue(String value) {
+            this.value = value;
+            return this;
+        }
+
+        public Builder withCreatedAt(Instant createdAt) {
+            this.createdAt = createdAt;
+            return this;
+        }
+
+        public ExamineeAttribute build() {
+            return new ExamineeAttribute(this);
+        }
+    }
+
+    /**
+     * @return The unique identifier of this {@link tds.exam.ExamineeAttribute}
+     */
+    public long getId() {
+        return id;
+    }
+
+    /**
+     * @return The identifier of the {@link tds.exam.Exam} to which this {@link tds.exam.ExamineeAttribute} is
+     * associated
+     */
+    public UUID getExamId() {
+        return examId;
+    }
+
+    /**
+     * @return The {@link tds.exam.ExamineeContext} describing when this {@link tds.exam.ExamineeAttribute} was captured
+     */
+    public ExamineeContext getContext() {
+        return context;
+    }
+
+    /**
+     * @return the name (referred to as "tds_id" in the legacy student application) of this
+     * {@link tds.exam.ExamineeAttribute}
+     */
+    public String getName() {
+        return name;
+    }
+
+    /**
+     * @return The value of this {@link tds.exam.ExamineeAttribute}
+     */
+    public String getValue() {
+        return value;
+    }
+
+    /**
+     * @return The date and time when this {@link tds.exam.ExamineeAttribute} was created
+     */
+    public Instant getCreatedAt() {
+        return createdAt;
+    }
+}

--- a/client/src/main/java/tds/exam/ExamineeContext.java
+++ b/client/src/main/java/tds/exam/ExamineeContext.java
@@ -1,0 +1,56 @@
+package tds.exam;
+
+/**
+ * Enumerate the possible contexts for an {@link tds.exam.ExamineeAttribute} or {@link tds.exam.ExamineeRelationship}:
+ * <ul>
+ *     <li>{@link #INITIAL}</li>
+ *     <li>{@link #FINAL}</li>
+ * </ul>
+ */
+public enum ExamineeContext {
+    /**
+     * The student package {@link tds.exam.ExamineeAttribute}s or {@link tds.exam.ExamineeRelationship}s were captured
+     * when the {@link tds.exam.Exam} is completed.
+     */
+    FINAL("FINAL"),
+
+    /**
+     * The student package {@link tds.exam.ExamineeAttribute}s or {@link tds.exam.ExamineeRelationship}s were captured
+     * when the {@link tds.exam.Exam} is being opened.
+     */
+    INITIAL("INITIAL");
+
+    private final String type;
+
+    ExamineeContext(String type) {
+        this.type = type;
+    }
+
+    /**
+     * @return A string representation of the {@link tds.exam.ExamineeContext} enum
+     */
+    String getType() {
+        return type;
+    }
+
+    /**
+     * Get an {@link tds.exam.ExamineeContext} from its string representation
+     *
+     * @param type The string that describes the type of {@link tds.exam.ExamineeContext} to get
+     * @return The equivalent {@link tds.exam.ExamineeContext}
+     */
+    public static ExamineeContext fromType(String type) {
+        for (ExamineeContext context : ExamineeContext.values()) {
+            if (context.getType().equals(type)) {
+                return context;
+            }
+        }
+
+        throw new IllegalArgumentException(String.format("Could not find ExamineeContext for %s", type));
+    }
+
+    @Override
+    public String toString() {
+        return type;
+    }
+}

--- a/client/src/main/java/tds/exam/ExamineeContext.java
+++ b/client/src/main/java/tds/exam/ExamineeContext.java
@@ -3,8 +3,8 @@ package tds.exam;
 /**
  * Enumerate the possible contexts for an {@link tds.exam.ExamineeAttribute} or {@link tds.exam.ExamineeRelationship}:
  * <ul>
- *     <li>{@link #INITIAL}</li>
- *     <li>{@link #FINAL}</li>
+ * <li>{@link #INITIAL}</li>
+ * <li>{@link #FINAL}</li>
  * </ul>
  */
 public enum ExamineeContext {

--- a/client/src/main/java/tds/exam/ExamineeRelationship.java
+++ b/client/src/main/java/tds/exam/ExamineeRelationship.java
@@ -1,0 +1,134 @@
+package tds.exam;
+
+import org.joda.time.Instant;
+
+import java.util.UUID;
+
+/**
+ * Represents a relationship from the student package
+ */
+public class ExamineeRelationship {
+    private long id;
+    private UUID examId;
+    private String name;
+    private String value;
+    private String type;
+    private ExamineeContext context;
+    private Instant createdAt;
+
+    /**
+     * Private constructor for frameworks
+     */
+    private ExamineeRelationship() {
+    }
+
+    public ExamineeRelationship(Builder builder) {
+        this.id = builder.id;
+        this.examId = builder.examId;
+        this.name = builder.name;
+        this.value = builder.value;
+        this.type = builder.type;
+        this.context = builder.context;
+        this.createdAt = builder.createdAt;
+    }
+
+    public static class Builder {
+        private long id;
+        private UUID examId;
+        private String name;
+        private String value;
+        private String type;
+        private ExamineeContext context;
+        private Instant createdAt;
+
+        public ExamineeRelationship build() {
+            return new ExamineeRelationship(this);
+        }
+
+        public Builder withId(long id) {
+            this.id = id;
+            return this;
+        }
+
+        public Builder withExamId(UUID examId) {
+            this.examId = examId;
+            return this;
+        }
+
+        public Builder withName(String name) {
+            this.name = name;
+            return this;
+        }
+
+        public Builder withValue(String value) {
+            this.value = value;
+            return this;
+        }
+
+        public Builder withType(String type) {
+            this.type = type;
+            return this;
+        }
+
+        public Builder withContext(ExamineeContext context) {
+            this.context = context;
+            return this;
+        }
+
+        public Builder withCreatedAt(Instant createdAt) {
+            this.createdAt = createdAt;
+            return this;
+        }
+    }
+
+    /**
+     * @return The unique identifier of this {@link tds.exam.ExamineeRelationship}
+     */
+    public long getId() {
+        return id;
+    }
+
+    /**
+     * @return The identifier of the {@link tds.exam.Exam} to which this {@link tds.exam.ExamineeRelationship} belongs
+     */
+    public UUID getExamId() {
+        return examId;
+    }
+
+    /**
+     * @return The name (referred to as "tds_id" in the legacy student application) of this
+     * {@link tds.exam.ExamineeRelationship}
+     */
+    public String getName() {
+        return name;
+    }
+
+    /**
+     * @return The value for this {@link tds.exam.ExamineeRelationship}
+     */
+    public String getValue() {
+        return value;
+    }
+
+    /**
+     * @return The relationship type for this {@link tds.exam.ExamineeRelationship}
+     */
+    public String getType() {
+        return type;
+    }
+
+    /**
+     * @return The {@link tds.exam.ExamineeContext} describing when this {@link tds.exam.ExamineeRelationship} was
+     * captured
+     */
+    public ExamineeContext getContext() {
+        return context;
+    }
+
+    /**
+     * @return The date and time when this {@link tds.exam.ExamineeRelationship} was created
+     */
+    public Instant getCreatedAt() {
+        return createdAt;
+    }
+}

--- a/client/src/main/java/tds/exam/ExamineeRelationship.java
+++ b/client/src/main/java/tds/exam/ExamineeRelationship.java
@@ -131,4 +131,32 @@ public class ExamineeRelationship {
     public Instant getCreatedAt() {
         return createdAt;
     }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) return true;
+        if (!(o instanceof ExamineeRelationship)) return false;
+
+        ExamineeRelationship that = (ExamineeRelationship) o;
+
+        if (getId() != that.getId()) return false;
+        if (!getExamId().equals(that.getExamId())) return false;
+        if (!getName().equals(that.getName())) return false;
+        if (!getValue().equals(that.getValue())) return false;
+        if (!getType().equals(that.getType())) return false;
+        if (getContext() != that.getContext()) return false;
+        return getCreatedAt().equals(that.getCreatedAt());
+    }
+
+    @Override
+    public int hashCode() {
+        int result = (int) (getId() ^ (getId() >>> 32));
+        result = 31 * result + getExamId().hashCode();
+        result = 31 * result + getName().hashCode();
+        result = 31 * result + getValue().hashCode();
+        result = 31 * result + getType().hashCode();
+        result = 31 * result + getContext().hashCode();
+        result = 31 * result + getCreatedAt().hashCode();
+        return result;
+    }
 }

--- a/service/src/main/java/tds/exam/repositories/ExamineeCommandRepository.java
+++ b/service/src/main/java/tds/exam/repositories/ExamineeCommandRepository.java
@@ -1,0 +1,23 @@
+package tds.exam.repositories;
+
+import tds.exam.ExamineeAttribute;
+import tds.exam.ExamineeRelationship;
+
+/**
+ * Handles data modification for the examinee_attribute and examinee_relationshiptables
+ */
+public interface ExamineeCommandRepository {
+    /**
+     * Insert a collection of {@link tds.exam.ExamineeAttribute}s into the database.
+     *
+     * @param attributes One or more {@link tds.exam.ExamineeAttribute}s to insert
+     */
+    void insertAttributes(ExamineeAttribute... attributes);
+
+    /**
+     * Insert a collection of {@link tds.exam.ExamineeRelationship}s into the database.
+     *
+     * @param relationships One or more {@link tds.exam.ExamineeRelationship}s to insert
+     */
+    void insertRelationships(ExamineeRelationship... relationships);
+}

--- a/service/src/main/java/tds/exam/repositories/ExamineeQueryRepository.java
+++ b/service/src/main/java/tds/exam/repositories/ExamineeQueryRepository.java
@@ -15,7 +15,7 @@ public interface ExamineeQueryRepository {
      * Find the {@link tds.exam.ExamineeAttribute}s associated with an {@link tds.exam.Exam} for the specified
      * {@link tds.exam.ExamineeContext}
      *
-     * @param examId The unique identifier of the {@link tds.exam.Exam}
+     * @param examId  The unique identifier of the {@link tds.exam.Exam}
      * @param context The {@link tds.exam.ExamineeContext} in which the attributes were stored
      * @return A collection of {@link tds.exam.ExamineeAttribute}s for the specified {@link tds.exam.ExamineeContext}
      */
@@ -25,7 +25,7 @@ public interface ExamineeQueryRepository {
      * Find the {@link tds.exam.ExamineeRelationship}s associated with an {@link tds.exam.Exam} for the specified
      * {@link tds.exam.ExamineeContext}
      *
-     * @param examId The unique identifier of the {@link tds.exam.Exam}
+     * @param examId  The unique identifier of the {@link tds.exam.Exam}
      * @param context The {@link tds.exam.ExamineeContext} in which the relationships were stored
      * @return A collection of {@link tds.exam.ExamineeRelationship}s for the specified {@link tds.exam.ExamineeContext}
      */

--- a/service/src/main/java/tds/exam/repositories/ExamineeQueryRepository.java
+++ b/service/src/main/java/tds/exam/repositories/ExamineeQueryRepository.java
@@ -1,0 +1,33 @@
+package tds.exam.repositories;
+
+import java.util.List;
+import java.util.UUID;
+
+import tds.exam.ExamineeAttribute;
+import tds.exam.ExamineeContext;
+import tds.exam.ExamineeRelationship;
+
+/**
+ * Handles data reads from the examinee_attribute and examinee_relationship tables
+ */
+public interface ExamineeQueryRepository {
+    /**
+     * Find the {@link tds.exam.ExamineeAttribute}s associated with an {@link tds.exam.Exam} for the specified
+     * {@link tds.exam.ExamineeContext}
+     *
+     * @param examId The unique identifier of the {@link tds.exam.Exam}
+     * @param context The {@link tds.exam.ExamineeContext} in which the attributes were stored
+     * @return A collection of {@link tds.exam.ExamineeAttribute}s for the specified {@link tds.exam.ExamineeContext}
+     */
+    List<ExamineeAttribute> findAllAttributes(UUID examId, ExamineeContext context);
+
+    /**
+     * Find the {@link tds.exam.ExamineeRelationship}s associated with an {@link tds.exam.Exam} for the specified
+     * {@link tds.exam.ExamineeContext}
+     *
+     * @param examId The unique identifier of the {@link tds.exam.Exam}
+     * @param context The {@link tds.exam.ExamineeContext} in which the relationships were stored
+     * @return A collection of {@link tds.exam.ExamineeRelationship}s for the specified {@link tds.exam.ExamineeContext}
+     */
+    List<ExamineeRelationship> findAllRelationships(UUID examId, ExamineeContext context);
+}

--- a/service/src/main/java/tds/exam/repositories/impl/ExamineeCommandRepositoryImpl.java
+++ b/service/src/main/java/tds/exam/repositories/impl/ExamineeCommandRepositoryImpl.java
@@ -42,6 +42,7 @@ public class ExamineeCommandRepositoryImpl implements ExamineeCommandRepository 
                 "VALUES (\n" +
                 "   :examId, \n" +
                 "   :context, \n" +
+                "   :attributeName, \n" +
                 "   :attributeValue, \n" +
                 "   :createdAt)";
 
@@ -52,7 +53,7 @@ public class ExamineeCommandRepositoryImpl implements ExamineeCommandRepository 
     public void insertRelationships(ExamineeRelationship... relationships) {
         final SqlParameterSource[] batchParameters = Stream.of(relationships)
             .map(relationship -> new MapSqlParameterSource("examId", relationship.getExamId().toString())
-                .addValue("attributeName", relationship.getId())
+                .addValue("attributeName", relationship.getName())
                 .addValue("attributeValue", relationship.getValue())
                 .addValue("attributeRelationship", relationship.getType())
                 .addValue("context", relationship.getContext().toString())

--- a/service/src/main/java/tds/exam/repositories/impl/ExamineeCommandRepositoryImpl.java
+++ b/service/src/main/java/tds/exam/repositories/impl/ExamineeCommandRepositoryImpl.java
@@ -1,0 +1,80 @@
+package tds.exam.repositories.impl;
+
+import org.joda.time.Instant;
+import org.springframework.beans.factory.annotation.Qualifier;
+import org.springframework.jdbc.core.namedparam.MapSqlParameterSource;
+import org.springframework.jdbc.core.namedparam.NamedParameterJdbcTemplate;
+import org.springframework.jdbc.core.namedparam.SqlParameterSource;
+import org.springframework.stereotype.Repository;
+
+import java.util.stream.Stream;
+
+import tds.common.data.mapping.ResultSetMapperUtility;
+import tds.exam.ExamineeAttribute;
+import tds.exam.ExamineeRelationship;
+import tds.exam.repositories.ExamineeCommandRepository;
+
+@Repository
+public class ExamineeCommandRepositoryImpl implements ExamineeCommandRepository {
+    private final NamedParameterJdbcTemplate jdbcTemplate;
+
+    public ExamineeCommandRepositoryImpl(@Qualifier("commandJdbcTemplate") NamedParameterJdbcTemplate jdbcTemplate) {
+        this.jdbcTemplate = jdbcTemplate;
+    }
+
+    @Override
+    public void insertAttributes(ExamineeAttribute... attributes) {
+        final SqlParameterSource[] batchParameters = Stream.of(attributes)
+            .map(attribute -> new MapSqlParameterSource("examId", attribute.getExamId().toString())
+                .addValue("context", attribute.getContext().toString())
+                .addValue("attributeName", attribute.getName())
+                .addValue("attributeValue", attribute.getValue())
+                .addValue("createdAt", ResultSetMapperUtility.mapJodaInstantToTimestamp(Instant.now())))
+            .toArray(MapSqlParameterSource[]::new);
+
+        final String SQL =
+            "INSERT INTO examinee_attribute( \n" +
+                "   exam_id, \n" +
+                "   context, \n" +
+                "   attribute_name, \n" +
+                "   attribute_value, \n" +
+                "   created_at) \n" +
+                "VALUES (\n" +
+                "   :examId, \n" +
+                "   :context, \n" +
+                "   :attributeValue, \n" +
+                "   :createdAt)";
+
+        jdbcTemplate.batchUpdate(SQL, batchParameters);
+    }
+
+    @Override
+    public void insertRelationships(ExamineeRelationship... relationships) {
+        final SqlParameterSource[] batchParameters = Stream.of(relationships)
+            .map(relationship -> new MapSqlParameterSource("examId", relationship.getExamId().toString())
+                .addValue("attributeName", relationship.getId())
+                .addValue("attributeValue", relationship.getValue())
+                .addValue("attributeRelationship", relationship.getType())
+                .addValue("context", relationship.getContext().toString())
+                .addValue("createdAt", ResultSetMapperUtility.mapJodaInstantToTimestamp(Instant.now())))
+            .toArray(MapSqlParameterSource[]::new);
+
+        final String SQL =
+            "INSERT INTO examinee_relationship( \n" +
+                "   exam_id, \n" +
+                "   attribute_name, \n" +
+                "   attribute_value, \n" +
+                "   attribute_relationship, \n" +
+                "   context, \n" +
+                "   created_at) \n" +
+                "VALUES ( \n" +
+                "   :examId, \n" +
+                "   :attributeName, \n" +
+                "   :attributeValue, \n" +
+                "   :attributeRelationship, \n" +
+                "   :context, \n" +
+                "   :createdAt)";
+
+        jdbcTemplate.batchUpdate(SQL, batchParameters);
+    }
+}

--- a/service/src/main/java/tds/exam/repositories/impl/ExamineeQueryRepositoryImpl.java
+++ b/service/src/main/java/tds/exam/repositories/impl/ExamineeQueryRepositoryImpl.java
@@ -30,17 +30,32 @@ public class ExamineeQueryRepositoryImpl implements ExamineeQueryRepository {
 
         final String SQL =
             "SELECT \n" +
-                "   id, \n" +
-                "   exam_id, \n" +
-                "   context, \n" +
-                "   attribute_name, \n" +
-                "   attribute_value, \n" +
-                "   created_at \n" +
+                "   attribute.id, \n" +
+                "   attribute.exam_id, \n" +
+                "   attribute.context, \n" +
+                "   attribute.attribute_name, \n" +
+                "   attribute.attribute_value, \n" +
+                "   attribute.created_at \n" +
                 "FROM \n" +
-                "   examinee_attribute \n" +
+                "   examinee_attribute attribute \n" +
+                "JOIN ( \n" +
+                "   SELECT \n" +
+                "       MAX(id) AS id \n" +
+                "   FROM \n" +
+                "       examinee_attribute \n" +
+                "   WHERE \n" +
+                "       exam_id = :examId \n" +
+                "       AND context = :context \n" +
+                "   GROUP BY \n" +
+                "       exam_id, \n" +
+                "       context, \n" +
+                "       attribute_name \n" +
+                ") most_recent_record \n" +
+                "   ON \n" +
+                "       most_recent_record.id = attribute.id \n" +
                 "WHERE \n" +
-                "   exam_id = :examId \n" +
-                "   AND context = :context";
+                "   attribute.exam_id = :examId	\n" +
+                "   AND attribute.context = :context";
 
         return jdbcTemplate.query(SQL, parameters, (rs, r) -> new ExamineeAttribute.Builder()
             .withId(rs.getLong("id"))
@@ -59,18 +74,34 @@ public class ExamineeQueryRepositoryImpl implements ExamineeQueryRepository {
 
         final String SQL =
             "SELECT \n" +
-                "   id, \n" +
-                "   exam_id, \n" +
-                "   context, \n" +
-                "   attribute_name, \n" +
-                "   attribute_value, \n" +
-                "   attribute_relationship, \n" +
-                "   created_at \n" +
+                "   relationship.id, \n" +
+                "   relationship.exam_id, \n" +
+                "   relationship.context, \n" +
+                "   relationship.attribute_name, \n" +
+                "   relationship.attribute_value, \n" +
+                "   relationship.attribute_relationship, \n" +
+                "   relationship.created_at \n" +
                 "FROM \n" +
-                "   examinee_relationship \n" +
+                "   examinee_relationship relationship \n" +
+                "JOIN ( \n" +
+                "   SELECT \n" +
+                "       MAX(id) AS id \n" +
+                "   FROM \n" +
+                "       examinee_relationship \n" +
+                "   WHERE \n" +
+                "       exam_id = :examId \n" +
+                "       AND context = :context \n" +
+                "   GROUP BY \n" +
+                "       exam_id, \n" +
+                "       context, \n" +
+                "       attribute_name, \n" +
+                "       attribute_relationship \n" +
+                ") most_recent_record \n" +
+                "   ON \n" +
+                "       most_recent_record.id = relationship.id \n" +
                 "WHERE \n" +
-                "   exam_id = :examId \n" +
-                "   AND context = :context";
+                "   relationship.exam_id = :examId \n" +
+                "   AND relationship.context = :context";
 
         return jdbcTemplate.query(SQL, parameters, (rs, r) -> new ExamineeRelationship.Builder()
             .withId(rs.getLong("id"))

--- a/service/src/main/java/tds/exam/repositories/impl/ExamineeQueryRepositoryImpl.java
+++ b/service/src/main/java/tds/exam/repositories/impl/ExamineeQueryRepositoryImpl.java
@@ -48,7 +48,7 @@ public class ExamineeQueryRepositoryImpl implements ExamineeQueryRepository {
             .withContext(ExamineeContext.fromType(rs.getString("context")))
             .withName(rs.getString("attribute_name"))
             .withValue(rs.getString("attribute_value"))
-            .withCreatedAt(ResultSetMapperUtility.mapTimestampToJodaInstant(rs, "crated_at"))
+            .withCreatedAt(ResultSetMapperUtility.mapTimestampToJodaInstant(rs, "created_at"))
             .build());
     }
 

--- a/service/src/main/java/tds/exam/repositories/impl/ExamineeQueryRepositoryImpl.java
+++ b/service/src/main/java/tds/exam/repositories/impl/ExamineeQueryRepositoryImpl.java
@@ -1,0 +1,84 @@
+package tds.exam.repositories.impl;
+
+import org.springframework.beans.factory.annotation.Qualifier;
+import org.springframework.jdbc.core.namedparam.MapSqlParameterSource;
+import org.springframework.jdbc.core.namedparam.NamedParameterJdbcTemplate;
+import org.springframework.jdbc.core.namedparam.SqlParameterSource;
+import org.springframework.stereotype.Repository;
+
+import java.util.List;
+import java.util.UUID;
+
+import tds.common.data.mapping.ResultSetMapperUtility;
+import tds.exam.ExamineeAttribute;
+import tds.exam.ExamineeContext;
+import tds.exam.ExamineeRelationship;
+import tds.exam.repositories.ExamineeQueryRepository;
+
+@Repository
+public class ExamineeQueryRepositoryImpl implements ExamineeQueryRepository {
+    private final NamedParameterJdbcTemplate jdbcTemplate;
+
+    public ExamineeQueryRepositoryImpl(@Qualifier("queryJdbcTemplate") NamedParameterJdbcTemplate jdbcTemplate) {
+        this.jdbcTemplate = jdbcTemplate;
+    }
+
+    @Override
+    public List<ExamineeAttribute> findAllAttributes(final UUID examId, final ExamineeContext context) {
+        final SqlParameterSource parameters = new MapSqlParameterSource("examId", examId.toString())
+            .addValue("context", context.toString());
+
+        final String SQL =
+            "SELECT \n" +
+                "   id, \n" +
+                "   exam_id, \n" +
+                "   context, \n" +
+                "   attribute_name, \n" +
+                "   attribute_value, \n" +
+                "   created_at \n" +
+                "FROM \n" +
+                "   examinee_attribute \n" +
+                "WHERE \n" +
+                "   exam_id = :examId \n" +
+                "   AND context = :context";
+
+        return jdbcTemplate.query(SQL, parameters, (rs, r) -> new ExamineeAttribute.Builder()
+            .withId(rs.getLong("id"))
+            .withExamId(UUID.fromString(rs.getString("exam_id")))
+            .withContext(ExamineeContext.fromType(rs.getString("context")))
+            .withName(rs.getString("attribute_name"))
+            .withValue(rs.getString("attribute_value"))
+            .withCreatedAt(ResultSetMapperUtility.mapTimestampToJodaInstant(rs, "crated_at"))
+            .build());
+    }
+
+    @Override
+    public List<ExamineeRelationship> findAllRelationships(final UUID examId, final ExamineeContext context) {
+        final SqlParameterSource parameters = new MapSqlParameterSource("examId", examId.toString())
+            .addValue("context", context.toString());
+
+        final String SQL =
+            "SELECT \n" +
+                "   id, \n" +
+                "   exam_id, \n" +
+                "   context, \n" +
+                "   attribute_name, \n" +
+                "   attribute_value, \n" +
+                "   attribute_relationship, \n" +
+                "   created_at \n" +
+                "FROM \n" +
+                "   examinee_relationship \n" +
+                "WHERE \n" +
+                "   exam_id = :examId \n" +
+                "   AND context = :context";
+
+        return jdbcTemplate.query(SQL, parameters, (rs, r) -> new ExamineeRelationship.Builder()
+            .withId(rs.getLong("id"))
+            .withExamId(UUID.fromString(rs.getString("exam_id")))
+            .withContext(ExamineeContext.fromType(rs.getString("context")))
+            .withName(rs.getString("attribute_name"))
+            .withValue(rs.getString("attribute_value"))
+            .withType(rs.getString("attribute_relationship"))
+            .build());
+    }
+}

--- a/service/src/main/java/tds/exam/services/ExamineeService.java
+++ b/service/src/main/java/tds/exam/services/ExamineeService.java
@@ -1,0 +1,21 @@
+package tds.exam.services;
+
+import java.util.UUID;
+
+import tds.exam.ExamineeContext;
+
+/**
+ * A service for interacting with {@link tds.exam.ExamineeAttribute}s and {@link tds.exam.ExamineeRelationship}s
+ */
+public interface ExamineeService {
+    /**
+     * Insert the {@link tds.exam.ExamineeAttribute}s and {@link tds.exam.ExamineeRelationship}s for this
+     * {@link tds.exam.Exam} for the specified {@link tds.exam.ExamineeContext}.
+     *
+     * @param examId The unique identifier of the {@link tds.exam.Exam} for which attributes and relationships are being
+     *               stored
+     * @param context The {@link tds.exam.ExamineeContext} that describes the state of the examniee's information when
+     *                these attributes and relationships were collected
+     */
+    void insertAttributesAndRelationships(UUID examId, ExamineeContext context);
+}

--- a/service/src/main/java/tds/exam/services/impl/ExamineeServiceImpl.java
+++ b/service/src/main/java/tds/exam/services/impl/ExamineeServiceImpl.java
@@ -40,7 +40,7 @@ public class ExamineeServiceImpl implements ExamineeService {
             .orElseThrow(() -> new NotFoundException(String.format("Could not find exam for id %s", examId)));
 
         Student student = studentService.getStudentById(exam.getStudentId())
-            .orElseThrow(() -> (new NotFoundException(String.format("Could not find student for exam id %s and student id %d", examId, exam.getStudentId()))));
+            .orElseThrow(() -> new NotFoundException(String.format("Could not find student for exam id %s and student id %d", examId, exam.getStudentId())));
 
         ExamineeAttribute[] examineeAttributes = student.getAttributes().stream()
             .map(attribute -> new ExamineeAttribute.Builder()

--- a/service/src/main/java/tds/exam/services/impl/ExamineeServiceImpl.java
+++ b/service/src/main/java/tds/exam/services/impl/ExamineeServiceImpl.java
@@ -1,0 +1,70 @@
+package tds.exam.services.impl;
+
+import org.joda.time.Instant;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.UUID;
+
+import tds.common.web.exceptions.NotFoundException;
+import tds.exam.Exam;
+import tds.exam.ExamineeAttribute;
+import tds.exam.ExamineeContext;
+import tds.exam.ExamineeRelationship;
+import tds.exam.repositories.ExamineeCommandRepository;
+import tds.exam.services.ExamService;
+import tds.exam.services.ExamineeService;
+import tds.exam.services.StudentService;
+import tds.student.Student;
+
+@Service
+public class ExamineeServiceImpl implements ExamineeService {
+    private final ExamineeCommandRepository examineeCommandRepository;
+    private final ExamService examService;
+    private final StudentService studentService;
+
+    @Autowired
+    public ExamineeServiceImpl(ExamineeCommandRepository examineeCommandRepository,
+                               ExamService examService,
+                               StudentService studentService) {
+        this.examineeCommandRepository = examineeCommandRepository;
+        this.examService = examService;
+        this.studentService = studentService;
+    }
+
+    @Override
+    @Transactional
+    public void insertAttributesAndRelationships(UUID examId, ExamineeContext context) {
+        Exam exam = examService.findExam(examId)
+            .orElseThrow(() -> new NotFoundException(String.format("Could not find exam for id %s", examId)));
+
+        Student student = studentService.getStudentById(exam.getStudentId())
+            .orElseThrow(() -> (new NotFoundException(String.format("Could not find student for exam id %s and student id %d", examId, exam.getStudentId()))));
+
+        ExamineeAttribute[] examineeAttributes = student.getAttributes().stream()
+            .map(attribute -> new ExamineeAttribute.Builder()
+                .withExamId(examId)
+                .withContext(context)
+                .withName(attribute.getName())
+                .withValue(attribute.getValue())
+                .withCreatedAt(Instant.now())
+                .build())
+            .toArray(ExamineeAttribute[]::new);
+
+        ExamineeRelationship[] examineeRelationships = student.getRelationships().stream()
+            .map(relationship -> new ExamineeRelationship.Builder()
+                .withExamId(examId)
+                .withContext(context)
+                .withName(relationship.getId())
+                .withValue(relationship.getValue())
+                .withType(relationship.getType())
+                .withCreatedAt(Instant.now())
+                .build())
+            .toArray(ExamineeRelationship[]::new);
+
+        examineeCommandRepository.insertAttributes(examineeAttributes);
+
+        examineeCommandRepository.insertRelationships(examineeRelationships);
+    }
+}

--- a/service/src/main/resources/db/migration/V1486592454__exam_create_examinee_tables.sql
+++ b/service/src/main/resources/db/migration/V1486592454__exam_create_examinee_tables.sql
@@ -1,0 +1,30 @@
+/***********************************************************************************************************************
+  File: V1486592454__exam_create_examinee_tables.sql
+
+  Desc: Create tables to store student attributes and their relationships
+
+***********************************************************************************************************************/
+USE exam;
+
+CREATE TABLE IF NOT EXISTS examinee_attribute (
+  id BIGINT(20) NOT NULL AUTO_INCREMENT,
+  exam_id CHAR(36) NOT NULL,
+  context VARCHAR(10) NOT NULL,
+  attribute_name VARCHAR(50) NOT NULL,
+  attribute_value VARCHAR(400) NOT NULL,
+  created_at TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP(3),
+  CONSTRAINT pk_exam_attribute_id PRIMARY KEY (id),
+  CONSTRAINT fk_exam_attribute_exam_id_exam_id FOREIGN KEY (exam_id) REFERENCES exam(id)
+);
+
+CREATE TABLE IF NOT EXISTS examinee_relationship (
+  id BIGINT(20) NOT NULL AUTO_INCREMENT,
+  exam_id CHAR(36) NOT NULL,
+  attribute_name VARCHAR(50) NOT NULL,
+  attribute_value VARCHAR(500) NOT NULL,
+  attribute_relationship VARCHAR(100) NOT NULL,
+  context VARCHAR(10) NOT NULL,
+  created_at TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP(3),
+  CONSTRAINT pk_exam_relationship_id PRIMARY KEY (id),
+  CONSTRAINT fk_exam_relationship_exam_id_exam_id FOREIGN KEY (exam_id) REFERENCES exam(id)
+);

--- a/service/src/test/java/tds/exam/builder/ExamItemBuilder.java
+++ b/service/src/test/java/tds/exam/builder/ExamItemBuilder.java
@@ -18,7 +18,6 @@ public class ExamItemBuilder {
     private long assessmentItemKey = 1234L;
     private String itemType = "MS";
     private int position = 1;
-    private boolean selected;
     private boolean required;
     private boolean markedForReview;
     private boolean fieldTest;

--- a/service/src/test/java/tds/exam/builder/ExamineeAttributeBuilder.java
+++ b/service/src/test/java/tds/exam/builder/ExamineeAttributeBuilder.java
@@ -1,0 +1,61 @@
+package tds.exam.builder;
+
+import org.joda.time.Instant;
+
+import java.util.UUID;
+
+import tds.exam.ExamineeAttribute;
+import tds.exam.ExamineeContext;
+
+/**
+ * Build an {@link tds.exam.ExamineeAttribute} with sample data
+ */
+public class ExamineeAttributeBuilder {
+    private long id = 0L;
+    private UUID examId = UUID.randomUUID();
+    private ExamineeContext context = ExamineeContext.INITIAL;
+    private String name = "UnitTestName";
+    private String value = "UnitTestValue";
+    private Instant createdAt = Instant.now();
+
+    public ExamineeAttribute build() {
+        return new ExamineeAttribute.Builder()
+            .withId(id)
+            .withExamId(examId)
+            .withContext(context)
+            .withName(name)
+            .withValue(value)
+            .withCreatedAt(createdAt)
+            .build();
+    }
+
+    public ExamineeAttributeBuilder withId(long id) {
+        this.id = id;
+        return this;
+    }
+
+    public ExamineeAttributeBuilder withExamId(UUID examId) {
+        this.examId = examId;
+        return this;
+    }
+
+    public ExamineeAttributeBuilder withContext(ExamineeContext context) {
+        this.context = context;
+        return this;
+    }
+
+    public ExamineeAttributeBuilder withName(String name) {
+        this.name = name;
+        return this;
+    }
+
+    public ExamineeAttributeBuilder withValue(String value) {
+        this.value = value;
+        return this;
+    }
+
+    public ExamineeAttributeBuilder withCreatedAt(Instant createdAt) {
+        this.createdAt = createdAt;
+        return this;
+    }
+}

--- a/service/src/test/java/tds/exam/builder/ExamineeRelationshipBuilder.java
+++ b/service/src/test/java/tds/exam/builder/ExamineeRelationshipBuilder.java
@@ -1,0 +1,68 @@
+package tds.exam.builder;
+
+import org.joda.time.Instant;
+
+import java.util.UUID;
+
+import tds.exam.ExamineeContext;
+import tds.exam.ExamineeRelationship;
+
+/**
+ * Build an {@link tds.exam.ExamineeRelationship} with sample data
+ */
+public class ExamineeRelationshipBuilder {
+    private long id = 0L;
+    private UUID examId = UUID.randomUUID();
+    private String name = "UnitTestRelationshipName";
+    private String value = "UnitTestRelationshipValue";
+    private String type = "UnitTestRelationshipType";
+    private ExamineeContext context = ExamineeContext.INITIAL;
+    private Instant createdAt = Instant.now();
+
+    public ExamineeRelationship build() {
+        return new ExamineeRelationship.Builder()
+            .withId(id)
+            .withExamId(examId)
+            .withContext(context)
+            .withName(name)
+            .withValue(value)
+            .withType(type)
+            .withCreatedAt(createdAt)
+            .build();
+    }
+
+    public ExamineeRelationshipBuilder withId(long id) {
+        this.id = id;
+        return this;
+    }
+
+    public ExamineeRelationshipBuilder withExamId(UUID examId) {
+        this.examId = examId;
+        return this;
+    }
+
+    public ExamineeRelationshipBuilder withName(String name) {
+        this.name = name;
+        return this;
+    }
+
+    public ExamineeRelationshipBuilder withValue(String value) {
+        this.value = value;
+        return this;
+    }
+
+    public ExamineeRelationshipBuilder withType(String type) {
+        this.type = type;
+        return this;
+    }
+
+    public ExamineeRelationshipBuilder withContext(ExamineeContext context) {
+        this.context = context;
+        return this;
+    }
+
+    public ExamineeRelationshipBuilder withCreatedAt(Instant createdAt) {
+        this.createdAt = createdAt;
+        return this;
+    }
+}

--- a/service/src/test/java/tds/exam/repositories/impl/ExamineeCommandRepositoryImplIntegrationTests.java
+++ b/service/src/test/java/tds/exam/repositories/impl/ExamineeCommandRepositoryImplIntegrationTests.java
@@ -1,0 +1,121 @@
+package tds.exam.repositories.impl;
+
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.beans.factory.annotation.Qualifier;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.jdbc.core.namedparam.NamedParameterJdbcTemplate;
+import org.springframework.test.context.junit4.SpringJUnit4ClassRunner;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.List;
+
+import tds.exam.Exam;
+import tds.exam.ExamineeAttribute;
+import tds.exam.ExamineeContext;
+import tds.exam.ExamineeRelationship;
+import tds.exam.builder.ExamBuilder;
+import tds.exam.builder.ExamineeAttributeBuilder;
+import tds.exam.builder.ExamineeRelationshipBuilder;
+import tds.exam.repositories.ExamCommandRepository;
+import tds.exam.repositories.ExamineeCommandRepository;
+import tds.exam.repositories.ExamineeQueryRepository;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+@RunWith(SpringJUnit4ClassRunner.class)
+@SpringBootTest
+@Transactional
+public class ExamineeCommandRepositoryImplIntegrationTests {
+    @Autowired
+    @Qualifier("commandJdbcTemplate")
+    private NamedParameterJdbcTemplate jdbcTemplate;
+
+    private ExamineeCommandRepository examineeCommandRepository;
+    private ExamineeQueryRepository examineeQueryRepository;
+    private ExamCommandRepository examCommandRepository;
+    private Exam mockExam = new ExamBuilder().build();
+
+    @Before
+    public void setUp() {
+        examineeCommandRepository = new ExamineeCommandRepositoryImpl(jdbcTemplate);
+        examineeQueryRepository = new ExamineeQueryRepositoryImpl(jdbcTemplate);
+
+        examCommandRepository = new ExamCommandRepositoryImpl(jdbcTemplate);
+    }
+
+    @Test
+    public void shouldInsertExamineeAttributes() {
+        examCommandRepository.insert(mockExam);
+
+        ExamineeAttribute firstAttribute = new ExamineeAttributeBuilder()
+            .withExamId(mockExam.getId())
+            .withContext(ExamineeContext.INITIAL)
+            .build();
+        ExamineeAttribute secondAttribute = new ExamineeAttributeBuilder()
+            .withExamId(mockExam.getId())
+            .withContext(ExamineeContext.INITIAL)
+            .withName("AnotherUnitTest")
+            .withValue("AnotherUnitTestValue")
+            .build();
+
+        examineeCommandRepository.insertAttributes(firstAttribute, secondAttribute);
+
+        List<ExamineeAttribute> savedAttributes = examineeQueryRepository.findAllAttributes(mockExam.getId(),
+            ExamineeContext.INITIAL);
+
+        assertThat(savedAttributes).hasSize(2);
+        ExamineeAttribute firstSavedAttribute = savedAttributes.get(0);
+        assertThat(firstSavedAttribute.getId()).isGreaterThan(0L);
+        assertThat(firstSavedAttribute.getExamId()).isEqualTo(mockExam.getId());
+        assertThat(firstSavedAttribute.getContext()).isEqualTo(firstAttribute.getContext());
+        assertThat(firstSavedAttribute.getName()).isEqualTo(firstAttribute.getName());
+        assertThat(firstSavedAttribute.getValue()).isEqualTo(firstAttribute.getValue());
+
+        ExamineeAttribute secondSavedAttribute = savedAttributes.get(1);
+        assertThat(secondSavedAttribute.getId()).isGreaterThan(0L);
+        assertThat(secondSavedAttribute.getExamId()).isEqualTo(mockExam.getId());
+        assertThat(secondSavedAttribute.getContext()).isEqualTo(secondAttribute.getContext());
+        assertThat(secondSavedAttribute.getName()).isEqualTo(secondAttribute.getName());
+        assertThat(secondSavedAttribute.getValue()).isEqualTo(secondAttribute.getValue());
+    }
+
+    @Test
+    public void shouldInsertExamineeRelationships() {
+        examCommandRepository.insert(mockExam);
+
+        ExamineeRelationship firstRelationship = new ExamineeRelationshipBuilder()
+            .withExamId(mockExam.getId())
+            .build();
+        ExamineeRelationship secondRelationship = new ExamineeRelationshipBuilder()
+            .withExamId(mockExam.getId())
+            .withName("AnotherUnitTestName")
+            .withValue("AnotherUnitTestValue")
+            .withType("AnotherUnitTestType")
+            .build();
+
+        examineeCommandRepository.insertRelationships(firstRelationship, secondRelationship);
+
+        List<ExamineeRelationship> savedRelationships = examineeQueryRepository.findAllRelationships(mockExam.getId(),
+            ExamineeContext.INITIAL);
+
+        assertThat(savedRelationships).hasSize(2);
+        ExamineeRelationship firstSavedRelationship = savedRelationships.get(0);
+        assertThat(firstSavedRelationship.getId()).isGreaterThan(0L);
+        assertThat(firstSavedRelationship.getExamId()).isEqualTo(mockExam.getId());
+        assertThat(firstSavedRelationship.getContext()).isEqualTo(firstRelationship.getContext());
+        assertThat(firstSavedRelationship.getName()).isEqualTo(firstRelationship.getName());
+        assertThat(firstSavedRelationship.getValue()).isEqualTo(firstRelationship.getValue());
+        assertThat(firstSavedRelationship.getType()).isEqualTo(firstRelationship.getType());
+
+        ExamineeRelationship secondSavedRelationship = savedRelationships.get(1);
+        assertThat(secondSavedRelationship.getId()).isGreaterThan(0L);
+        assertThat(secondSavedRelationship.getExamId()).isEqualTo(mockExam.getId());
+        assertThat(secondSavedRelationship.getContext()).isEqualTo(secondRelationship.getContext());
+        assertThat(secondSavedRelationship.getName()).isEqualTo(secondRelationship.getName());
+        assertThat(secondSavedRelationship.getValue()).isEqualTo(secondRelationship.getValue());
+        assertThat(secondSavedRelationship.getType()).isEqualTo(secondRelationship.getType());
+    }
+}

--- a/service/src/test/java/tds/exam/repositories/impl/ExamineeCommandRepositoryImplIntegrationTests.java
+++ b/service/src/test/java/tds/exam/repositories/impl/ExamineeCommandRepositoryImplIntegrationTests.java
@@ -42,7 +42,6 @@ public class ExamineeCommandRepositoryImplIntegrationTests {
     public void setUp() {
         examineeCommandRepository = new ExamineeCommandRepositoryImpl(jdbcTemplate);
         examineeQueryRepository = new ExamineeQueryRepositoryImpl(jdbcTemplate);
-
         examCommandRepository = new ExamCommandRepositoryImpl(jdbcTemplate);
     }
 

--- a/service/src/test/java/tds/exam/repositories/impl/ExamineeQueryRepositoryImplIntegrationTests.java
+++ b/service/src/test/java/tds/exam/repositories/impl/ExamineeQueryRepositoryImplIntegrationTests.java
@@ -1,0 +1,93 @@
+package tds.exam.repositories.impl;
+
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.beans.factory.annotation.Qualifier;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.jdbc.core.namedparam.NamedParameterJdbcTemplate;
+import org.springframework.test.context.junit4.SpringJUnit4ClassRunner;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.List;
+import java.util.UUID;
+
+import tds.exam.ExamineeAttribute;
+import tds.exam.ExamineeContext;
+import tds.exam.ExamineeRelationship;
+import tds.exam.builder.ExamBuilder;
+import tds.exam.builder.ExamineeAttributeBuilder;
+import tds.exam.builder.ExamineeRelationshipBuilder;
+import tds.exam.repositories.ExamCommandRepository;
+import tds.exam.repositories.ExamineeCommandRepository;
+import tds.exam.repositories.ExamineeQueryRepository;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+@RunWith(SpringJUnit4ClassRunner.class)
+@SpringBootTest
+@Transactional
+public class ExamineeQueryRepositoryImplIntegrationTests {
+    @Autowired
+    @Qualifier("commandJdbcTemplate")
+    private NamedParameterJdbcTemplate jdbcTemplate;
+
+    private ExamCommandRepository examCommandRepository;
+    private ExamineeCommandRepository examineeCommandRepository;
+    private ExamineeQueryRepository examineeQueryRepository;
+
+    private final UUID examId = UUID.randomUUID();
+
+    @Before
+    public void setUp() {
+        examineeCommandRepository = new ExamineeCommandRepositoryImpl(jdbcTemplate);
+        examineeQueryRepository = new ExamineeQueryRepositoryImpl(jdbcTemplate);
+        examCommandRepository = new ExamCommandRepositoryImpl(jdbcTemplate);
+    }
+
+    @Test
+    public void shouldFetchTheMostRecentExamineeAttributeValue() {
+        examCommandRepository.insert(new ExamBuilder().withId(examId).build());
+
+        ExamineeAttribute attribute = new ExamineeAttributeBuilder()
+            .withExamId(examId)
+            .withValue("1 attribute value")
+            .build();
+        ExamineeAttribute moreRecentAttribute = new ExamineeAttributeBuilder()
+            .withExamId(examId)
+            .withValue("2 attribute value")
+            .build();
+
+        examineeCommandRepository.insertAttributes(attribute, moreRecentAttribute);
+
+        List<ExamineeAttribute> result = examineeQueryRepository.findAllAttributes(examId, ExamineeContext.INITIAL);
+
+        assertThat(result).hasSize(1);
+        ExamineeAttribute mostRecentAttribute = result.get(0);
+        assertThat(mostRecentAttribute.getValue()).isEqualTo(moreRecentAttribute.getValue());
+    }
+
+    @Test
+    public void shouldFetchTheMostRecentExamineeRelationshipValue() {
+        examCommandRepository.insert(new ExamBuilder().withId(examId).build());
+
+        ExamineeRelationship relationship = new ExamineeRelationshipBuilder()
+            .withExamId(examId)
+            .withValue("1 relationship value")
+            .build();
+        ExamineeRelationship moreRecentRelationship = new ExamineeRelationshipBuilder()
+            .withExamId(examId)
+            .withValue("2 relationship value")
+            .build();
+
+        examineeCommandRepository.insertRelationships(relationship, moreRecentRelationship);
+
+        List<ExamineeRelationship> result = examineeQueryRepository.findAllRelationships(examId,
+            ExamineeContext.INITIAL);
+
+        assertThat(result).hasSize(1);
+        ExamineeRelationship mostRecentRelationship = result.get(0);
+        assertThat(mostRecentRelationship.getValue()).isEqualTo(moreRecentRelationship.getValue());
+    }
+}

--- a/service/src/test/java/tds/exam/services/impl/ExamineeServiceImplTest.java
+++ b/service/src/test/java/tds/exam/services/impl/ExamineeServiceImplTest.java
@@ -1,0 +1,118 @@
+package tds.exam.services.impl;
+
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.Mock;
+import org.mockito.runners.MockitoJUnitRunner;
+
+import java.util.Arrays;
+import java.util.Optional;
+import java.util.UUID;
+
+import tds.common.web.exceptions.NotFoundException;
+import tds.exam.Exam;
+import tds.exam.ExamineeAttribute;
+import tds.exam.ExamineeContext;
+import tds.exam.ExamineeRelationship;
+import tds.exam.builder.ExamBuilder;
+import tds.exam.repositories.ExamineeCommandRepository;
+import tds.exam.services.ExamService;
+import tds.exam.services.ExamineeService;
+import tds.exam.services.StudentService;
+import tds.student.RtsStudentPackageAttribute;
+import tds.student.RtsStudentPackageRelationship;
+import tds.student.Student;
+
+import static org.mockito.Matchers.any;
+import static org.mockito.Matchers.anyVararg;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyZeroInteractions;
+import static org.mockito.Mockito.when;
+
+@RunWith(MockitoJUnitRunner.class)
+public class ExamineeServiceImplTest {
+    @Mock
+    private ExamineeCommandRepository examineeCommandRepository;
+
+    @Mock
+    private ExamService examService;
+
+    @Mock
+    private StudentService studentService;
+
+    private ExamineeService examineeService;
+
+    @Before
+    public void setUp() {
+        examineeService = new ExamineeServiceImpl(examineeCommandRepository, examService, studentService);
+    }
+
+    @Test
+    public void shouldInsertAttributesAndRelationships() {
+        Exam mockExam = new ExamBuilder().build();
+
+        RtsStudentPackageAttribute[] mockRtsStudentPackageAttributes = new RtsStudentPackageAttribute[]{
+            new RtsStudentPackageAttribute("UnitTestAttribute", "UnitTestAttributeValue"),
+            new RtsStudentPackageAttribute("AnotherUnitTestAttribute", "AnotherUnitTestAttributeValue"),
+        };
+        RtsStudentPackageRelationship[] mockRtsStudentPackageRelationships = new RtsStudentPackageRelationship[]{
+            new RtsStudentPackageRelationship("RelationshipId",
+                "RelationshipType",
+                "RelationshipValue",
+                "entityKey"),
+            new RtsStudentPackageRelationship("AnotherRelationshipId",
+                "AnotherRelationshipType",
+                "AnotherRelationshipValue",
+                "anotherEntityKey"),
+        };
+
+        Student mockStudent = new Student.Builder(1L, "UNIT_TEST_CLIENT")
+            .withLoginSSID("UNIT_TEST_SSID")
+            .withAttributes(Arrays.asList(mockRtsStudentPackageAttributes))
+            .withRelationships(Arrays.asList(mockRtsStudentPackageRelationships))
+            .build();
+
+        when(examService.findExam(mockExam.getId()))
+            .thenReturn(Optional.of(mockExam));
+        when(studentService.getStudentById(mockExam.getStudentId()))
+            .thenReturn(Optional.of(mockStudent));
+
+        examineeService.insertAttributesAndRelationships(mockExam.getId(), ExamineeContext.INITIAL);
+        verify(examService).findExam(mockExam.getId());
+        verify(studentService).getStudentById(mockStudent.getId());
+        verify(examineeCommandRepository).insertAttributes((ExamineeAttribute[]) anyVararg());
+        verify(examineeCommandRepository).insertRelationships((ExamineeRelationship[]) anyVararg());
+    }
+
+    @Test(expected = NotFoundException.class)
+    public void shouldThrowNotFoundExceptionWhenExamCannotBeFound() {
+        Student mockStudent = new Student.Builder(1L, "UNIT_TEST_CLIENT")
+            .build();
+
+        when(examService.findExam(any(UUID.class)))
+            .thenReturn(Optional.empty());
+        when(studentService.getStudentById(any(Long.class)))
+            .thenReturn(Optional.of(mockStudent));
+
+        examineeService.insertAttributesAndRelationships(UUID.randomUUID(), ExamineeContext.INITIAL);
+        verify(examService).findExam(any(UUID.class));
+        verifyZeroInteractions(studentService);
+        verifyZeroInteractions(examineeCommandRepository);
+    }
+
+    @Test(expected = NotFoundException.class)
+    public void shouldThrowNotFoundExceptionWhenExamCanBeFoundButStudentCannot() {
+        Exam mockExam = new ExamBuilder().build();
+
+        when(examService.findExam(any(UUID.class)))
+            .thenReturn(Optional.of(mockExam));
+        when(studentService.getStudentById(any(Long.class)))
+            .thenReturn(Optional.empty());
+
+        examineeService.insertAttributesAndRelationships(UUID.randomUUID(), ExamineeContext.INITIAL);
+        verify(examService).findExam(any(UUID.class));
+        verify(studentService).getStudentById(any(Long.class));
+        verifyZeroInteractions(examineeCommandRepository);
+    }
+}


### PR DESCRIPTION
[TDS-665](https://jira.fairwaytech.com/browse/TDS-665):  Save student attributes and relationships to the `exam` database.  This PR effectively ports `CommonDLL._SetTesteeAttributes_SP()` (`CommonDLL`, line 1185).

#### Notes
* Related to the [feature/student-attrs](https://github.com/SmarterApp/TDS_StudentService/pull/15) pull request in the *TDS_StudentService* repo
* So far, the `ExamineeService` implementation is used internally; there is no need for a controller endpoint
* The `ExamineeQueryRepository` implementation has been provided primarily to facilitate testing