### PR TITLE
Use the external configuration service for configurations.  Add a loc…

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -38,5 +38,6 @@
         <docker.image.prefix>fwsbac</docker.image.prefix>
         <mysql.version>5.1.39</mysql.version>
         <joda-time.version>2.9.5</joda-time.version>
+        <spring.cloud.config.version>1.2.2.RELEASE</spring.cloud.config.version>
     </properties>
 </project>

--- a/service/pom.xml
+++ b/service/pom.xml
@@ -21,6 +21,18 @@
         <assertj.version>3.4.1</assertj.version>
     </properties>
 
+    <dependencyManagement>
+        <dependencies>
+            <dependency>
+                <groupId>org.springframework.cloud</groupId>
+                <artifactId>spring-cloud-config</artifactId>
+                <version>${spring.cloud.config.version}</version>
+                <type>pom</type>
+                <scope>import</scope>
+            </dependency>
+        </dependencies>
+    </dependencyManagement>
+
     <dependencies>
         <!-- TDS -->
         <dependency>
@@ -64,6 +76,10 @@
                     <artifactId>spring-boot-starter-tomcat</artifactId>
                 </exclusion>
             </exclusions>
+        </dependency>
+        <dependency>
+            <groupId>org.springframework.cloud</groupId>
+            <artifactId>spring-cloud-starter-config</artifactId>
         </dependency>
         <dependency>
             <groupId>org.springframework.boot</groupId>

--- a/service/src/main/docker/docker-startup.sh
+++ b/service/src/main/docker/docker-startup.sh
@@ -6,30 +6,4 @@
 #
 #-----------------------------------------------------------------------------------------------------------------------
 
-java \
-    -Dspring.ds_queries.jdbcUrl="jdbc:mysql://${EXAM_DB_HOST}/${EXAM_DB_NAME}" \
-    -Dspring.ds_queries.username="${EXAM_DB_USER}" \
-    -Dspring.ds_queries.password="${EXAM_DB_PASSWORD}" \
-    -Dspring.ds_queries.driver-class-name=com.mysql.jdbc.Driver \
-    -Dspring.ds_commands.jdbcUrl="jdbc:mysql://${EXAM_DB_HOST}/${EXAM_DB_NAME}" \
-    -Dspring.ds_commands.username="${EXAM_DB_USER}" \
-    -Dspring.ds_commands.password="${EXAM_DB_PASSWORD}" \
-    -Dspring.ds_commands.driver-class-name=com.mysql.jdbc.Driver \
-    -Dspring.datasource.testWhileIdle=true \
-    -Dspring.datasource.timeBetweenEvictionRunsMillis=60000 \
-    -Dspring.datasource.validationQuery="SELECT 1" \
-    -Dexam-service.session-url=http://session:8080/ \
-    -Dexam-service.student-url=http://student:8080/ \
-    -Dexam-service.assessment-url=http://assessment:8080/ \
-    -Dexam-service.config-url=http://config:8080/ \
-    -Dflyway.enabled=${EXAM_FLYWAY_ENABLED} \
-    -Dflyway.url="jdbc:mysql://${EXAM_DB_HOST}/${EXAM_DB_NAME}" \
-    -Dflyway.user="${EXAM_DB_USER}" \
-    -Dflyway.password="${EXAM_DB_PASSWORD}" \
-    -jar /tds-exam-service.jar \
-    --server-port="8080" \
-    --server.undertow.buffer-size=16384 \
-    --server.undertow.buffers-per-region=20 \
-    --server.undertow.io-threads=64 \
-    --server.undertow.worker-threads=512 \
-    --server.undertow.direct-buffers=true
+java -jar /tds-exam-service.jar

--- a/service/src/main/resources/application.yml
+++ b/service/src/main/resources/application.yml
@@ -1,0 +1,39 @@
+spring:
+  profiles: local-development
+  ds_queries:
+    jdbcUrl: ${mysql.url}
+    username: ${mysql.user}
+    password: ${mysql.password}
+    driver-class-name: 'com.mysql.jdbc.Driver'
+  ds_commands:
+    jdbcUrl: ${mysql.url}
+    username: ${mysql.user}
+    password: ${mysql.password}
+    driver-class-name: 'com.mysql.jdbc.Driver'
+
+server:
+  port: 8081
+  undertow:
+    buffer-size: 16384
+    buffers-per-region: 20
+    io-threads: 64
+    worker-threads: 512
+    direct-buffers: true
+
+flyway:
+  enabled: true
+  url: ${mysql.url}
+  user: ${mysql.user}
+  password: ${mysql.password}
+
+#Ports defined in TDS_Build:docker-compose.yml
+exam-service:
+  session-url: http://localhost:32842
+  student-url: http://localhost:32840
+  assessment-url: http://localhost:32841
+  config-url: http://localhost:32843
+
+mysql:
+  url: jdbc:mysql://localhost:3306/exam
+  user: username
+  password: password

--- a/service/src/main/resources/application.yml
+++ b/service/src/main/resources/application.yml
@@ -32,8 +32,3 @@ exam-service:
   student-url: http://localhost:32840
   assessment-url: http://localhost:32841
   config-url: http://localhost:32843
-
-mysql:
-  url: jdbc:mysql://localhost:3306/exam
-  user: username
-  password: password

--- a/service/src/main/resources/bootstrap.yml
+++ b/service/src/main/resources/bootstrap.yml
@@ -1,0 +1,8 @@
+spring:
+  application:
+    name: exam-service
+  cloud:
+    config:
+      uri: ${CONFIG_SERVICE_URL:http://localhost:8888}
+      enabled: ${CONFIG_SERVICE_ENABLED:false}
+      fail-fast: ${CONFIG_SERVICE_ENABLED:false}


### PR DESCRIPTION
…al-development configuration profile with sample property values.

This PR updates the Exam Service to optionally pull configurations from a Spring Cloud Config service.
* Pull docker configuration values out of the docker start script
* Add default properties to an application.yml file under a "local-development" profile
* Add bootstrap configuration properties that will connect to a remote configuration service if CONFIG_SERVICE_ENABLED and CONFIG_SERVICE_URL environment properties are set.

There is a [related pull request](https://github.com/SmarterApp/TDS_Build/pull/3) for TDS_Build.