### PR TITLE
Use the configured MySql host

### DIFF
--- a/service/src/main/docker/docker-startup.sh
+++ b/service/src/main/docker/docker-startup.sh
@@ -7,11 +7,11 @@
 #-----------------------------------------------------------------------------------------------------------------------
 
 java \
-    -Dspring.ds_queries.jdbcUrl="jdbc:mysql://exam_mysql/${EXAM_DB_NAME}" \
+    -Dspring.ds_queries.jdbcUrl="jdbc:mysql://${EXAM_DB_HOST}/${EXAM_DB_NAME}" \
     -Dspring.ds_queries.username="${EXAM_DB_USER}" \
     -Dspring.ds_queries.password="${EXAM_DB_PASSWORD}" \
     -Dspring.ds_queries.driver-class-name=com.mysql.jdbc.Driver \
-    -Dspring.ds_commands.jdbcUrl="jdbc:mysql://exam_mysql/${EXAM_DB_NAME}" \
+    -Dspring.ds_commands.jdbcUrl="jdbc:mysql://${EXAM_DB_HOST}/${EXAM_DB_NAME}" \
     -Dspring.ds_commands.username="${EXAM_DB_USER}" \
     -Dspring.ds_commands.password="${EXAM_DB_PASSWORD}" \
     -Dspring.ds_commands.driver-class-name=com.mysql.jdbc.Driver \
@@ -23,7 +23,7 @@ java \
     -Dexam-service.assessment-url=http://assessment:8080/ \
     -Dexam-service.config-url=http://config:8080/ \
     -Dflyway.enabled=${EXAM_FLYWAY_ENABLED} \
-    -Dflyway.url="jdbc:mysql://exam_mysql/${EXAM_DB_NAME}" \
+    -Dflyway.url="jdbc:mysql://${EXAM_DB_HOST}/${EXAM_DB_NAME}" \
     -Dflyway.user="${EXAM_DB_USER}" \
     -Dflyway.password="${EXAM_DB_PASSWORD}" \
     -jar /tds-exam-service.jar \


### PR DESCRIPTION
Use the configured EXAM_DB_HOST value when connecting to the MySql exam datasource.

NOTE that if using docker-compose, you will need to update your tds-docker.env properties file in the TDS_Build project to "exam_mysql" to avoid any behavioral changes.

This is a step towards removing the mysql container image.

See [this related pull request](https://github.com/SmarterApp/TDS_Build/pull/2)