### PR TITLE
Replace TDS_Common SNAPSHOT dependency with released version dependency.

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -26,8 +26,8 @@
         <unit-tests.skip>false</unit-tests.skip>
         <integration-tests.skip>true</integration-tests.skip>
 
-        <tds-common.version>0.0.1-SNAPSHOT</tds-common.version>
-        <tds-common-legacy.version>0.0.1-SNAPSHOT</tds-common-legacy.version>
+        <tds-common.version>0.0.1</tds-common.version>
+        <tds-common-legacy.version>0.0.1</tds-common-legacy.version>
         <tds-exam-client.version>0.0.1-SNAPSHOT</tds-exam-client.version>
         <tds-session.version>0.0.1-SNAPSHOT</tds-session.version>
         <tds-assessment-client.version>0.0.1-SNAPSHOT</tds-assessment-client.version>


### PR DESCRIPTION
Now that TDS_Common version 0.0.1 has been released, we need to update our service dependencies to use the released version rather than the SNAPSHOT version.  (By default, we cannot release a project that has SNAPSHOT dependencies.)

Once approved, I'll do the same for our other services directly on 'develop' without additional PRs.

NOTE: Once merged into 'develop' developers will need to download and install the maven settings.xml file in their ~/.m2/ directory per https://confluence.fairwaytech.com/display/SBAC1719/Maven+Configuration in order to pull artifacts from Bintray.