### PR TITLE
Feature/exams for session endpoint

### DIFF
--- a/service/pom.xml
+++ b/service/pom.xml
@@ -172,6 +172,12 @@
             <scope>test</scope>
         </dependency>
         <dependency>
+            <groupId>io.github.benas</groupId>
+            <artifactId>random-beans</artifactId>
+            <version>3.5.0</version>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
             <groupId>com.google.guava</groupId>
             <artifactId>guava</artifactId>
             <version>19.0</version>

--- a/service/src/main/java/tds/exam/services/ExamService.java
+++ b/service/src/main/java/tds/exam/services/ExamService.java
@@ -86,7 +86,7 @@ public interface ExamService {
      *
      * @param sessionId        the id of the session the {@link tds.exam.Exam}s belong to
      * @param expandableParams a param representing the optional expandable data to include
-     * @return a {@link tds.common.Response} containing the full list of {@link tds.exam.ExpandableExam}s in the session
+     * @return a list of {@link tds.exam.ExpandableExam}s in the session
      */
-    Response<List<ExpandableExam>> findExamsBySessionId(final UUID sessionId, final Set<String> invalidStatuses, final String... expandableParams);
+    List<ExpandableExam> findExamsBySessionId(final UUID sessionId, final Set<String> invalidStatuses, final String... expandableParams);
 }

--- a/service/src/main/java/tds/exam/services/impl/ExamServiceImpl.java
+++ b/service/src/main/java/tds/exam/services/impl/ExamServiceImpl.java
@@ -306,8 +306,8 @@ class ExamServiceImpl implements ExamService {
     }
 
     @Override
-    public Response<List<ExpandableExam>> findExamsBySessionId(final UUID sessionId, final Set<String> invalidStatuses,
-                                                               final String... expandableParams) {
+    public List<ExpandableExam> findExamsBySessionId(final UUID sessionId, final Set<String> invalidStatuses,
+                                                     final String... expandableParams) {
         final Set<String> params = Sets.newHashSet(expandableParams);
         final List<Exam> exams = examQueryRepository.findAllExamsInSessionWithoutStatus(sessionId, invalidStatuses);
         final Map<UUID, ExpandableExam.Builder> examBuilders = exams.stream()
@@ -328,12 +328,10 @@ class ExamServiceImpl implements ExamService {
             //TODO: fetch count of unfulfilled print/emboss requests for each exam
         }
 
-        // Build each exam
-        List<ExpandableExam> expandableExams = examBuilders.values().stream()
+        // Build each exam and return
+        return examBuilders.values().stream()
             .map(builders -> builders.build())
             .collect(Collectors.toList());
-
-        return new Response<>(expandableExams);
     }
 
     @Transactional

--- a/service/src/main/java/tds/exam/web/endpoints/ExamController.java
+++ b/service/src/main/java/tds/exam/web/endpoints/ExamController.java
@@ -106,8 +106,8 @@ public class ExamController {
 
     @RequestMapping(value = "/session/{sessionId}", method = RequestMethod.GET, produces = MediaType.APPLICATION_JSON_VALUE)
     ResponseEntity<List<ExpandableExam>> findExamsForSessionId(@PathVariable final UUID sessionId,
-                                                                         @RequestParam final Set<String> statusNot,
-                                                                         @RequestParam("expandable") final String... expandableParams) {
+                                                               @RequestParam final Set<String> statusNot,
+                                                               @RequestParam("expandable") final String... expandableParams) {
         final List<ExpandableExam> exams = examService.findExamsBySessionId(sessionId, statusNot,
             expandableParams);
 

--- a/service/src/main/java/tds/exam/web/endpoints/ExamController.java
+++ b/service/src/main/java/tds/exam/web/endpoints/ExamController.java
@@ -106,10 +106,9 @@ public class ExamController {
 
     @RequestMapping(value = "/session/{sessionId}", method = RequestMethod.GET, produces = MediaType.APPLICATION_JSON_VALUE)
     ResponseEntity<List<ExpandableExam>> findExamsForSessionId(@PathVariable final UUID sessionId,
-                                                               @RequestParam final Set<String> statusNot,
-                                                               @RequestParam(value = "expandable", required = false) final String... expandableParams) {
-        final List<ExpandableExam> exams = examService.findExamsBySessionId(sessionId, statusNot,
-            expandableParams);
+                                                               @RequestParam(required = false) final Set<String> statusNot,
+                                                               @RequestParam(required = false) final String... embed) {
+        final List<ExpandableExam> exams = examService.findExamsBySessionId(sessionId, statusNot, embed);
 
         if (exams.isEmpty()) {
             return new ResponseEntity<>(exams, HttpStatus.NO_CONTENT);

--- a/service/src/main/java/tds/exam/web/endpoints/ExamController.java
+++ b/service/src/main/java/tds/exam/web/endpoints/ExamController.java
@@ -15,7 +15,9 @@ import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.ResponseStatus;
 import org.springframework.web.bind.annotation.RestController;
 
+import java.util.List;
 import java.util.Optional;
+import java.util.Set;
 import java.util.UUID;
 
 import tds.common.Response;
@@ -26,6 +28,7 @@ import tds.exam.Exam;
 import tds.exam.ExamConfiguration;
 import tds.exam.ExamStatusCode;
 import tds.exam.ExamStatusStage;
+import tds.exam.ExpandableExam;
 import tds.exam.OpenExamRequest;
 import tds.exam.services.ExamService;
 
@@ -79,26 +82,40 @@ public class ExamController {
 
         return ResponseEntity.ok(examConfiguration);
     }
-    
+
     @RequestMapping(value = "/{examId}/status", method = RequestMethod.PUT, produces = MediaType.APPLICATION_JSON_VALUE)
     ResponseEntity<NoContentResponseResource> updateStatus(@PathVariable final UUID examId,
                                                            @RequestParam final String status,
                                                            @RequestParam(required = false) final String stage,
                                                            @RequestParam(required = false) final String reason) {
-    
+
         ExamStatusCode examStatus = (stage == null) ? new ExamStatusCode(status) : new ExamStatusCode(status, ExamStatusStage.fromType(stage));
         final Optional<ValidationError> maybeStatusTransitionFailure = examService.updateExamStatus(examId, examStatus, reason);
-    
+
         if (maybeStatusTransitionFailure.isPresent()) {
             NoContentResponseResource response = new NoContentResponseResource(maybeStatusTransitionFailure.get());
             return new ResponseEntity<>(response, HttpStatus.UNPROCESSABLE_ENTITY);
         }
-    
+
         Link link = linkTo(methodOn(ExamController.class).getExamById(examId)).withSelfRel();
         final HttpHeaders headers = new HttpHeaders();
         headers.add("Location", link.getHref());
-    
+
         return new ResponseEntity<>(headers, HttpStatus.NO_CONTENT);
+    }
+
+    @RequestMapping(value = "/session/{sessionId}", method = RequestMethod.GET, produces = MediaType.APPLICATION_JSON_VALUE)
+    ResponseEntity<List<ExpandableExam>> findExamsForSessionId(@PathVariable final UUID sessionId,
+                                                                         @RequestParam final Set<String> statusNot,
+                                                                         @RequestParam("expandable") final String... expandableParams) {
+        final List<ExpandableExam> exams = examService.findExamsBySessionId(sessionId, statusNot,
+            expandableParams);
+
+        if (exams.isEmpty()) {
+            return new ResponseEntity<>(exams, HttpStatus.NO_CONTENT);
+        }
+
+        return ResponseEntity.ok(exams);
     }
 
     @RequestMapping(value = "/{examId}/pause", method = RequestMethod.PUT, produces = MediaType.APPLICATION_JSON_VALUE)

--- a/service/src/main/java/tds/exam/web/endpoints/ExamController.java
+++ b/service/src/main/java/tds/exam/web/endpoints/ExamController.java
@@ -107,7 +107,7 @@ public class ExamController {
     @RequestMapping(value = "/session/{sessionId}", method = RequestMethod.GET, produces = MediaType.APPLICATION_JSON_VALUE)
     ResponseEntity<List<ExpandableExam>> findExamsForSessionId(@PathVariable final UUID sessionId,
                                                                @RequestParam final Set<String> statusNot,
-                                                               @RequestParam("expandable") final String... expandableParams) {
+                                                               @RequestParam(value = "expandable", required = false) final String... expandableParams) {
         final List<ExpandableExam> exams = examService.findExamsBySessionId(sessionId, statusNot,
             expandableParams);
 

--- a/service/src/test/java/tds/exam/services/impl/ExamServiceImplTest.java
+++ b/service/src/test/java/tds/exam/services/impl/ExamServiceImplTest.java
@@ -1356,11 +1356,8 @@ public class ExamServiceImplTest {
         when(mockExamQueryRepository.findAllExamsInSessionWithoutStatus(eq(sessionId), any())).thenReturn(Arrays.asList(exam1, exam2));
         when(mockExamAccommodationService.findApprovedAccommodations(any(), any()))
             .thenReturn(Arrays.asList(exam1accommodation1, exam1accommodation2, exam2accommodation));
-        Response<List<ExpandableExam>> response = examService.findExamsBySessionId(sessionId, invalidStatuses,
+        List<ExpandableExam> expandableExams = examService.findExamsBySessionId(sessionId, invalidStatuses,
             ExpandableExam.EXPANDABLE_PARAMS_EXAM_ACCOMMODATIONS);
-        assertThat(response.getData().isPresent()).isTrue();
-        assertThat(response.getError().isPresent()).isFalse();
-        List<ExpandableExam> expandableExams = response.getData().get();
 
         verify(mockExamQueryRepository).findAllExamsInSessionWithoutStatus(eq(sessionId), any());
         verify(mockExamAccommodationService).findApprovedAccommodations(any(), any());
@@ -1409,11 +1406,8 @@ public class ExamServiceImplTest {
             exam1.getId(), 4,
             exam2.getId(), 1
         ));
-        Response<List<ExpandableExam>> response = examService.findExamsBySessionId(sessionId, invalidStatuses,
+        List<ExpandableExam> expandableExams = examService.findExamsBySessionId(sessionId, invalidStatuses,
             ExpandableExam.EXPANDABLE_PARAMS_EXAM_ACCOMMODATIONS, ExpandableExam.EXPANDABLE_PARAMS_ITEM_RESPONSE_COUNT);
-        assertThat(response.getData().isPresent()).isTrue();
-        assertThat(response.getError().isPresent()).isFalse();
-        List<ExpandableExam> expandableExams = response.getData().get();
 
         verify(mockExamQueryRepository).findAllExamsInSessionWithoutStatus(eq(sessionId), any());
         verify(mockExamAccommodationService).findApprovedAccommodations(any(), any());

--- a/service/src/test/java/tds/exam/web/endpoints/ExamControllerIntegrationTests.java
+++ b/service/src/test/java/tds/exam/web/endpoints/ExamControllerIntegrationTests.java
@@ -1,5 +1,6 @@
 package tds.exam.web.endpoints;
 
+import com.google.common.collect.ImmutableSet;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -9,6 +10,14 @@ import org.springframework.context.annotation.Import;
 import org.springframework.http.MediaType;
 import org.springframework.test.context.junit4.SpringRunner;
 import org.springframework.test.web.servlet.MockMvc;
+
+import java.net.URI;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Optional;
+import java.util.Set;
+import java.util.UUID;
+
 import tds.common.ValidationError;
 import tds.common.configuration.JacksonObjectMapperConfiguration;
 import tds.common.configuration.SecurityConfiguration;
@@ -16,16 +25,15 @@ import tds.common.web.advice.ExceptionAdvice;
 import tds.exam.Exam;
 import tds.exam.ExamStatusCode;
 import tds.exam.ExamStatusStage;
+import tds.exam.ExpandableExam;
 import tds.exam.builder.ExamBuilder;
 import tds.exam.error.ValidationErrorCode;
 import tds.exam.services.ExamPageService;
 import tds.exam.services.ExamService;
 
-import java.net.URI;
-import java.util.Optional;
-import java.util.UUID;
-
+import static io.github.benas.randombeans.api.EnhancedRandom.random;
 import static org.hamcrest.CoreMatchers.is;
+import static org.hamcrest.Matchers.hasSize;
 import static org.mockito.Matchers.any;
 import static org.mockito.Matchers.eq;
 import static org.mockito.Matchers.isNull;
@@ -44,64 +52,64 @@ import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.
 public class ExamControllerIntegrationTests {
     @Autowired
     private MockMvc http;
-    
+
     @MockBean
     private ExamService mockExamService;
-    
+
     @MockBean
     private ExamPageService mockExamPageService;
-    
+
     @Test
     public void shouldReturnExam() throws Exception {
         UUID examId = UUID.randomUUID();
         Exam exam = new ExamBuilder().withId(examId).build();
-        
+
         when(mockExamService.findExam(examId)).thenReturn(Optional.of(exam));
-        
+
         http.perform(get(new URI(String.format("/exam/%s", examId)))
             .contentType(MediaType.APPLICATION_JSON))
             .andExpect(status().isOk())
             .andExpect(jsonPath("id", is(examId.toString())));
-        
+
         verify(mockExamService).findExam(examId);
     }
-    
+
     @Test
     public void shouldReturnNotFoundIfExamCannotBeFound() throws Exception {
         UUID examId = UUID.randomUUID();
-        
+
         when(mockExamService.findExam(examId)).thenReturn(Optional.empty());
-        
+
         http.perform(get(new URI(String.format("/exam/%s", examId)))
             .contentType(MediaType.APPLICATION_JSON))
             .andExpect(status().isNotFound());
-        
+
         verify(mockExamService).findExam(examId);
     }
-    
+
     @Test
     public void shouldPauseAnExam() throws Exception {
         UUID examId = UUID.randomUUID();
-        
+
         when(mockExamService.updateExamStatus(examId,
             new ExamStatusCode(ExamStatusCode.STATUS_PAUSED, ExamStatusStage.INACTIVE))).thenReturn(Optional.empty());
-        
+
         http.perform(put(new URI(String.format("/exam/%s/pause", examId)))
             .contentType(MediaType.APPLICATION_JSON))
             .andExpect(status().isNoContent())
             .andExpect(header().string("Location", String.format("http://localhost/exam/%s", examId)));
-        
+
         verify(mockExamService).updateExamStatus(examId,
             new ExamStatusCode(ExamStatusCode.STATUS_PAUSED, ExamStatusStage.INACTIVE));
     }
-    
+
     @Test
     public void shouldReturnAnErrorWhenAttemptingToPauseAnExamInAnInvalidTransitionState() throws Exception {
         UUID examId = UUID.randomUUID();
-        
+
         when(mockExamService.updateExamStatus(examId, new ExamStatusCode(ExamStatusCode.STATUS_PAUSED, ExamStatusStage.INACTIVE)))
             .thenReturn(Optional.of(new ValidationError(ValidationErrorCode.EXAM_STATUS_TRANSITION_FAILURE, "Bad transition from foo to bar")));
-        
+
         http.perform(put(new URI(String.format("/exam/%s/pause", examId)))
             .contentType(MediaType.APPLICATION_JSON))
             .andExpect(status().isUnprocessableEntity())
@@ -110,57 +118,106 @@ public class ExamControllerIntegrationTests {
             .andExpect(jsonPath("errors[0].code", is("badStatusTransition")))
             .andExpect(jsonPath("errors[0].message", is("Bad transition from foo to bar")));
     }
-    
+
     @Test
     public void shouldPauseAllExamsInASession() throws Exception {
         UUID sessionId = UUID.randomUUID();
         doNothing().when(mockExamService).pauseAllExamsInSession(sessionId);
-        
+
         http.perform(put(new URI(String.format("/exam/pause/%s", sessionId)))
             .contentType(MediaType.APPLICATION_JSON))
             .andExpect(status().isNoContent());
-        
+
         verify(mockExamService).pauseAllExamsInSession(sessionId);
     }
-    
+
     @Test
     public void shouldUpdateExamStatus() throws Exception {
         final UUID examId = UUID.randomUUID();
         final String statusCode = ExamStatusCode.STATUS_APPROVED;
-        
+
         when(mockExamService.updateExamStatus(eq(examId), any(), (String) isNull())).thenReturn(Optional.empty());
-        
+
         http.perform(put(new URI(String.format("/exam/%s/status/", examId)))
             .param("status", statusCode)
             .contentType(MediaType.APPLICATION_JSON))
             .andExpect(status().isNoContent());
-        
+
         verify(mockExamService).updateExamStatus(eq(examId), any(), (String) isNull());
     }
-    
+
     @Test
     public void shouldFailStatusUpdateWithError() throws Exception {
         final UUID examId = UUID.randomUUID();
         final String statusCode = ExamStatusCode.STATUS_APPROVED;
-        
+
         when(mockExamService.updateExamStatus(eq(examId), any(), (String) isNull()))
             .thenReturn(Optional.of(new ValidationError("Some", "Error")));
-        
+
         http.perform(put(new URI(String.format("/exam/%s/status/", examId)))
             .param("status", statusCode)
             .contentType(MediaType.APPLICATION_JSON))
             .andExpect(status().isUnprocessableEntity());
-        
+
         verify(mockExamService).updateExamStatus(eq(examId), any(), (String) isNull());
+    }
+
+    @Test
+    public void shouldReturnNoContentForEmptyList() throws Exception {
+        final UUID sessionId = UUID.randomUUID();
+        final Set<String> invalidStatuses = ImmutableSet.of(ExamStatusCode.STATUS_SUSPENDED);
+        when(mockExamService.findExamsBySessionId(sessionId, invalidStatuses, ExpandableExam.EXPANDABLE_PARAMS_EXAM_ACCOMMODATIONS))
+            .thenReturn(new ArrayList<>());
+
+        http.perform(get(new URI(String.format("/exam/session/%s", sessionId)))
+            .param("statusNot", ExamStatusCode.STATUS_SUSPENDED)
+            .param("expandable", ExpandableExam.EXPANDABLE_PARAMS_EXAM_ACCOMMODATIONS)
+            .contentType(MediaType.APPLICATION_JSON))
+            .andExpect(status().isNoContent());
+    }
+
+    @Test
+    public void shouldReturnListOfExpandableExamsForSessionId() throws Exception {
+        final UUID sessionId = UUID.randomUUID();
+        final Set<String> invalidStatuses = ImmutableSet.of(
+            ExamStatusCode.STATUS_SUSPENDED,
+            ExamStatusCode.STATUS_PENDING,
+            ExamStatusCode.STATUS_DENIED
+        );
+
+        final ExpandableExam expandableExam1 = random(ExpandableExam.class);
+        final ExpandableExam expandableExam2 = random(ExpandableExam.class);
+
+        when(mockExamService.findExamsBySessionId(sessionId, invalidStatuses, ExpandableExam.EXPANDABLE_PARAMS_EXAM_ACCOMMODATIONS,
+            ExpandableExam.EXPANDABLE_PARAMS_ITEM_RESPONSE_COUNT))
+            .thenReturn(Arrays.asList(expandableExam1, expandableExam2));
+
+        http.perform(get(new URI(String.format("/exam/session/%s", sessionId)))
+            .param("statusNot", ExamStatusCode.STATUS_SUSPENDED)
+            .param("statusNot", ExamStatusCode.STATUS_PENDING)
+            .param("statusNot", ExamStatusCode.STATUS_DENIED)
+            .param("expandable", ExpandableExam.EXPANDABLE_PARAMS_EXAM_ACCOMMODATIONS)
+            .param("expandable", ExpandableExam.EXPANDABLE_PARAMS_ITEM_RESPONSE_COUNT)
+            .contentType(MediaType.APPLICATION_JSON))
+            .andExpect(status().isOk())
+            .andExpect(jsonPath("[0].exam.id", is(expandableExam1.getExam().getId().toString())))
+            .andExpect(jsonPath("[0].itemsResponseCount", is(expandableExam1.getItemsResponseCount())))
+            .andExpect(jsonPath("[0].examAccommodations", hasSize(expandableExam1.getExamAccommodations().size())))
+            .andExpect(jsonPath("[0].examAccommodations[0].id", is(expandableExam1.getExamAccommodations().get(0).getId().toString())))
+            .andExpect(jsonPath("[0].examAccommodations[1].id", is(expandableExam1.getExamAccommodations().get(1).getId().toString())))
+            .andExpect(jsonPath("[1].exam.id", is(expandableExam2.getExam().getId().toString())))
+            .andExpect(jsonPath("[1].itemsResponseCount", is(expandableExam2.getItemsResponseCount())))
+            .andExpect(jsonPath("[1].examAccommodations[0].id", is(expandableExam2.getExamAccommodations().get(0).getId().toString())))
+            .andExpect(jsonPath("[1].examAccommodations", hasSize(expandableExam2.getExamAccommodations().size())));
     }
 
     @Test
     public void shouldThrowWithNoStatusProvided() throws Exception {
         final UUID examId = UUID.randomUUID();
-        
+
         http.perform(put(new URI(String.format("/exam/%s/status/", examId)))
             .contentType(MediaType.APPLICATION_JSON))
             .andExpect(status().isInternalServerError());
-        
+
     }
 }


### PR DESCRIPTION
This PR includes the endpoint that proctor will call to retrieve the list of "expandable exams" (exams with additional data) for a sessionId. 

Some notes:
- This, along with the code in ExamServiceImpl.findExamsBySessionId() covers the query found below. Please reference inline SQL comments below for explanations of where this data can/will be retrieved by the proctor application
- The service/endpoint will no longer return a Response-wrapped object. We do not need to wrap our data in a response since there is no possible validation errors or any errors that will be displayed in the UI.
- The query filters by exams with a status NOT IN 'pending', 'suspended', or 'denied'. The controller/service will not filter this implicitly, but these filter values will be be included as query parameters by the caller (the proctor app).
- The entrypoint in the legacy code that corresponds to this work is in TDS_Proctor - TestSessionDaoImpl.getCurrentSessionTestees()

```
select 
  tOpp._efk_AdminSubject,                         --exam.assessmentKey
  tOpp._fk_TestOpportunity as opportunityKey,     --exam.id
  tOpp._efk_Testee,                               --exam.studentId
  tOpp._efk_TestID,                               --exam.assessmentId
  tOpp.Opportunity,                               --exam.attempts
  tOpp.TesteeName,                                --exam.studentName
  TesteeID,                                       --exam.loginSsid  
  tOpp.Status,                                    --exam.status
  tOpp.DateCompleted,                             --exam.completedAt
  tOpp._fk_Session,                               --exam.sessionId    (uuid)
  tOpp.SessID as SessionID,                       --exam.sessionKey  (ADM-99)
  '' as sessionName,  
  maxitems as ItemCount,                          --exam.maxItems
  case when tOpp.status = 'paused' and datePaused is not null   -- Can be extracted from Exam if status == paused (diff of dateChanged and "now")
    then timestampdiff(MINUTE, datePaused, now(3)) 
  else 
    cast(null as CHAR) end as pauseMinutes,       -- null if not paused, otherwise the number of mins the exam has been paused for
  numResponses as ResponseCount,                   
  (
    select 
      count(*) 
    from 
      testopprequest REQ 
    where 
      REQ._fk_TestOpportunity = tOpp._fk_TestOpportunity 
      and REQ._fk_Session = ${sessionKey}
      and DateFulfilled is null 
      and DateSubmitted > ${midnightAM} 
      and DateSubmitted < ${midnightPM}
  ) as RequestCountN,                             -- the number of unfulfilled requests for this exam/session          
  (
    select 
      value as score 
    from 
      testopportunityscores S
    join configs.client_testscorefeatures F
      on S.MeasureOf = F.MeasureOf 
      and S.MeasureLabel = F.MeasureLabel 
    where 
      F.ClientName = ${clientname} 
      and ReportToProctor = 1 
      and S._fk_TestOpportunity = tOpp._fk_TestOpportunity 
      and S.IsOfficial = 1 
    limit 1
  ) as Score,                                 -- Not needed
  AccommodationString as Accommodations,      -- ExamService will return entire list of exam accommodations
  tOpp.customAccommodations,                  -- exam.customAccommodations
  tOpp.mode,                                  -- Not needed, always "online"
  ctp.msb                                     -- TODO: Need to fetch MSB flag from assessment
from testopportunity_readonly tOpp 
left outer join                       -- Join not necessary - only used to validate testid and clientname (part of exam) and to get msb flag. 
  configs.client_testproperties ctp 
  on tOpp._efk_testid = ctp.testid 
  and tOpp.clientname = ctp.clientname 
where 
  _fk_Session = ${sessionKey} 
  and tOpp.DateChanged > ${midnightAM} -- midnight date in UTC
  and tOpp.DateChanged < ${midnightPM} 
  and tOpp.status not in ('pending', 'suspended', 'denied');
  ```