### PR TITLE
Feature/exam status update endpoint

### DIFF
--- a/client/src/main/java/tds/exam/ExamStatusCode.java
+++ b/client/src/main/java/tds/exam/ExamStatusCode.java
@@ -1,5 +1,10 @@
 package tds.exam;
 
+import javax.validation.constraints.NotNull;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.Map;
+
 public class ExamStatusCode {
     public static final String STATUS_PAUSED = "paused";
     public static final String STATUS_PENDING = "pending";
@@ -22,7 +27,31 @@ public class ExamStatusCode {
     public static final String STATUS_REPORTED = "reported";
     public static final String STATUS_CLOSED = "closed";
     public static final String STATUS_DISABLED = "disabled";
-
+    
+    // Mapping status codes to stages
+    private static final Map<String, ExamStatusStage> statusToStage;
+    static {
+        Map<String, ExamStatusStage> stageMap = new HashMap<>();
+        stageMap.put(STATUS_PAUSED, ExamStatusStage.INACTIVE);
+        stageMap.put(STATUS_PENDING, ExamStatusStage.IN_USE);
+        stageMap.put(STATUS_APPROVED, ExamStatusStage.IN_USE);
+        stageMap.put(STATUS_SUSPENDED, ExamStatusStage.IN_USE);
+        stageMap.put(STATUS_REVIEW, ExamStatusStage.IN_USE);
+        stageMap.put(STATUS_STARTED, ExamStatusStage.IN_USE);
+        stageMap.put(STATUS_DENIED, ExamStatusStage.INACTIVE);
+        stageMap.put(STATUS_COMPLETED, ExamStatusStage.CLOSED);
+        stageMap.put(STATUS_SCORED, ExamStatusStage.CLOSED);
+        stageMap.put(STATUS_SEGMENT_ENTRY, ExamStatusStage.IN_USE);
+        stageMap.put(STATUS_SEGMENT_EXIT, ExamStatusStage.IN_USE);
+        stageMap.put(STATUS_INVALIDATED, ExamStatusStage.CLOSED);
+        stageMap.put(STATUS_EXPIRED, ExamStatusStage.CLOSED);
+        stageMap.put(STATUS_SUBMITTED, ExamStatusStage.CLOSED);
+        stageMap.put(STATUS_RESCORED, ExamStatusStage.CLOSED);
+        stageMap.put(STATUS_REPORTED, ExamStatusStage.CLOSED);
+        stageMap.put(STATUS_CLOSED, ExamStatusStage.CLOSED);
+        statusToStage = Collections.unmodifiableMap(stageMap);
+    }
+    
     private String code;
     private ExamStatusStage stage;
 
@@ -38,6 +67,15 @@ public class ExamStatusCode {
      * Private constructor for frameworks
      */
     private ExamStatusCode() {
+    }
+    
+    public ExamStatusCode(String code) {
+        this.code = code;
+        this.stage = statusToStage.get(code);
+        
+        if (this.stage == null) {
+            throw new IllegalArgumentException(String.format("No default stage found for status code %s", code));
+        }
     }
 
     public ExamStatusCode(String code, ExamStatusStage stage) {

--- a/service/src/main/java/tds/exam/web/endpoints/ExamController.java
+++ b/service/src/main/java/tds/exam/web/endpoints/ExamController.java
@@ -78,9 +78,11 @@ public class ExamController {
         return ResponseEntity.ok(examConfiguration);
     }
     
-    @RequestMapping(value = "/{examId}/status")
-    ResponseEntity<NoContentResponseResource> updateStatus(@PathVariable final UUID examId, @RequestParam final String status,
-                                                           @RequestParam final String stage, @RequestParam(required = false) final String reason) {
+    @RequestMapping(value = "/{examId}/status", method = RequestMethod.PUT, produces = MediaType.APPLICATION_JSON_VALUE)
+    ResponseEntity<NoContentResponseResource> updateStatus(@PathVariable final UUID examId,
+                                                           @RequestParam final String status,
+                                                           @RequestParam(required = false) final String stage,
+                                                           @RequestParam(required = false) final String reason) {
     
         ExamStatusCode examStatus = (stage == null) ? new ExamStatusCode(status) : new ExamStatusCode(status, ExamStatusStage.fromType(stage));
         final Optional<ValidationError> maybeStatusTransitionFailure = examService.updateExamStatus(examId, examStatus, reason);


### PR DESCRIPTION
This PR corresponds to JIRA TDS-518. This endpoint will be called when student or proctor needs to update a status for an exam.

A new map has been added to ExamStatusCode to map status' to their default stage, if no stage is provided by the caller of this API.