### PR TITLE
Expandable exams  + findExamsBySession service code

### DIFF
--- a/client/src/main/java/tds/exam/ExpandableExam.java
+++ b/client/src/main/java/tds/exam/ExpandableExam.java
@@ -47,14 +47,23 @@ public class ExpandableExam {
         }
     }
 
+    /**
+     * @return The base {@link tds.exam.Exam}
+     */
     public Exam getExam() {
         return exam;
     }
 
+    /**
+     * @return The {@link tds.exam.ExamAccommodation}s of the exam
+     */
     public List<ExamAccommodation> getExamAccommodations() {
         return examAccommodations;
     }
 
+    /**
+     * @return The count of items that have existing responses for the exam
+     */
     public int getItemsResponseCount() {
         return itemResponseCount;
     }

--- a/client/src/main/java/tds/exam/ExpandableExam.java
+++ b/client/src/main/java/tds/exam/ExpandableExam.java
@@ -1,0 +1,61 @@
+package tds.exam;
+
+import java.util.List;
+
+/**
+ * A model representing an {@link tds.exam.Exam} as well as other optional exam-specific data
+ */
+public class ExpandableExam {
+    public static final String EXPANDABLE_PARAMS_EXAM_ACCOMMODATIONS = "examAccommodations";
+    public static final String EXPANDABLE_PARAMS_ITEM_RESPONSE_COUNT = "itemResponseCount";
+    public static final String EXPANDABLE_PARAMS_UNFULFILLED_REQUEST_COUNT = "unfulfilledRequestCount";
+
+    private Exam exam;
+    private int itemResponseCount;
+    private List<ExamAccommodation> examAccommodations;
+
+    /* Empty private constructor for frameworks */
+    private ExpandableExam() {}
+
+    public ExpandableExam(Builder builder) {
+        this.exam = builder.exam;
+        this.examAccommodations = builder.examAccommodations;
+        this.itemResponseCount = builder.itemResponseCount;
+    }
+
+    public static class Builder {
+        private Exam exam;
+        private List<ExamAccommodation> examAccommodations;
+        private int itemResponseCount;
+
+        public Builder(Exam exam) {
+            this.exam = exam;
+        }
+
+        public Builder withExamAccommodations(List<ExamAccommodation> examAccommodations) {
+            this.examAccommodations = examAccommodations;
+            return this;
+        }
+
+        public Builder withItemsResponseCount(int itemResponseCount) {
+            this.itemResponseCount = itemResponseCount;
+            return this;
+        }
+
+        public ExpandableExam build() {
+            return new ExpandableExam(this);
+        }
+    }
+
+    public Exam getExam() {
+        return exam;
+    }
+
+    public List<ExamAccommodation> getExamAccommodations() {
+        return examAccommodations;
+    }
+
+    public int getItemsResponseCount() {
+        return itemResponseCount;
+    }
+}

--- a/service/src/main/java/tds/exam/repositories/ExamAccommodationQueryRepository.java
+++ b/service/src/main/java/tds/exam/repositories/ExamAccommodationQueryRepository.java
@@ -22,16 +22,16 @@ public interface ExamAccommodationQueryRepository {
     /**
      * Retrieves all the accommodations associated with an exam
      *
-     * @param examId the exam id for the
+     * @param examIds the exam ids to find exam accommodations for
      * @return list of {@link tds.exam.ExamAccommodation}
      */
-    List<ExamAccommodation> findAccommodations(final UUID examId);
+    List<ExamAccommodation> findAccommodations(final UUID... examIds);
 
     /**
      * Retrieves all the approved {@link tds.exam.ExamAccommodation} associated with the exam
      *
-     * @param examId the unique id for the exam
+     * @param examIds the unique ids for the exams
      * @return list containing approved {@link tds.exam.ExamAccommodation}
      */
-    List<ExamAccommodation> findApprovedAccommodations(final UUID examId);
+    List<ExamAccommodation> findApprovedAccommodations(final UUID... examIds);
 }

--- a/service/src/main/java/tds/exam/repositories/ExamItemQueryRepository.java
+++ b/service/src/main/java/tds/exam/repositories/ExamItemQueryRepository.java
@@ -1,5 +1,6 @@
 package tds.exam.repositories;
 
+import java.util.Map;
 import java.util.UUID;
 
 /**
@@ -14,4 +15,12 @@ public interface ExamItemQueryRepository {
      * @return the item position of the last item responded to
      */
     int getCurrentExamItemPosition(final UUID examId);
+
+    /**
+     * Fetches a map of examIds for their respective number of items responded to
+     *
+     * @param examIds the ids of the exams to fetch response counts for
+     * @return a mapping of examIds to the number of items that exam has responded to
+     */
+    Map<UUID, Integer> getResponseCounts(final UUID... examIds);
 }

--- a/service/src/main/java/tds/exam/repositories/ExamQueryRepository.java
+++ b/service/src/main/java/tds/exam/repositories/ExamQueryRepository.java
@@ -46,10 +46,20 @@ public interface ExamQueryRepository {
      * Find all {@link tds.exam.Exam}s that belong to a {@link tds.session.Session} so they can be paused.
      *
      * @param sessionId The unique identifier of the session
-     * @param statusSet A {@code java.util.Set} of statuses that can transition to "paused"
+     * @param statuses A {@code java.util.Set} the statuses to filter by
      * @return A collection of exams that are assigned to the specified session
      */
-    List<Exam> findAllExamsInSessionWithStatus(final UUID sessionId, final Set<String> statusSet);
+    List<Exam> findAllExamsInSessionWithStatus(final UUID sessionId, final Set<String> statuses);
+
+    /**
+     * Find all {@link tds.exam.Exam}s that belong to a {@link tds.session.Session} that do not have the provided
+     * status codes
+     *
+     * @param sessionId The unique identifier of the session
+     * @param statuses A {@code java.util.Set} the statuses to filter by
+     * @return A collection of exams that are assigned to the specified session
+     */
+    List<Exam> findAllExamsInSessionWithoutStatus(final UUID sessionId, final Set<String> statuses);
 
     /**
      * Retrieves a listing of all ability records for the specified exam and student.

--- a/service/src/main/java/tds/exam/repositories/impl/ExamAccommodationQueryRepositoryImpl.java
+++ b/service/src/main/java/tds/exam/repositories/impl/ExamAccommodationQueryRepositoryImpl.java
@@ -90,13 +90,8 @@ public class ExamAccommodationQueryRepositoryImpl implements ExamAccommodationQu
     }
 
     private List<ExamAccommodation> getAccommodations(final boolean excludeDenied, final UUID... examIds) {
-        final SqlParameterSource parameters = (examIds.length > 1)
-            ? new MapSqlParameterSource("examIds", Arrays.stream(examIds).map(UUID::toString).collect(Collectors.toSet()))
-            : new MapSqlParameterSource("examId", examIds[0].toString());
-
-        final String WHERE_CLAUSE = examIds.length > 1
-            ? "ea.exam_id IN (:examIds) \n"
-            : "ea.exam_id = :examId \n";
+        final SqlParameterSource parameters = new MapSqlParameterSource("examIds",
+            Arrays.stream(examIds).map(UUID::toString).collect(Collectors.toSet()));
 
         String SQL =
             "SELECT \n" +
@@ -128,7 +123,7 @@ public class ExamAccommodationQueryRepositoryImpl implements ExamAccommodationQu
                 "JOIN exam_accommodation_event eae \n" +
                 "  ON last_event.id = eae.id \n" +
                 "WHERE \n" +
-                WHERE_CLAUSE +
+                "   ea.exam_id IN (:examIds) \n" +
                 "   AND eae.deleted_at IS NULL";
 
         if (excludeDenied) {

--- a/service/src/main/java/tds/exam/repositories/impl/ExamItemQueryRepositoryImpl.java
+++ b/service/src/main/java/tds/exam/repositories/impl/ExamItemQueryRepositoryImpl.java
@@ -2,12 +2,21 @@ package tds.exam.repositories.impl;
 
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.beans.factory.annotation.Qualifier;
+import org.springframework.dao.DataAccessException;
+import org.springframework.jdbc.core.ResultSetExtractor;
 import org.springframework.jdbc.core.namedparam.MapSqlParameterSource;
 import org.springframework.jdbc.core.namedparam.NamedParameterJdbcTemplate;
 import org.springframework.jdbc.core.namedparam.SqlParameterSource;
 import org.springframework.stereotype.Repository;
 
+import java.sql.ResultSet;
+import java.sql.SQLException;
+import java.util.Arrays;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.Map;
 import java.util.UUID;
+import java.util.stream.Collectors;
 
 import tds.exam.repositories.ExamItemQueryRepository;
 
@@ -45,5 +54,48 @@ public class ExamItemQueryRepositoryImpl implements ExamItemQueryRepository {
                 "   PE.deleted_at IS NULL;\n";
 
         return jdbcTemplate.queryForObject(SQL, params, Integer.class);
+    }
+
+    @Override
+    public Map<UUID, Integer> getResponseCounts(final UUID... examIds) {
+        // Needs to toString() each UUID individually
+        final SqlParameterSource params = new MapSqlParameterSource("examIds",
+            Arrays.stream(examIds).map(UUID::toString).collect(Collectors.toSet()));
+        final String SQL =
+            "SELECT \n" +
+                "   exam_id, \n" +
+                "   COUNT(id) as response_count \n" +
+                "FROM ( \n" +
+                "   SELECT\n" +
+                "       P.exam_id, \n" +
+                "       I.id\n" +
+                "   FROM \n" +
+                "       exam.exam_item I \n" +
+                "   JOIN \n" +
+                "       exam.exam_item_response IR \n" +
+                "   ON \n" +
+                "       I.id = IR.exam_item_id \n" +
+                "   JOIN \n" +
+                "       exam.exam_page P \n" +
+                "   ON \n" +
+                "       P.id = I.exam_page_id \n" +
+                "   JOIN \n" +
+                "       exam.exam_page_event PE \n" +
+                "   ON \n" +
+                "       PE.exam_page_id = P.id \n" +
+                "   WHERE \n" +
+                "       PE.deleted_at IS NULL \n" +
+                "       AND P.exam_id IN (:examIds) \n" +
+                "   GROUP BY P.exam_id, I.id \n" +
+                ") examIdCounts \n" +
+                "GROUP BY exam_id";
+
+        return jdbcTemplate.query(SQL, params, (ResultSetExtractor<Map<UUID, Integer>>) rs -> {
+            HashMap<UUID, Integer> examIdResponseCounts = new HashMap<>();
+            while(rs.next()){
+                examIdResponseCounts.put(UUID.fromString(rs.getString("exam_id")), rs.getInt("response_count"));
+            }
+            return examIdResponseCounts;
+        });
     }
 }

--- a/service/src/main/java/tds/exam/repositories/impl/ExamQueryRepositoryImpl.java
+++ b/service/src/main/java/tds/exam/repositories/impl/ExamQueryRepositoryImpl.java
@@ -255,7 +255,16 @@ public class ExamQueryRepositoryImpl implements ExamQueryRepository {
     }
 
     @Override
+    public List<Exam> findAllExamsInSessionWithoutStatus(final UUID sessionId, final Set<String> statuses) {
+        return findAllExamsWithStatus(sessionId, statuses, true);
+    }
+
+    @Override
     public List<Exam> findAllExamsInSessionWithStatus(final UUID sessionId, final Set<String> statuses) {
+        return findAllExamsWithStatus(sessionId, statuses, false);
+    }
+
+    private List<Exam> findAllExamsWithStatus(final UUID sessionId, final Set<String> statuses, final boolean inverse) {
         final SqlParameterSource parameters = new MapSqlParameterSource("sessionId", sessionId.toString())
             .addValue("statuses", statuses);
 
@@ -290,7 +299,7 @@ public class ExamQueryRepositoryImpl implements ExamQueryRepository {
                 "          AND eacc.type = 'Language'\n" +
                 "  ) \n" +
                 "WHERE ee.session_id = :sessionId \n" +
-                "   AND ee.status IN (:statuses) \n " +
+                "   AND ee.status " + (inverse ? "NOT " : "") + " IN (:statuses) \n " +
                 "   AND lang.type = 'Language'";
 
         return jdbcTemplate.query(SQL, parameters, examRowMapper);

--- a/service/src/main/java/tds/exam/services/ExamAccommodationService.java
+++ b/service/src/main/java/tds/exam/services/ExamAccommodationService.java
@@ -42,10 +42,10 @@ public interface ExamAccommodationService {
     /**
      * Finds the approved {@link tds.exam.ExamAccommodation}
      *
-     * @param examId the exam id
-     * @return list of approved {@link tds.exam.ExamAccommodation}
+     * @param examIds the exam ids
+     * @return list of approved {@link tds.exam.ExamAccommodation}s
      */
-    List<ExamAccommodation> findApprovedAccommodations(UUID examId);
+    List<ExamAccommodation> findApprovedAccommodations(UUID... examIds);
 
     /**
      * Initializes accommodations on a previous exam

--- a/service/src/main/java/tds/exam/services/ExamItemService.java
+++ b/service/src/main/java/tds/exam/services/ExamItemService.java
@@ -38,5 +38,5 @@ public interface ExamItemService {
      * @param examIds the ids of the exams to fetch response counts for
      * @return a mapping of examIds to the number of items that exam has responded to
      */
-    Map<UUID, Integer> getResponseCounts(UUID... examIds);
+    Map<UUID, Integer> getResponseCounts(final UUID... examIds);
 }

--- a/service/src/main/java/tds/exam/services/ExamItemService.java
+++ b/service/src/main/java/tds/exam/services/ExamItemService.java
@@ -1,5 +1,6 @@
 package tds.exam.services;
 
+import java.util.Map;
 import java.util.UUID;
 
 import tds.common.Response;
@@ -22,7 +23,6 @@ public interface ExamItemService {
      */
     Response<ExamPage> insertResponses(final ExamInfo request, final int mostRecentPagePosition, final ExamItemResponse... responses);
 
-
     /**
      * Fetches the highest exam position - the position of the {@link tds.exam.ExamItem} that
      * was last responded to by a student.
@@ -31,4 +31,12 @@ public interface ExamItemService {
      * @return the position of the last {@link tds.exam.ExamItem} responded to by a student
      */
     int getExamPosition(final UUID examId);
+
+    /**
+     * Fetches a map of examIds for their respective number of items responded to
+     *
+     * @param examIds the ids of the exams to fetch response counts for
+     * @return a mapping of examIds to the number of items that exam has responded to
+     */
+    Map<UUID, Integer> getResponseCounts(UUID... examIds);
 }

--- a/service/src/main/java/tds/exam/services/ExamService.java
+++ b/service/src/main/java/tds/exam/services/ExamService.java
@@ -2,6 +2,7 @@ package tds.exam.services;
 
 import java.util.List;
 import java.util.Optional;
+import java.util.Set;
 import java.util.UUID;
 
 import tds.assessment.Assessment;
@@ -87,5 +88,5 @@ public interface ExamService {
      * @param expandableParams a param representing the optional expandable data to include
      * @return a {@link tds.common.Response} containing the full list of {@link tds.exam.ExpandableExam}s in the session
      */
-    Response<List<ExpandableExam>> findExamsBySessionId(final UUID sessionId, final String... expandableParams);
+    Response<List<ExpandableExam>> findExamsBySessionId(final UUID sessionId, final Set<String> invalidStatuses, final String... expandableParams);
 }

--- a/service/src/main/java/tds/exam/services/ExamService.java
+++ b/service/src/main/java/tds/exam/services/ExamService.java
@@ -9,15 +9,15 @@ import tds.common.Response;
 import tds.common.ValidationError;
 import tds.exam.Exam;
 import tds.exam.ExamConfiguration;
-import tds.exam.ExamSegment;
 import tds.exam.ExamStatusCode;
+import tds.exam.ExpandableExam;
 import tds.exam.OpenExamRequest;
 
 /**
  * Main entry point for interacting with {@link Exam}
  */
 public interface ExamService {
-    
+
     /**
      * Retrieves an exam based on the UUID
      *
@@ -25,7 +25,7 @@ public interface ExamService {
      * @return {@link Exam} otherwise null
      */
     Optional<Exam> findExam(final UUID uuid);
-    
+
     /**
      * Opens a new exam
      *
@@ -33,7 +33,7 @@ public interface ExamService {
      * @return {@link tds.common.Response<tds.exam.Exam>} containing exam or errors
      */
     Response<Exam> openExam(final OpenExamRequest openExamRequest);
-    
+
     /**
      * Starts a new or existing exam.
      *
@@ -41,7 +41,7 @@ public interface ExamService {
      * @return {@link tds.common.Response<tds.exam.Exam>} containing the exam's configuration or errors.
      */
     Response<ExamConfiguration> startExam(final UUID examId);
-    
+
     /**
      * Retrieves the initial ability value for an {@link Exam}.
      *
@@ -50,7 +50,7 @@ public interface ExamService {
      * @return the initial ability for an {@link Exam}.
      */
     Optional<Double> getInitialAbility(final Exam exam, final Assessment assessment);
-    
+
     /**
      * Change the {@link tds.exam.Exam}'s status to a new status.
      *
@@ -61,7 +61,7 @@ public interface ExamService {
      * to the new status; otherwise {@code Optional.empty()}.\
      */
     Optional<ValidationError> updateExamStatus(final UUID examId, final ExamStatusCode newStatus, final String statusChangeReason);
-    
+
     /**
      * Change the {@link tds.exam.Exam}'s status to a new status.
      *
@@ -71,11 +71,21 @@ public interface ExamService {
      * to the new status; otherwise {@code Optional.empty()}.\
      */
     Optional<ValidationError> updateExamStatus(final UUID examId, final ExamStatusCode newStatus);
-    
+
     /**
      * Update the status of all {@link tds.exam.Exam}s in the specified {@link tds.session.Session} to "paused"
      *
      * @param sessionId The unique identifier of the session that has been closed
      */
     void pauseAllExamsInSession(final UUID sessionId);
+
+    /**
+     * Returns a list of all {@link tds.exam.ExpandableExam}s within a session. The expandable exam contains
+     * additional optional exam data.
+     *
+     * @param sessionId        the id of the session the {@link tds.exam.Exam}s belong to
+     * @param expandableParams a param representing the optional expandable data to include
+     * @return the full list of {@link tds.exam.ExpandableExam}s in the session
+     */
+    List<ExpandableExam> findExamsBySessionId(final UUID sessionId, final String... expandableParams);
 }

--- a/service/src/main/java/tds/exam/services/ExamService.java
+++ b/service/src/main/java/tds/exam/services/ExamService.java
@@ -85,7 +85,7 @@ public interface ExamService {
      *
      * @param sessionId        the id of the session the {@link tds.exam.Exam}s belong to
      * @param expandableParams a param representing the optional expandable data to include
-     * @return the full list of {@link tds.exam.ExpandableExam}s in the session
+     * @return a {@link tds.common.Response} containing the full list of {@link tds.exam.ExpandableExam}s in the session
      */
-    List<ExpandableExam> findExamsBySessionId(final UUID sessionId, final String... expandableParams);
+    Response<List<ExpandableExam>> findExamsBySessionId(final UUID sessionId, final String... expandableParams);
 }

--- a/service/src/main/java/tds/exam/services/impl/ExamAccommodationServiceImpl.java
+++ b/service/src/main/java/tds/exam/services/impl/ExamAccommodationServiceImpl.java
@@ -113,8 +113,8 @@ class ExamAccommodationServiceImpl implements ExamAccommodationService {
     }
 
     @Override
-    public List<ExamAccommodation> findApprovedAccommodations(final UUID examId) {
-        return examAccommodationQueryRepository.findApprovedAccommodations(examId);
+    public List<ExamAccommodation> findApprovedAccommodations(final UUID... examIds) {
+        return examAccommodationQueryRepository.findApprovedAccommodations(examIds);
     }
 
     @Transactional

--- a/service/src/main/java/tds/exam/services/impl/ExamItemServiceImpl.java
+++ b/service/src/main/java/tds/exam/services/impl/ExamItemServiceImpl.java
@@ -4,6 +4,7 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
+import java.util.Map;
 import java.util.Optional;
 import java.util.UUID;
 import java.util.stream.Stream;
@@ -102,5 +103,10 @@ public class ExamItemServiceImpl implements ExamItemService {
     @Override
     public int getExamPosition(final UUID examId) {
         return examItemQueryRepository.getCurrentExamItemPosition(examId);
+    }
+
+    @Override
+    public Map<UUID, Integer> getResponseCounts(UUID... examIds) {
+        return examItemQueryRepository.getResponseCounts(examIds);
     }
 }

--- a/service/src/main/java/tds/exam/services/impl/ExamItemServiceImpl.java
+++ b/service/src/main/java/tds/exam/services/impl/ExamItemServiceImpl.java
@@ -106,7 +106,7 @@ public class ExamItemServiceImpl implements ExamItemService {
     }
 
     @Override
-    public Map<UUID, Integer> getResponseCounts(UUID... examIds) {
+    public Map<UUID, Integer> getResponseCounts(final UUID... examIds) {
         return examItemQueryRepository.getResponseCounts(examIds);
     }
 }

--- a/service/src/main/java/tds/exam/services/impl/ExamServiceImpl.java
+++ b/service/src/main/java/tds/exam/services/impl/ExamServiceImpl.java
@@ -306,7 +306,7 @@ class ExamServiceImpl implements ExamService {
     }
 
     @Override
-    public List<ExpandableExam> findExamsBySessionId(final UUID sessionId, final String... expandableParams) {
+    public Response<List<ExpandableExam>> findExamsBySessionId(final UUID sessionId, final String... expandableParams) {
         final Set<String> params = Sets.newHashSet(expandableParams);
         final Set<String> validExamStatuses = Sets.newHashSet(
             ExamStatusCode.STATUS_PENDING,
@@ -338,7 +338,7 @@ class ExamServiceImpl implements ExamService {
             .map(builders -> builders.build())
             .collect(Collectors.toList());
 
-        return expandableExams;
+        return new Response<>(expandableExams);
     }
 
     @Transactional

--- a/service/src/test/java/tds/exam/repositories/impl/ExamAccommodationQueryRepositoryIntegrationTests.java
+++ b/service/src/test/java/tds/exam/repositories/impl/ExamAccommodationQueryRepositoryIntegrationTests.java
@@ -12,6 +12,7 @@ import org.springframework.test.context.junit4.SpringJUnit4ClassRunner;
 import org.springframework.transaction.annotation.Transactional;
 
 import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.Collections;
 import java.util.List;
 import java.util.UUID;
@@ -172,6 +173,21 @@ public class ExamAccommodationQueryRepositoryIntegrationTests {
         assertThat(secondExamAccommodation.getCreatedAt()).isLessThan(Instant.now());
         assertThat(secondExamAccommodation.getDeniedAt()).isNull();
         assertThat(secondExamAccommodation.isApproved()).isTrue();
+    }
+
+    @Test
+    public void shouldReturnExamAccommodationsForTwoExams() {
+        final UUID examId1 = UUID.randomUUID();
+        final UUID examId2 = UUID.randomUUID();
+
+        ExamAccommodation accommodation1 = new ExamAccommodationBuilder().withExamId(examId1).build();
+        ExamAccommodation accommodation2 = new ExamAccommodationBuilder().withExamId(examId2).build();
+        ExamAccommodation accommodation3 = new ExamAccommodationBuilder().withExamId(examId2).build();
+
+        examAccommodationCommandRepository.insert(Arrays.asList(accommodation1, accommodation2, accommodation3));
+
+        assertThat(examAccommodationQueryRepository.findApprovedAccommodations(examId1)).hasSize(1);
+        assertThat(examAccommodationQueryRepository.findApprovedAccommodations(examId1, examId2)).hasSize(3);
     }
 
     @Test

--- a/service/src/test/java/tds/exam/repositories/impl/ExamAccommodationQueryRepositoryIntegrationTests.java
+++ b/service/src/test/java/tds/exam/repositories/impl/ExamAccommodationQueryRepositoryIntegrationTests.java
@@ -186,7 +186,12 @@ public class ExamAccommodationQueryRepositoryIntegrationTests {
 
         examAccommodationCommandRepository.insert(Arrays.asList(accommodation1, accommodation2, accommodation3));
 
-        assertThat(examAccommodationQueryRepository.findApprovedAccommodations(examId1)).hasSize(1);
+        List<ExamAccommodation> approvedAccommodationsExam1 = examAccommodationQueryRepository.findApprovedAccommodations(examId1);
+        assertThat(approvedAccommodationsExam1).containsExactly(accommodation1);
+
+        List<ExamAccommodation> approvedAccommodationsExam1And2 = examAccommodationQueryRepository.findApprovedAccommodations(examId1, examId2);
+        assertThat(approvedAccommodationsExam1And2).containsExactlyInAnyOrder(accommodation1, accommodation2, accommodation3);
+
         assertThat(examAccommodationQueryRepository.findApprovedAccommodations(examId1, examId2)).hasSize(3);
     }
 

--- a/service/src/test/java/tds/exam/repositories/impl/ExamItemRepositoryIntegrationTests.java
+++ b/service/src/test/java/tds/exam/repositories/impl/ExamItemRepositoryIntegrationTests.java
@@ -1,0 +1,226 @@
+package tds.exam.repositories.impl;
+
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.beans.factory.annotation.Qualifier;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.jdbc.core.namedparam.NamedParameterJdbcTemplate;
+import org.springframework.test.context.junit4.SpringJUnit4ClassRunner;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.Arrays;
+import java.util.Map;
+import java.util.UUID;
+
+import tds.exam.Exam;
+import tds.exam.ExamItem;
+import tds.exam.ExamItemResponse;
+import tds.exam.ExamPage;
+import tds.exam.ExamSegment;
+import tds.exam.builder.ExamBuilder;
+import tds.exam.builder.ExamItemBuilder;
+import tds.exam.builder.ExamItemResponseBuilder;
+import tds.exam.builder.ExamSegmentBuilder;
+import tds.exam.repositories.ExamCommandRepository;
+import tds.exam.repositories.ExamItemCommandRepository;
+import tds.exam.repositories.ExamItemQueryRepository;
+import tds.exam.repositories.ExamPageCommandRepository;
+import tds.exam.repositories.ExamPageQueryRepository;
+import tds.exam.repositories.ExamSegmentCommandRepository;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+@RunWith(SpringJUnit4ClassRunner.class)
+@SpringBootTest
+@Transactional
+public class ExamItemRepositoryIntegrationTests {
+    @Autowired
+    @Qualifier("commandJdbcTemplate")
+    private NamedParameterJdbcTemplate commandJdbcTemplate;
+    private ExamItemCommandRepository examItemCommandRepository;
+    private ExamPageCommandRepository examPageCommandRepository;
+    private ExamPageQueryRepository examPageQueryRepository;
+    private ExamCommandRepository examCommandRepository;
+    private ExamItemQueryRepository examItemQueryRepository;
+    private ExamSegmentCommandRepository examSegmentCommandRepository;
+
+    @Before
+    public void setUp() {
+        examItemCommandRepository = new ExamItemCommandRepositoryImpl(commandJdbcTemplate);
+        examPageCommandRepository = new ExamPageCommandRepositoryImpl(commandJdbcTemplate);
+        examPageQueryRepository = new ExamPageQueryRepositoryImpl(commandJdbcTemplate);
+        examCommandRepository = new ExamCommandRepositoryImpl(commandJdbcTemplate);
+        examItemQueryRepository = new ExamItemQueryRepositoryImpl(commandJdbcTemplate);
+        examSegmentCommandRepository = new ExamSegmentCommandRepositoryImpl(commandJdbcTemplate);
+    }
+
+    @Test
+    public void shouldExcludeItemsInDeletedPages() {
+        Exam exam = new ExamBuilder().build();
+        examCommandRepository.insert(exam);
+        ExamSegment mockExamSegment = new ExamSegmentBuilder()
+            .withExamId(exam.getId())
+            .build();
+        examSegmentCommandRepository.insert(Arrays.asList(mockExamSegment));
+
+        // This page will be deleted
+        ExamPage page1 = new ExamPage.Builder()
+            .withId(UUID.randomUUID())
+            .withExamId(exam.getId())
+            .withSegmentId(mockExamSegment.getSegmentId())
+            .withSegmentKey(mockExamSegment.getSegmentKey())
+            .withPagePosition(1)
+            .withItemGroupKey("key1")
+            .build();
+
+        examPageCommandRepository.insert(page1);
+
+        ExamItem examItem = new ExamItemBuilder()
+            .withId(UUID.randomUUID())
+            .withExamPageId(page1.getId())
+            .withPosition(1)
+            .build();
+
+        ExamItemResponse examItemResponse = new ExamItemResponseBuilder()
+            .withExamItemId(examItem.getId())
+            .withSequence(2)
+            .build();
+
+        examItemCommandRepository.insert(examItem);
+        examItemCommandRepository.insertResponses(examItemResponse);
+        // Now the above is marked as deleted.
+        examPageCommandRepository.deleteAll(exam.getId());
+
+        ExamPage page2 = new ExamPage.Builder()
+            .withId(UUID.randomUUID())
+            .withExamId(exam.getId())
+            .withSegmentId(mockExamSegment.getSegmentId())
+            .withSegmentKey(mockExamSegment.getSegmentKey())
+            .withPagePosition(1)
+            .withItemGroupKey("key1")
+            .build();
+
+        examPageCommandRepository.insert(page2);
+
+        ExamItem examItem2 = new ExamItemBuilder()
+            .withId(UUID.randomUUID())
+            .withExamPageId(page1.getId())
+            .withPosition(1)
+            .build();
+
+        ExamItemResponse examItemResponse2 = new ExamItemResponseBuilder()
+            .withExamItemId(examItem.getId())
+            .withSequence(2)
+            .build();
+
+        examItemCommandRepository.insert(examItem2);
+        examItemCommandRepository.insertResponses(examItemResponse2);
+        Map<UUID, Integer> examIdsToResponseCounts = examItemQueryRepository.getResponseCounts(exam.getId());
+        assertThat(examIdsToResponseCounts).hasSize(1);
+        assertThat(examIdsToResponseCounts.get(exam.getId())).isEqualTo(1);
+    }
+
+    @Test
+    public void shouldFindTwoExamsThatHaveItemsRespondedTo() {
+        Exam exam1 = new ExamBuilder().build();
+        Exam exam2 = new ExamBuilder().build();
+        examCommandRepository.insert(exam1);
+        examCommandRepository.insert(exam2);
+
+        ExamSegment mockExamSegment1 = new ExamSegmentBuilder()
+            .withExamId(exam1.getId())
+            .build();
+        ExamSegment mockExamSegment2 = new ExamSegmentBuilder()
+            .withExamId(exam2.getId())
+            .build();
+
+        examSegmentCommandRepository.insert(Arrays.asList(mockExamSegment1, mockExamSegment2));
+
+        // Page for 1st exam
+        ExamPage examPage1 = new ExamPage.Builder()
+            .withId(UUID.randomUUID())
+            .withExamId(exam1.getId())
+            .withSegmentId(mockExamSegment1.getSegmentId())
+            .withSegmentKey(mockExamSegment1.getSegmentKey())
+            .withPagePosition(1)
+            .withItemGroupKey("key1")
+            .build();
+
+        // Page for 2nd exam
+        ExamPage examPage2 = new ExamPage.Builder()
+            .withId(UUID.randomUUID())
+            .withExamId(exam2.getId())
+            .withSegmentId(mockExamSegment2.getSegmentId())
+            .withSegmentKey(mockExamSegment2.getSegmentKey())
+            .withPagePosition(1)
+            .withItemGroupKey("key1")
+            .build();
+
+        assertThat(examPageQueryRepository.findAll(exam1.getId())).isEmpty();
+        assertThat(examPageQueryRepository.findAll(exam2.getId())).isEmpty();
+        examPageCommandRepository.insert(examPage1, examPage2);
+
+        // will have single response
+        ExamItem exam1Item1 = new ExamItemBuilder()
+            .withId(UUID.randomUUID())
+            .withExamPageId(examPage1.getId())
+            .withPosition(1)
+            .build();
+
+        // will have two responses
+        ExamItem exam1Item2 = new ExamItemBuilder()
+            .withId(UUID.randomUUID())
+            .withExamPageId(examPage1.getId())
+            .withPosition(2)
+            .build();
+
+        // will have two responses
+        ExamItem exam2Item1 = new ExamItemBuilder()
+            .withId(UUID.randomUUID())
+            .withExamPageId(examPage2.getId())
+            .withPosition(1)
+            .build();
+
+        // will have no responses
+        ExamItem exam2Item2 = new ExamItemBuilder()
+            .withId(UUID.randomUUID())
+            .withExamPageId(examPage2.getId())
+            .withPosition(2)
+            .build();
+
+        examItemCommandRepository.insert(exam1Item1, exam1Item2, exam2Item1, exam2Item2);
+
+        // Exam 1
+        ExamItemResponse exam1Item1Response = new ExamItemResponseBuilder()
+            .withExamItemId(exam1Item1.getId())
+            .withSequence(2)
+            .build();
+        ExamItemResponse exam1Item2Response1 = new ExamItemResponseBuilder()
+            .withExamItemId(exam1Item2.getId())
+            .withSequence(1)
+            .build();
+        ExamItemResponse exam1Item2Response2 = new ExamItemResponseBuilder()
+            .withExamItemId(exam1Item2.getId())
+            .withSequence(3)
+            .build();
+        // Exam 2
+        ExamItemResponse exam2Item1Response1 = new ExamItemResponseBuilder()
+            .withExamItemId(exam2Item1.getId())
+            .withSequence(1)
+            .build();
+        ExamItemResponse exam2Item1Response2 = new ExamItemResponseBuilder()
+            .withExamItemId(exam2Item1.getId())
+            .withSequence(2)
+            .build();
+
+        examItemCommandRepository.insertResponses(exam1Item1Response, exam1Item2Response1, exam1Item2Response2,
+            exam2Item1Response1, exam2Item1Response2);
+
+        Map<UUID, Integer> examIdsToResponseCounts = examItemQueryRepository.getResponseCounts(exam1.getId(), exam2.getId());
+        assertThat(examIdsToResponseCounts).hasSize(2);
+        assertThat(examIdsToResponseCounts.get(exam1.getId())).isEqualTo(2);
+        assertThat(examIdsToResponseCounts.get(exam2.getId())).isEqualTo(1);
+    }
+}

--- a/service/src/test/java/tds/exam/services/impl/ExamItemServiceImplTest.java
+++ b/service/src/test/java/tds/exam/services/impl/ExamItemServiceImplTest.java
@@ -1,5 +1,6 @@
 package tds.exam.services.impl;
 
+import com.google.common.collect.ImmutableMap;
 import org.joda.time.Instant;
 import org.junit.Before;
 import org.junit.Test;
@@ -7,6 +8,7 @@ import org.junit.runner.RunWith;
 import org.mockito.Mock;
 import org.mockito.runners.MockitoJUnitRunner;
 
+import java.util.Map;
 import java.util.Optional;
 import java.util.UUID;
 
@@ -146,7 +148,7 @@ public class ExamItemServiceImplTest {
             .withStatus(new ExamStatusCode(ExamStatusCode.STATUS_STARTED, ExamStatusStage.IN_PROGRESS), Instant.now())
             .build();
         ValidationError mockApprovalFailure = new ValidationError(ValidationErrorCode.EXAM_APPROVAL_SESSION_CLOSED,
-                "The session is not available for testing, please check with your test administrator.");
+            "The session is not available for testing, please check with your test administrator.");
 
         when(mockExamQueryRepository.getExamById(examInfo.getExamId()))
             .thenReturn(Optional.of(mockExam));
@@ -215,6 +217,20 @@ public class ExamItemServiceImplTest {
         examItemService.insertResponses(examInfo, currentPagePosition, response);
         verify(mockExamApprovalService).getApproval(any(ExamInfo.class));
         verify(mockExamQueryRepository).getExamById(examInfo.getExamId());
+    }
+
+    @Test
+    public void shouldReturnResponseCountMap() {
+        UUID examId1 = UUID.randomUUID();
+        UUID examId2 = UUID.randomUUID();
+        Map<UUID, Integer> mockMap = ImmutableMap.of(
+            UUID.randomUUID(), 1,
+            UUID.randomUUID(), 2
+        );
+        when(mockExamItemQueryRepository.getResponseCounts(examId1, examId2)).thenReturn(mockMap);
+        Map<UUID, Integer> returnMap = examItemService.getResponseCounts(examId1, examId2);
+        assertThat(returnMap).hasSize(2);
+        verify(mockExamItemQueryRepository).getResponseCounts(examId1, examId2);
     }
 
     @Test(expected = NotFoundException.class)

--- a/service/src/test/java/tds/exam/services/impl/ExamServiceImplTest.java
+++ b/service/src/test/java/tds/exam/services/impl/ExamServiceImplTest.java
@@ -1,5 +1,6 @@
 package tds.exam.services.impl;
 
+import com.google.common.collect.ImmutableMap;
 import org.assertj.core.util.Lists;
 import org.joda.time.Days;
 import org.joda.time.Instant;
@@ -39,6 +40,7 @@ import tds.exam.ExamInfo;
 import tds.exam.ExamStatusCode;
 import tds.exam.ExamStatusStage;
 import tds.exam.ExamineeContext;
+import tds.exam.ExpandableExam;
 import tds.exam.OpenExamRequest;
 import tds.exam.builder.AssessmentBuilder;
 import tds.exam.builder.ExamAccommodationBuilder;
@@ -72,7 +74,9 @@ import tds.student.Student;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.Matchers.any;
+import static org.mockito.Matchers.eq;
 import static org.mockito.Matchers.isA;
+import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.verifyZeroInteractions;
@@ -297,7 +301,7 @@ public class ExamServiceImplTest {
         when(mockSessionService.findExternalSessionConfigurationByClientName("SBAC_PT")).thenReturn(Optional.of(extSessionConfig));
         when(mockConfigService.findClientSystemFlag("SBAC_PT", ALLOW_ANONYMOUS_STUDENT_FLAG_TYPE)).thenReturn(Optional.of(clientSystemFlag));
         when(mockSessionService.findSessionById(openExamRequest.getSessionId())).thenReturn(Optional.of(currentSession));
-                when(mockAssessmentService.findAssessment("SBAC_PT", openExamRequest.getAssessmentKey())).thenReturn(Optional.of(assessment));
+        when(mockAssessmentService.findAssessment("SBAC_PT", openExamRequest.getAssessmentKey())).thenReturn(Optional.of(assessment));
         when(mockExamQueryRepository.getLastAvailableExam(openExamRequest.getStudentId(), assessment.getAssessmentId(), "SBAC_PT")).thenReturn(Optional.empty());
         when(mockSessionService.findExternalSessionConfigurationByClientName("SBAC_PT")).thenReturn(Optional.of(extSessionConfig));
         when(mockAssessmentService.findAssessmentWindows("SBAC_PT", assessment.getAssessmentId(), openExamRequest.getStudentId(), extSessionConfig))
@@ -329,7 +333,7 @@ public class ExamServiceImplTest {
         assertThat(exam.getSubject()).isEqualTo(assessment.getSubject());
     }
 
-    @Test (expected = IllegalStateException.class)
+    @Test(expected = IllegalStateException.class)
     public void shouldThrowIfTimeConfigurationCannotBeFound() {
         OpenExamRequest openExamRequest = new OpenExamRequestBuilder()
             .withStudentId(-1)
@@ -1331,6 +1335,90 @@ public class ExamServiceImplTest {
         examService.pauseAllExamsInSession(mockSessionId);
 
         verify(mockExamCommandRepository, times(0)).update(Matchers.<Exam>anyVararg());
+    }
+
+    @Test
+    public void shouldReturnExpandableExamsWithExamAccommodationsOnlyForSessionId() {
+        UUID sessionId = UUID.randomUUID();
+        Exam exam1 = new ExamBuilder().build();
+        Exam exam2 = new ExamBuilder().build();
+
+        ExamAccommodation exam1accommodation1 = new ExamAccommodationBuilder().withExamId(exam1.getId()).build();
+        ExamAccommodation exam1accommodation2 = new ExamAccommodationBuilder().withExamId(exam1.getId()).build();
+        ExamAccommodation exam2accommodation = new ExamAccommodationBuilder().withExamId(exam2.getId()).build();
+
+
+        when(mockExamQueryRepository.findAllExamsInSessionWithStatus(eq(sessionId), any())).thenReturn(Arrays.asList(exam1, exam2));
+        when(mockExamAccommodationService.findApprovedAccommodations(any(), any()))
+            .thenReturn(Arrays.asList(exam1accommodation1, exam1accommodation2, exam2accommodation));
+        List<ExpandableExam> expandableExams = examService.findExamsBySessionId(sessionId, ExpandableExam.EXPANDABLE_PARAMS_EXAM_ACCOMMODATIONS);
+        verify(mockExamQueryRepository).findAllExamsInSessionWithStatus(eq(sessionId), any());
+        verify(mockExamAccommodationService).findApprovedAccommodations(any(), any());
+        // Should not call this
+        verify(mockExamItemService, never()).getResponseCounts(any());
+
+        assertThat(expandableExams).hasSize(2);
+
+        ExpandableExam expExam1 = null;
+        ExpandableExam expExam2 = null;
+
+        for (ExpandableExam expandableExam : expandableExams) {
+            if (expandableExam.getExam().getId().equals(exam1.getId())) {
+                expExam1 = expandableExam;
+            } else if (expandableExam.getExam().getId().equals(exam2.getId())) {
+                expExam2 = expandableExam;
+            }
+        }
+
+        assertThat(expExam1.getExam()).isEqualTo(exam1);
+        assertThat(expExam1.getExamAccommodations()).hasSize(2);
+        assertThat(expExam2.getExam()).isEqualTo(exam2);
+        assertThat(expExam2.getExamAccommodations()).hasSize(1);
+    }
+
+    @Test
+    public void shouldReturnExpandableExamsWithExamAccommodationsAndResponseCountsSessionId() {
+        UUID sessionId = UUID.randomUUID();
+        Exam exam1 = new ExamBuilder().build();
+        Exam exam2 = new ExamBuilder().build();
+
+        ExamAccommodation exam1accommodation1 = new ExamAccommodationBuilder().withExamId(exam1.getId()).build();
+        ExamAccommodation exam1accommodation2 = new ExamAccommodationBuilder().withExamId(exam1.getId()).build();
+        ExamAccommodation exam2accommodation = new ExamAccommodationBuilder().withExamId(exam2.getId()).build();
+
+        when(mockExamQueryRepository.findAllExamsInSessionWithStatus(eq(sessionId), any())).thenReturn(Arrays.asList(exam1, exam2));
+        when(mockExamAccommodationService.findApprovedAccommodations(any(), any()))
+            .thenReturn(Arrays.asList(exam1accommodation1, exam1accommodation2, exam2accommodation));
+        when(mockExamItemService.getResponseCounts(any(), any())).thenReturn(ImmutableMap.of(
+            exam1.getId(), 4,
+            exam2.getId(), 1
+        ));
+        List<ExpandableExam> expandableExams = examService.findExamsBySessionId(sessionId,
+            ExpandableExam.EXPANDABLE_PARAMS_EXAM_ACCOMMODATIONS, ExpandableExam.EXPANDABLE_PARAMS_ITEM_RESPONSE_COUNT);
+        verify(mockExamQueryRepository).findAllExamsInSessionWithStatus(eq(sessionId), any());
+        verify(mockExamAccommodationService).findApprovedAccommodations(any(), any());
+        // Should not call this
+        verify(mockExamItemService).getResponseCounts(any(), any());
+
+        assertThat(expandableExams).hasSize(2);
+
+        ExpandableExam expExam1 = null;
+        ExpandableExam expExam2 = null;
+
+        for (ExpandableExam expandableExam : expandableExams) {
+            if (expandableExam.getExam().getId().equals(exam1.getId())) {
+                expExam1 = expandableExam;
+            } else if (expandableExam.getExam().getId().equals(exam2.getId())) {
+                expExam2 = expandableExam;
+            }
+        }
+
+        assertThat(expExam1.getExam()).isEqualTo(exam1);
+        assertThat(expExam1.getExamAccommodations()).hasSize(2);
+        assertThat(expExam1.getItemsResponseCount()).isEqualTo(4);
+        assertThat(expExam2.getExam()).isEqualTo(exam2);
+        assertThat(expExam2.getExamAccommodations()).hasSize(1);
+        assertThat(expExam2.getItemsResponseCount()).isEqualTo(1);
     }
 
     private Exam createExam(UUID sessionId, UUID thisExamId, String assessmentId, String clientName, long studentId) {

--- a/service/src/test/java/tds/exam/services/impl/ExamServiceImplTest.java
+++ b/service/src/test/java/tds/exam/services/impl/ExamServiceImplTest.java
@@ -1351,7 +1351,11 @@ public class ExamServiceImplTest {
         when(mockExamQueryRepository.findAllExamsInSessionWithStatus(eq(sessionId), any())).thenReturn(Arrays.asList(exam1, exam2));
         when(mockExamAccommodationService.findApprovedAccommodations(any(), any()))
             .thenReturn(Arrays.asList(exam1accommodation1, exam1accommodation2, exam2accommodation));
-        List<ExpandableExam> expandableExams = examService.findExamsBySessionId(sessionId, ExpandableExam.EXPANDABLE_PARAMS_EXAM_ACCOMMODATIONS);
+        Response<List<ExpandableExam>> response = examService.findExamsBySessionId(sessionId, ExpandableExam.EXPANDABLE_PARAMS_EXAM_ACCOMMODATIONS);
+        assertThat(response.getData().isPresent()).isTrue();
+        assertThat(response.getError().isPresent()).isFalse();
+        List<ExpandableExam> expandableExams = response.getData().get();
+
         verify(mockExamQueryRepository).findAllExamsInSessionWithStatus(eq(sessionId), any());
         verify(mockExamAccommodationService).findApprovedAccommodations(any(), any());
         // Should not call this
@@ -1393,8 +1397,12 @@ public class ExamServiceImplTest {
             exam1.getId(), 4,
             exam2.getId(), 1
         ));
-        List<ExpandableExam> expandableExams = examService.findExamsBySessionId(sessionId,
+        Response<List<ExpandableExam>> response = examService.findExamsBySessionId(sessionId,
             ExpandableExam.EXPANDABLE_PARAMS_EXAM_ACCOMMODATIONS, ExpandableExam.EXPANDABLE_PARAMS_ITEM_RESPONSE_COUNT);
+        assertThat(response.getData().isPresent()).isTrue();
+        assertThat(response.getError().isPresent()).isFalse();
+        List<ExpandableExam> expandableExams = response.getData().get();
+
         verify(mockExamQueryRepository).findAllExamsInSessionWithStatus(eq(sessionId), any());
         verify(mockExamAccommodationService).findApprovedAccommodations(any(), any());
         // Should not call this


### PR DESCRIPTION
[TDS-709]  - This PR covers code for the ExpandableExam, as well as a service method populating some additional pieces of data needed by the proctor application, such as the exam accommodations and the number of items a student has answered (responded to). 

Included in this PR are changes to some ExamAccommodationService/Repository methods that previously took in a single UUID (exam id) as an argument. These have been expanded to take in a variable number of exam id arguments in order to reduce the number of jdbc/database calls. 

TDS-646, which depends on this PR, covers the query found in TDS_Proctor - TestSessionDaoImpl.getCurrentSessionTestees() [line 88]. ExamService.findExamsBySessionId() is essentially a port of this query, with some unused fields removed. That query, formatter and with some of my personal comments is found below:

```
select 
  tOpp._efk_AdminSubject,                         --exam.assessmentKey
  tOpp._fk_TestOpportunity as opportunityKey,     --exam.id
  tOpp._efk_Testee,                               --exam.studentId
  tOpp._efk_TestID,                               --exam.assessmentId
  tOpp.Opportunity,                               --exam.attempts
  tOpp.TesteeName,                                --exam.studentName
  TesteeID,                                       --exam.loginSsid  
  tOpp.Status,                                    --exam.status
  tOpp.DateCompleted,                             --exam.completedAt
  tOpp._fk_Session,                               --exam.sessionId    (uuid)
  tOpp.SessID as SessionID,                       --exam.sessionKey  (ADM-99)
  '' as sessionName,  
  maxitems as ItemCount,                          --exam.maxItems
  case when tOpp.status = 'paused' and datePaused is not null 
    then timestampdiff(MINUTE, datePaused, now(3)) 
  else 
    cast(null as CHAR) end as pauseMinutes,       -- null if not paused, otherwise the number of mins the exam has been paused for
  numResponses as ResponseCount,                   
  (
    select 
      count(*) 
    from 
      testopprequest REQ 
    where 
      REQ._fk_TestOpportunity = tOpp._fk_TestOpportunity 
      and REQ._fk_Session = ${sessionKey}
      and DateFulfilled is null 
      and DateSubmitted > ${midnightAM} 
      and DateSubmitted < ${midnightPM}
  ) as RequestCountN,                             -- the number of unfulfilled requests for this exam/session          
  (
    select 
      value as score 
    from 
      testopportunityscores S
    join configs.client_testscorefeatures F
      on S.MeasureOf = F.MeasureOf 
      and S.MeasureLabel = F.MeasureLabel 
    where 
      F.ClientName = ${clientname} 
      and ReportToProctor = 1 
      and S._fk_TestOpportunity = tOpp._fk_TestOpportunity 
      and S.IsOfficial = 1 
    limit 1
  ) as Score,                                 -- not needed
  AccommodationString as Accommodations,      -- ExamService will return entire list of exam accommodations
  tOpp.customAccommodations,                  -- exam.customAccommodations
  tOpp.mode,                                  -- Not needed, always "online"
  ctp.msb                                     -- TODO: Need to fetch MSB flag from assessment
from testopportunity_readonly tOpp 
left outer join                       -- Join not necessary - only used to validate testid and clientname (part of exam) and to get msb flag. 
  configs.client_testproperties ctp 
  on tOpp._efk_testid = ctp.testid 
  and tOpp.clientname = ctp.clientname 
where 
  _fk_Session = ${sessionKey} 
  and tOpp.DateChanged > ${midnightAM}
  and tOpp.DateChanged < ${midnightPM} 
  and tOpp.status not in ('pending', 'suspended', 'denied');
```


