### PR TITLE
Exam repository query will now join on exam_accommodations to retriev…

### DIFF
--- a/service/src/main/java/tds/exam/repositories/impl/ExamQueryRepositoryImpl.java
+++ b/service/src/main/java/tds/exam/repositories/impl/ExamQueryRepositoryImpl.java
@@ -53,12 +53,12 @@ public class ExamQueryRepositoryImpl implements ExamQueryRepository {
         "e.assessment_window_id, \n" +
         "e.assessment_algorithm, \n" +
         "e.segmented, \n" +
+        "lang.code AS language_code, \n" +
         "ee.attempts, \n" +
         "ee.status, \n" +
         "ee.status_changed_at, \n" +
         "ee.max_items, \n" +
         "ee.expires_at, \n" +
-        "ee.language_code, \n" +
         "ee.status_change_reason, \n" +
         "ee.deleted_at, \n" +
         "ee.changed_at, \n" +
@@ -101,7 +101,12 @@ public class ExamQueryRepositoryImpl implements ExamQueryRepository {
                 "  ON last_event.exam_id = ee.exam_id AND \n" +
                 "     last_event.id = ee.id\n" +
                 "JOIN exam.exam_status_codes esc \n" +
-                "  ON esc.status = ee.status";
+                "  ON esc.status = ee.status \n" +
+                "JOIN exam.exam_accommodation lang \n" +
+                "  ON lang.exam_id= e.id \n" +
+                "WHERE \n" +
+                "   lang.type = 'Language' AND \n" +
+                "   lang.segment_position = 0";
 
         Optional<Exam> examOptional;
         try {
@@ -141,10 +146,14 @@ public class ExamQueryRepositoryImpl implements ExamQueryRepository {
                 "     last_event.id = ee.id \n" +
                 "JOIN exam.exam_status_codes esc \n" +
                 "  ON esc.status = ee.status \n" +
+                "JOIN exam.exam_accommodation lang \n" +
+                "  ON lang.exam_id= e.id \n" +
                 "WHERE \n" +
                 "   e.student_id = :studentId \n" +
                 "   AND e.assessment_id = :assessmentId \n" +
                 "   AND e.client_name = :clientName \n" +
+                "   AND lang.type = 'Language' \n" +
+                "   AND lang.segment_position = 0 \n" +
                 "ORDER BY \n" +
                 "   e.created_at DESC";
 
@@ -245,8 +254,12 @@ public class ExamQueryRepositoryImpl implements ExamQueryRepository {
                 "     last_event.id = ee.id\n" +
                 "JOIN exam.exam_status_codes esc \n" +
                 "  ON esc.status = ee.status \n" +
+                "JOIN exam.exam_accommodation lang \n" +
+                "  ON lang.exam_id= e.id \n" +
                 "WHERE ee.session_id = :sessionId \n" +
-                "AND ee.status IN (:statusSet)";
+                "   AND ee.status IN (:statusSet) \n " +
+                "   AND lang.type = 'Language' \n" +
+                "   AND lang.segment_position = 0";
 
         return jdbcTemplate.query(SQL, parameters, new ExamRowMapper());
     }
@@ -324,9 +337,13 @@ public class ExamQueryRepositoryImpl implements ExamQueryRepository {
                 "  ON last_event.id = ee.id \n" +
                 "JOIN exam.exam_status_codes esc \n" +
                 "  ON esc.status = ee.status \n" +
+                "JOIN exam.exam_accommodation lang \n" +
+                "  ON lang.exam_id= e.id \n" +
                 "WHERE \n" +
                 "  ee.session_id = :sessionId AND \n" +
-                "  ee.status IN (:statusSet)";
+                "  ee.status IN (:statusSet) AND \n" +
+                "  lang.type = 'Language' AND \n" +
+                "  lang.segment_position = 0";
 
         return jdbcTemplate.query(SQL, parameters, new ExamRowMapper());
     }

--- a/service/src/main/java/tds/exam/repositories/impl/ExamQueryRepositoryImpl.java
+++ b/service/src/main/java/tds/exam/repositories/impl/ExamQueryRepositoryImpl.java
@@ -102,11 +102,21 @@ public class ExamQueryRepositoryImpl implements ExamQueryRepository {
                 "     last_event.id = ee.id\n" +
                 "JOIN exam.exam_status_codes esc \n" +
                 "  ON esc.status = ee.status \n" +
-                "JOIN exam.exam_accommodation lang \n" +
-                "  ON lang.exam_id= e.id \n" +
+                "LEFT JOIN exam.exam_accommodation lang \n" +
+                "  ON lang.exam_id = e.id \n" +
+                "  AND lang.created_at = \n" +
+                "  ( \n" +
+                "       SELECT \n" +
+                "           MAX(eacc.created_at) \n" +
+                "       FROM \n" +
+                "          exam.exam_accommodation eacc \n" +
+                "          WHERE \n" +
+                "          eacc.exam_id = e.id \n" +
+                "          AND eacc.type = 'Language'\n" +
+                "  ) \n" +
                 "WHERE \n" +
-                "   lang.type = 'Language' AND \n" +
-                "   lang.segment_position = 0";
+                "   lang.type = 'Language'";
+        
 
         Optional<Exam> examOptional;
         try {
@@ -146,17 +156,27 @@ public class ExamQueryRepositoryImpl implements ExamQueryRepository {
                 "     last_event.id = ee.id \n" +
                 "JOIN exam.exam_status_codes esc \n" +
                 "  ON esc.status = ee.status \n" +
-                "JOIN exam.exam_accommodation lang \n" +
-                "  ON lang.exam_id= e.id \n" +
+                "LEFT JOIN exam.exam_accommodation lang \n" +
+                "  ON lang.exam_id = e.id \n" +
+                "  AND lang.created_at = \n" +
+                "  ( \n" +
+                "       SELECT \n" +
+                "           MAX(eacc.created_at) \n" +
+                "       FROM \n" +
+                "          exam.exam_accommodation eacc \n" +
+                "          WHERE \n" +
+                "          eacc.exam_id = e.id \n" +
+                "          AND eacc.type = 'Language'\n" +
+                "  ) \n" +
                 "WHERE \n" +
                 "   e.student_id = :studentId \n" +
                 "   AND e.assessment_id = :assessmentId \n" +
                 "   AND e.client_name = :clientName \n" +
-                "   AND lang.type = 'Language' \n" +
-                "   AND lang.segment_position = 0 \n" +
+                "   AND lang.type = 'Language'" +
                 "ORDER BY \n" +
                 "   e.created_at DESC";
-
+    
+    
         Optional<Exam> examOptional;
         try {
             examOptional = Optional.of(jdbcTemplate.queryForObject(query, parameters, new ExamRowMapper()));
@@ -254,13 +274,22 @@ public class ExamQueryRepositoryImpl implements ExamQueryRepository {
                 "     last_event.id = ee.id\n" +
                 "JOIN exam.exam_status_codes esc \n" +
                 "  ON esc.status = ee.status \n" +
-                "JOIN exam.exam_accommodation lang \n" +
-                "  ON lang.exam_id= e.id \n" +
+                "LEFT JOIN exam.exam_accommodation lang \n" +
+                "  ON lang.exam_id = e.id \n" +
+                "  AND lang.created_at = \n" +
+                "  ( \n" +
+                "       SELECT \n" +
+                "           MAX(eacc.created_at) \n" +
+                "       FROM \n" +
+                "          exam.exam_accommodation eacc \n" +
+                "          WHERE \n" +
+                "          eacc.exam_id = e.id \n" +
+                "          AND eacc.type = 'Language'\n" +
+                "  ) \n" +
                 "WHERE ee.session_id = :sessionId \n" +
                 "   AND ee.status IN (:statusSet) \n " +
-                "   AND lang.type = 'Language' \n" +
-                "   AND lang.segment_position = 0";
-
+                "   AND lang.type = 'Language'";
+    
         return jdbcTemplate.query(SQL, parameters, new ExamRowMapper());
     }
 
@@ -299,14 +328,14 @@ public class ExamQueryRepositoryImpl implements ExamQueryRepository {
                 "ON \n" +
                 "  exam.id = exam_scores.exam_id \n" +
                 "WHERE\n" +
-                "  exam.client_name = :clientName AND\n" +
-                "  exam.student_id = :studentId AND\n" +
-                "  exam.subject = :subject AND\n" +
-                "  ee.deleted_at IS NULL AND\n" +
-                "  ee.scored_at IS NOT NULL AND\n" +
-                "  exam.id <> :examId AND\n" +
-                "  exam_scores.use_for_ability = 1 AND\n" +
-                "  exam_scores.value IS NOT NULL \n" +
+                "  exam.client_name = :clientName \n" +
+                "  AND exam.student_id = :studentId \n" +
+                "  AND exam.subject = :subject \n" +
+                "  AND ee.deleted_at IS NULL \n" +
+                "  AND ee.scored_at IS NOT NULL \n" +
+                "  AND exam.id <> :examId \n" +
+                "  AND exam_scores.use_for_ability = 1 \n" +
+                "  AND exam_scores.value IS NOT NULL \n" +
                 "ORDER BY ee.scored_at DESC";
 
         return jdbcTemplate.query(SQL, parameters, new AbilityRowMapper());
@@ -337,14 +366,24 @@ public class ExamQueryRepositoryImpl implements ExamQueryRepository {
                 "  ON last_event.id = ee.id \n" +
                 "JOIN exam.exam_status_codes esc \n" +
                 "  ON esc.status = ee.status \n" +
-                "JOIN exam.exam_accommodation lang \n" +
-                "  ON lang.exam_id= e.id \n" +
+                "LEFT JOIN exam.exam_accommodation lang \n" +
+                "  ON lang.exam_id = e.id \n" +
+                "  AND lang.created_at = \n" +
+                "  ( \n" +
+                "       SELECT \n" +
+                "           MAX(eacc.created_at) \n" +
+                "       FROM \n" +
+                "          exam.exam_accommodation eacc \n" +
+                "          WHERE \n" +
+                "          eacc.exam_id = e.id \n" +
+                "          AND eacc.type = 'Language'\n" +
+                "  ) \n" +
                 "WHERE \n" +
-                "  ee.session_id = :sessionId AND \n" +
-                "  ee.status IN (:statusSet) AND \n" +
-                "  lang.type = 'Language' AND \n" +
-                "  lang.segment_position = 0";
-
+                "  ee.session_id = :sessionId \n" +
+                "  AND ee.status IN (:statusSet) \n" +
+                "  AND lang.type = 'Language' \n";
+    
+    
         return jdbcTemplate.query(SQL, parameters, new ExamRowMapper());
     }
 

--- a/service/src/test/java/tds/exam/repositories/impl/ExamCommandRepositoryImplIntegrationTests.java
+++ b/service/src/test/java/tds/exam/repositories/impl/ExamCommandRepositoryImplIntegrationTests.java
@@ -12,13 +12,16 @@ import org.springframework.test.context.junit4.SpringJUnit4ClassRunner;
 import org.springframework.transaction.annotation.Transactional;
 
 import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.List;
 import java.util.Optional;
 
 import tds.exam.Exam;
 import tds.exam.ExamStatusCode;
 import tds.exam.ExamStatusStage;
+import tds.exam.builder.ExamAccommodationBuilder;
 import tds.exam.builder.ExamBuilder;
+import tds.exam.repositories.ExamAccommodationCommandRepository;
 import tds.exam.repositories.ExamCommandRepository;
 import tds.exam.repositories.ExamQueryRepository;
 
@@ -34,11 +37,14 @@ public class ExamCommandRepositoryImplIntegrationTests {
 
     private ExamCommandRepository examCommandRepository;
     private ExamQueryRepository examQueryRepository;
+    private ExamAccommodationCommandRepository examAccommodationCommandRepository;
+    
 
     @Before
     public void setUp() {
         examCommandRepository = new ExamCommandRepositoryImpl(jdbcTemplate);
         examQueryRepository = new ExamQueryRepositoryImpl(jdbcTemplate);
+        examAccommodationCommandRepository = new ExamAccommodationCommandRepositoryImpl(jdbcTemplate);
     }
 
     @Test
@@ -51,6 +57,14 @@ public class ExamCommandRepositoryImplIntegrationTests {
         assertThat(examQueryRepository.getExamById(exam.getId())).isNotPresent();
 
         examCommandRepository.insert(exam);
+        examAccommodationCommandRepository.insert(Arrays.asList(
+          new ExamAccommodationBuilder()
+            .withType("Language")
+            .withCode("ENU")
+            .withExamId(exam.getId())
+            .withSegmentPosition(0)
+            .build()
+        ));
 
         Optional<Exam> maybeExam = examQueryRepository.getExamById(exam.getId());
         assertThat(maybeExam).isPresent();
@@ -89,7 +103,14 @@ public class ExamCommandRepositoryImplIntegrationTests {
         assertThat(examQueryRepository.getExamById(mockExam.getId())).isNotPresent();
 
         examCommandRepository.insert(mockExam);
-
+        examAccommodationCommandRepository.insert(Arrays.asList(
+          new ExamAccommodationBuilder()
+            .withType("Language")
+            .withCode("ENU")
+            .withExamId(mockExam.getId())
+            .withSegmentPosition(0)
+            .build()
+        ));
         Optional<Exam> maybeExam = examQueryRepository.getExamById(mockExam.getId());
         assertThat(maybeExam).isPresent();
 
@@ -121,7 +142,18 @@ public class ExamCommandRepositoryImplIntegrationTests {
         exams.add(mockFirstExam);
         exams.add(mockSecondExam);
 
-        exams.forEach(e -> examCommandRepository.insert(e));
+        exams.forEach(e -> {
+            examCommandRepository.insert(e);
+            examAccommodationCommandRepository.insert(Arrays.asList(
+              new ExamAccommodationBuilder()
+                .withType("Language")
+                .withCode("ENU")
+                .withExamId(e.getId())
+                .withSegmentPosition(0)
+                .build()
+            ));
+        });
+        
 
         List<Exam> examsWithChanges = new ArrayList<>();
         examsWithChanges.add(new Exam.Builder().fromExam(mockFirstExam)


### PR DESCRIPTION
…e language accommodation

I needed to insert an ExamAccommodation during ExamQuery/Command integration tests so that the "find" queries would not fail. an Exam should __always__ have an exam language at the assessment-level (segment_position = 0) by the time it is access with a query repository.

Note that the "segment_position = 0" is to ensure that we only retrieve one accommodation record. 
TDS-660 is a an open bug where exam accommodations are inserted at position "1" instead of "0" during open test flow. Once this is addressed, the segment_position = 0 clause is extraneous and can be removed. 

https://jira.fairwaytech.com/browse/TDS-660?filter=-2