### PR TITLE
Exam Print Request endpoint

### DIFF
--- a/client/src/main/java/tds/exam/ExamPrintRequest.java
+++ b/client/src/main/java/tds/exam/ExamPrintRequest.java
@@ -1,0 +1,241 @@
+package tds.exam;
+
+import org.joda.time.Instant;
+
+import java.util.UUID;
+
+/**
+ * Represents a request to print or emboss and exam item, passage, or page.
+ */
+public class ExamPrintRequest {
+    public static final String REQUEST_TYPE_EMBOSS_ITEM = "EMBOSSITEM";
+    public static final String REQUEST_TYPE_EMBOSS_PASSAGE = "EMBOSSPASSAGE";
+    public static final String REQUEST_TYPE_PRINT_ITEM = "PRINTITEM";
+    public static final String REQUEST_TYPE_PRINT_PASSAGE = "PRINTPASSAGE";
+
+    private UUID id;
+    private UUID examId;
+    private UUID sessionId;
+    private String type;
+    private String value;
+    private int itemPosition;
+    private int pagePosition;
+    private String parameters;
+    private String description;
+    private Instant createdAt;
+    private Instant approvedAt;
+    private Instant deniedAt;
+    private String reasonDenied;
+
+    private ExamPrintRequest() {
+    }
+
+    public ExamPrintRequest(Builder builder) {
+        this.createdAt = builder.createdAt;
+        this.pagePosition = builder.pagePosition;
+        this.itemPosition = builder.itemPosition;
+        this.approvedAt = builder.approvedAt;
+        this.examId = builder.examId;
+        this.parameters = builder.parameters;
+        this.deniedAt = builder.deniedAt;
+        this.value = builder.value;
+        this.id = builder.id;
+        this.sessionId = builder.sessionId;
+        this.type = builder.type;
+        this.reasonDenied = builder.reasonDenied;
+        this.description = builder.description;
+    }
+
+    public static final class Builder {
+        private UUID id;
+        private UUID examId;
+        private UUID sessionId;
+        private String type;
+        private String value;
+        private int itemPosition;
+        private int pagePosition;
+        private String parameters;
+        private String description;
+        private Instant createdAt;
+        private Instant approvedAt;
+        private Instant deniedAt;
+        private String reasonDenied;
+
+        public Builder withId(UUID id) {
+            this.id = id;
+            return this;
+        }
+
+        public Builder withExamId(UUID examId) {
+            this.examId = examId;
+            return this;
+        }
+
+        public Builder withSessionId(UUID sessionId) {
+            this.sessionId = sessionId;
+            return this;
+        }
+
+        public Builder withType(String type) {
+            this.type = type;
+            return this;
+        }
+
+        public Builder withValue(String value) {
+            this.value = value;
+            return this;
+        }
+
+        public Builder withItemPosition(int itemPosition) {
+            this.itemPosition = itemPosition;
+            return this;
+        }
+
+        public Builder withPagePosition(int pagePosition) {
+            this.pagePosition = pagePosition;
+            return this;
+        }
+
+        public Builder withParameters(String parameters) {
+            this.parameters = parameters;
+            return this;
+        }
+
+        public Builder withDescription(String description) {
+            this.description = description;
+            return this;
+        }
+
+        public Builder withCreatedAt(Instant createdAt) {
+            this.createdAt = createdAt;
+            return this;
+        }
+
+        public Builder withApprovedAt(Instant approvedAt) {
+            this.approvedAt = approvedAt;
+            return this;
+        }
+
+        public Builder withDeniedAt(Instant deniedAt) {
+            this.deniedAt = deniedAt;
+            return this;
+        }
+
+        public Builder withReasonDenied(String reasonDenied) {
+            this.reasonDenied = reasonDenied;
+            return this;
+        }
+
+        public Builder fromExamPrintRequest(ExamPrintRequest request) {
+            this.createdAt = request.createdAt;
+            this.pagePosition = request.pagePosition;
+            this.itemPosition = request.itemPosition;
+            this.approvedAt = request.approvedAt;
+            this.examId = request.examId;
+            this.parameters = request.parameters;
+            this.deniedAt = request.deniedAt;
+            this.value = request.value;
+            this.id = request.id;
+            this.sessionId = request.sessionId;
+            this.type = request.type;
+            this.reasonDenied = request.reasonDenied;
+            this.description = request.description;
+            return this;
+        }
+
+        public ExamPrintRequest build() {
+            return new ExamPrintRequest(this);
+        }
+    }
+
+    /**
+     * @return the id of the {@link tds.exam.ExamPrintRequest}
+     */
+    public UUID getId() {
+        return id;
+    }
+
+    /**
+     * @return the id of the exam requesting a print or embossing
+     */
+    public UUID getExamId() {
+        return examId;
+    }
+
+    /**
+     * @return the id of the session the exam belongs to that is request a print or emboss
+     */
+    public UUID getSessionId() {
+        return sessionId;
+    }
+
+    /**
+     * @return The type of print request (embossing item, embossing passing, print item, print passage, etc.)
+     */
+    public String getType() {
+        return type;
+    }
+
+    /**
+     * @return The value of the request - the path(s) to the requested resource
+     */
+    public String getValue() {
+        return value;
+    }
+
+    /**
+     * @return The position of the item that is being requested for print or embossing
+     */
+    public int getItemPosition() {
+        return itemPosition;
+    }
+
+    /**
+     * @return The position of the page that is being requested for print or embossing
+     */
+    public int getPagePosition() {
+        return pagePosition;
+    }
+
+    /**
+     * @return A string representing additional parameter(s) for the request
+     */
+    public String getParameters() {
+        return parameters;
+    }
+
+    /**
+     * @return The description of the request
+     */
+    public String getDescription() {
+        return description;
+    }
+
+    /**
+     * @return The {@link org.joda.time.Instant} the request was submitted
+     */
+    public Instant getCreatedAt() {
+        return createdAt;
+    }
+
+    /**
+     * @return If approved, the {@link org.joda.time.Instant} the request was approved by a proctor
+     */
+    public Instant getApprovedAt() {
+        return approvedAt;
+    }
+
+    /**
+     * @return If denied, the {@link org.joda.time.Instant} the request was denied by a proctor
+     */
+    public Instant getDeniedAt() {
+        return deniedAt;
+    }
+
+    /**
+     * @return If denied, a description of why the {@link tds.exam.ExamPrintRequest} was denied, provided by the proctor
+     */
+    public String getReasonDenied() {
+        return reasonDenied;
+    }
+}

--- a/service/src/main/java/tds/exam/repositories/ExamPrintRequestCommandRepository.java
+++ b/service/src/main/java/tds/exam/repositories/ExamPrintRequestCommandRepository.java
@@ -1,0 +1,16 @@
+package tds.exam.repositories;
+
+import tds.exam.ExamPrintRequest;
+
+/**
+ * A repository for writing {@link tds.exam.ExamPrintRequest} data
+ */
+public interface ExamPrintRequestCommandRepository {
+
+    /**
+     * Creates a request to print an exam
+     *
+     * @param examPrintRequest
+     */
+    void insert(final ExamPrintRequest examPrintRequest);
+}

--- a/service/src/main/java/tds/exam/repositories/ExamPrintRequestQueryRepository.java
+++ b/service/src/main/java/tds/exam/repositories/ExamPrintRequestQueryRepository.java
@@ -1,0 +1,19 @@
+package tds.exam.repositories;
+
+import java.util.Map;
+import java.util.UUID;
+
+/**
+ * A repository for reading {@link tds.exam.ExamPrintRequest} data
+ */
+public interface ExamPrintRequestQueryRepository {
+
+    /**
+     * Retrieves a map of exam ids to their respective count of unfulfilled {@link tds.exam.ExamPrintRequest}
+     *
+     * @param sessionId The session of the exams
+     * @param examIds   The list of exam ids for each {@link tds.exam.ExamPrintRequest}
+     * @return A map of exam ids to their request count
+     */
+    Map<UUID, Integer> findRequestCountsForExamIds(final UUID sessionId, final UUID... examIds);
+}

--- a/service/src/main/java/tds/exam/repositories/impl/ExamPrintRequestCommandRepositoryImpl.java
+++ b/service/src/main/java/tds/exam/repositories/impl/ExamPrintRequestCommandRepositoryImpl.java
@@ -1,0 +1,88 @@
+package tds.exam.repositories.impl;
+
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.beans.factory.annotation.Qualifier;
+import org.springframework.jdbc.core.namedparam.MapSqlParameterSource;
+import org.springframework.jdbc.core.namedparam.NamedParameterJdbcTemplate;
+import org.springframework.jdbc.core.namedparam.SqlParameterSource;
+import org.springframework.stereotype.Repository;
+
+import tds.exam.ExamPrintRequest;
+import tds.exam.repositories.ExamPrintRequestCommandRepository;
+
+import static tds.common.data.mapping.ResultSetMapperUtility.mapJodaInstantToTimestamp;
+
+@Repository
+public class ExamPrintRequestCommandRepositoryImpl implements ExamPrintRequestCommandRepository {
+    private final NamedParameterJdbcTemplate jdbcTemplate;
+
+    @Autowired
+    public ExamPrintRequestCommandRepositoryImpl(@Qualifier("commandJdbcTemplate") final NamedParameterJdbcTemplate jdbcTemplate) {
+        this.jdbcTemplate = jdbcTemplate;
+    }
+
+    @Override
+    public void insert(final ExamPrintRequest examPrintRequest) {
+        SqlParameterSource params = new MapSqlParameterSource("id", examPrintRequest.getId().toString())
+            .addValue("examId", examPrintRequest.getExamId().toString())
+            .addValue("sessionId", examPrintRequest.getSessionId().toString())
+            .addValue("type", examPrintRequest.getType())
+            .addValue("value", examPrintRequest.getValue())
+            .addValue("itemPosition", examPrintRequest.getItemPosition())
+            .addValue("pagePosition", examPrintRequest.getPagePosition())
+            .addValue("parameters", examPrintRequest.getParameters())
+            .addValue("description", examPrintRequest.getDescription());
+
+        final String examPrintRequestSQL =
+            "INSERT INTO \n" +
+                "exam.exam_print_request ( \n" +
+                "   id, \n" +
+                "   exam_id, \n" +
+                "   session_id, \n" +
+                "   type, \n" +
+                "   value, \n" +
+                "   item_position, \n" +
+                "   page_position, \n" +
+                "   parameters, \n" +
+                "   description \n" +
+                ") \n" +
+                "VALUES ( \n" +
+                "   :id, \n" +
+                "   :examId, \n" +
+                "   :sessionId, \n" +
+                "   :type, \n" +
+                "   :value, \n" +
+                "   :itemPosition, \n" +
+                "   :pagePosition, \n" +
+                "   :parameters, \n" +
+                "   :description \n" +
+                ")";
+
+        jdbcTemplate.update(examPrintRequestSQL, params);
+        update(examPrintRequest);
+    }
+
+    private void update(final ExamPrintRequest examPrintRequest) {
+        MapSqlParameterSource params = new MapSqlParameterSource("examRequestId", examPrintRequest.getId().toString())
+            .addValue("approvedAt", mapJodaInstantToTimestamp(examPrintRequest.getApprovedAt()))
+            .addValue("deniedAt", mapJodaInstantToTimestamp(examPrintRequest.getDeniedAt()))
+            .addValue("reasonDenied", examPrintRequest.getReasonDenied());
+
+        final String updateExamPrintRequestSQL =
+            "INSERT INTO \n" +
+                "exam.exam_print_request_event ( \n" +
+                "   exam_print_request_id, \n" +
+                "   approved_at, \n" +
+                "   denied_at, \n" +
+                "   reason_denied \n" +
+                ") \n" +
+                "VALUES ( \n" +
+                "   :examRequestId, \n" +
+                "   :approvedAt, \n" +
+                "   :deniedAt, \n" +
+                "   :reasonDenied \n" +
+                ")";
+
+        jdbcTemplate.update(updateExamPrintRequestSQL, params);
+    }
+}

--- a/service/src/main/java/tds/exam/repositories/impl/ExamPrintRequestCommandRepositoryImpl.java
+++ b/service/src/main/java/tds/exam/repositories/impl/ExamPrintRequestCommandRepositoryImpl.java
@@ -23,7 +23,7 @@ public class ExamPrintRequestCommandRepositoryImpl implements ExamPrintRequestCo
 
     @Override
     public void insert(final ExamPrintRequest examPrintRequest) {
-        SqlParameterSource params = new MapSqlParameterSource("id", examPrintRequest.getId().toString())
+        final SqlParameterSource params = new MapSqlParameterSource("id", examPrintRequest.getId().toString())
             .addValue("examId", examPrintRequest.getExamId().toString())
             .addValue("sessionId", examPrintRequest.getSessionId().toString())
             .addValue("type", examPrintRequest.getType())
@@ -63,7 +63,7 @@ public class ExamPrintRequestCommandRepositoryImpl implements ExamPrintRequestCo
     }
 
     private void update(final ExamPrintRequest examPrintRequest) {
-        MapSqlParameterSource params = new MapSqlParameterSource("examRequestId", examPrintRequest.getId().toString())
+        final SqlParameterSource params = new MapSqlParameterSource("examRequestId", examPrintRequest.getId().toString())
             .addValue("approvedAt", mapJodaInstantToTimestamp(examPrintRequest.getApprovedAt()))
             .addValue("deniedAt", mapJodaInstantToTimestamp(examPrintRequest.getDeniedAt()))
             .addValue("reasonDenied", examPrintRequest.getReasonDenied());

--- a/service/src/main/java/tds/exam/repositories/impl/ExamPrintRequestQueryRepositoryImpl.java
+++ b/service/src/main/java/tds/exam/repositories/impl/ExamPrintRequestQueryRepositoryImpl.java
@@ -1,0 +1,65 @@
+package tds.exam.repositories.impl;
+
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.beans.factory.annotation.Qualifier;
+import org.springframework.jdbc.core.ResultSetExtractor;
+import org.springframework.jdbc.core.namedparam.MapSqlParameterSource;
+import org.springframework.jdbc.core.namedparam.NamedParameterJdbcTemplate;
+import org.springframework.stereotype.Repository;
+
+import java.util.Arrays;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.UUID;
+import java.util.stream.Collectors;
+
+import tds.exam.repositories.ExamPrintRequestQueryRepository;
+
+@Repository
+public class ExamPrintRequestQueryRepositoryImpl implements ExamPrintRequestQueryRepository {
+    private final NamedParameterJdbcTemplate jdbcTemplate;
+
+    @Autowired
+    public ExamPrintRequestQueryRepositoryImpl(@Qualifier("queryJdbcTemplate") final NamedParameterJdbcTemplate queryJdbcTemplate) {
+        this.jdbcTemplate = queryJdbcTemplate;
+    }
+
+    @Override
+    public Map<UUID, Integer> findRequestCountsForExamIds(final UUID sessionId, final UUID... examIds) {
+        final MapSqlParameterSource params = new MapSqlParameterSource("sessionId", sessionId.toString())
+            .addValue("examIds", Arrays.stream(examIds).map(UUID::toString).collect(Collectors.toSet()));
+
+        final String SQL =
+            "SELECT \n" +
+                "   PR.exam_id, \n" +
+                "   COUNT(PR.id) AS requestCount \n" +
+                "FROM  \n" +
+                "   exam.exam_print_request PR \n" +
+                "JOIN ( \n" +
+                "   SELECT \n" +
+                "       exam_print_request_id, \n" +
+                "       MAX(id) AS id \n"+
+                "   FROM \n" +
+                "       exam.exam_print_request_event \n" +
+                "   GROUP BY exam_print_request_id \n" +
+                ") last_event \n" +
+                "   ON PR.id = last_event.exam_print_request_id \n" +
+                "JOIN exam.exam_print_request_event PRE \n" +
+                "   ON last_event.exam_print_request_id = PRE.exam_print_request_id \n" +
+                "   AND last_event.id = PRE.id \n" +
+                "WHERE \n" +
+                "   exam_id IN (:examIds) \n" +
+                "   AND approved_at IS NULL \n" +
+                "   AND denied_at IS NULL \n" +
+                "   AND session_id = :sessionId \n" +
+                "GROUP BY exam_id";
+
+        return jdbcTemplate.query(SQL, params, (ResultSetExtractor<Map<UUID, Integer>>) rs -> {
+            HashMap<UUID, Integer> examIdResponseCounts = new HashMap<>();
+            while (rs.next()) {
+                examIdResponseCounts.put(UUID.fromString(rs.getString("exam_id")), rs.getInt("requestCount"));
+            }
+            return examIdResponseCounts;
+        });
+    }
+}

--- a/service/src/main/java/tds/exam/repositories/impl/ExamPrintRequestQueryRepositoryImpl.java
+++ b/service/src/main/java/tds/exam/repositories/impl/ExamPrintRequestQueryRepositoryImpl.java
@@ -5,6 +5,7 @@ import org.springframework.beans.factory.annotation.Qualifier;
 import org.springframework.jdbc.core.ResultSetExtractor;
 import org.springframework.jdbc.core.namedparam.MapSqlParameterSource;
 import org.springframework.jdbc.core.namedparam.NamedParameterJdbcTemplate;
+import org.springframework.jdbc.core.namedparam.SqlParameterSource;
 import org.springframework.stereotype.Repository;
 
 import java.util.Arrays;
@@ -26,7 +27,7 @@ public class ExamPrintRequestQueryRepositoryImpl implements ExamPrintRequestQuer
 
     @Override
     public Map<UUID, Integer> findRequestCountsForExamIds(final UUID sessionId, final UUID... examIds) {
-        final MapSqlParameterSource params = new MapSqlParameterSource("sessionId", sessionId.toString())
+        final SqlParameterSource params = new MapSqlParameterSource("sessionId", sessionId.toString())
             .addValue("examIds", Arrays.stream(examIds).map(UUID::toString).collect(Collectors.toSet()));
 
         final String SQL =
@@ -38,7 +39,7 @@ public class ExamPrintRequestQueryRepositoryImpl implements ExamPrintRequestQuer
                 "JOIN ( \n" +
                 "   SELECT \n" +
                 "       exam_print_request_id, \n" +
-                "       MAX(id) AS id \n"+
+                "       MAX(id) AS id \n" +
                 "   FROM \n" +
                 "       exam.exam_print_request_event \n" +
                 "   GROUP BY exam_print_request_id \n" +

--- a/service/src/main/java/tds/exam/services/ExamPrintRequestService.java
+++ b/service/src/main/java/tds/exam/services/ExamPrintRequestService.java
@@ -1,0 +1,28 @@
+package tds.exam.services;
+
+import java.util.Map;
+import java.util.UUID;
+
+import tds.exam.ExamPrintRequest;
+
+/**
+ * Service used to create, read, and update exam print and emboss requests
+ */
+public interface ExamPrintRequestService {
+
+    /**
+     * Creates an exam print or emboss request
+     *
+     * @param examPrintRequest an object containing exam print request information
+     */
+    void insert(final ExamPrintRequest examPrintRequest);
+
+    /**
+     * Retrieves a map of exam ids to their respective count of unfulfilled {@link tds.exam.ExamPrintRequest}
+     *
+     * @param sessionId The session of the exams
+     * @param examIds   The list of exam ids for each {@link tds.exam.ExamPrintRequest}
+     * @return A map of exam ids to their request count
+     */
+    Map<UUID, Integer> findRequestCountsForExamIds(final UUID sessionId, final UUID... examIds);
+}

--- a/service/src/main/java/tds/exam/services/impl/ExamPrintRequestServiceImpl.java
+++ b/service/src/main/java/tds/exam/services/impl/ExamPrintRequestServiceImpl.java
@@ -1,0 +1,35 @@
+package tds.exam.services.impl;
+
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.stereotype.Service;
+
+import java.util.Map;
+import java.util.UUID;
+
+import tds.exam.ExamPrintRequest;
+import tds.exam.repositories.ExamPrintRequestCommandRepository;
+import tds.exam.repositories.ExamPrintRequestQueryRepository;
+import tds.exam.services.ExamPrintRequestService;
+
+@Service
+public class ExamPrintRequestServiceImpl implements ExamPrintRequestService{
+    private final ExamPrintRequestCommandRepository examPrintRequestCommandRepository;
+    private final ExamPrintRequestQueryRepository examPrintRequestQueryRepository;
+
+    @Autowired
+    public ExamPrintRequestServiceImpl(final ExamPrintRequestCommandRepository examPrintRequestCommandRepository,
+                                       final ExamPrintRequestQueryRepository examPrintRequestQueryRepository) {
+        this.examPrintRequestCommandRepository = examPrintRequestCommandRepository;
+        this.examPrintRequestQueryRepository = examPrintRequestQueryRepository;
+    }
+
+    @Override
+    public void insert(final ExamPrintRequest examPrintRequest) {
+        examPrintRequestCommandRepository.insert(examPrintRequest);
+    }
+
+    @Override
+    public Map<UUID, Integer> findRequestCountsForExamIds(final UUID sessionId, final UUID... examIds) {
+        return examPrintRequestQueryRepository.findRequestCountsForExamIds(sessionId, examIds);
+    }
+}

--- a/service/src/main/java/tds/exam/services/impl/ExamPrintRequestServiceImpl.java
+++ b/service/src/main/java/tds/exam/services/impl/ExamPrintRequestServiceImpl.java
@@ -2,6 +2,7 @@ package tds.exam.services.impl;
 
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
 
 import java.util.Map;
 import java.util.UUID;
@@ -24,6 +25,7 @@ public class ExamPrintRequestServiceImpl implements ExamPrintRequestService{
     }
 
     @Override
+    @Transactional
     public void insert(final ExamPrintRequest examPrintRequest) {
         examPrintRequestCommandRepository.insert(examPrintRequest);
     }

--- a/service/src/main/java/tds/exam/web/endpoints/ExamPrintRequestController.java
+++ b/service/src/main/java/tds/exam/web/endpoints/ExamPrintRequestController.java
@@ -1,0 +1,30 @@
+package tds.exam.web.endpoints;
+
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.MediaType;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestMethod;
+import org.springframework.web.bind.annotation.ResponseStatus;
+import org.springframework.web.bind.annotation.RestController;
+
+import tds.exam.ExamPrintRequest;
+import tds.exam.services.ExamPrintRequestService;
+
+@RestController
+@RequestMapping("/exam/print")
+public class ExamPrintRequestController {
+    private final ExamPrintRequestService examPrintRequestService;
+
+    @Autowired
+    public ExamPrintRequestController(final ExamPrintRequestService examPrintRequestService) {
+        this.examPrintRequestService = examPrintRequestService;
+    }
+
+    @RequestMapping(method = RequestMethod.POST, produces = MediaType.APPLICATION_JSON_VALUE)
+    @ResponseStatus(HttpStatus.NO_CONTENT)
+    public void createExamRequest(@RequestBody ExamPrintRequest request) {
+        examPrintRequestService.insert(request);
+    }
+}

--- a/service/src/main/resources/db/migration/V1487976556__exam_create_table_exam_requests.sql
+++ b/service/src/main/resources/db/migration/V1487976556__exam_create_table_exam_requests.sql
@@ -1,0 +1,35 @@
+/***********************************************************************************************************************
+  File: V1487976556__exam_create_table_exam_requests.sql
+
+  Desc: Create tables to store exam requests, such as print or embossing requests
+
+***********************************************************************************************************************/
+USE exam;
+
+DROP TABLE  IF EXISTS exam_requests;
+DROP TABLE  IF EXISTS exam_requests_event;
+
+CREATE TABLE exam_print_request (
+  id CHAR(36) NOT NULL,
+  exam_id CHAR(36) NOT NULL,
+  session_id CHAR(36) NOT NULL,
+  type VARCHAR(50) NOT NULL,
+  value VARCHAR(250) NOT NULL,
+  item_position INT(11) NOT NULL,
+  page_position INT(11) NOT NULL,
+  parameters VARCHAR(255) DEFAULT NULL,
+  description VARCHAR(255),
+  created_at TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP(3),
+  CONSTRAINT pk_exam_request_id PRIMARY KEY (id),
+  CONSTRAINT fk_exam_request_exam_id_exam_id FOREIGN KEY (exam_id) REFERENCES exam(id)
+);
+
+CREATE TABLE exam_print_request_event (
+  id BIGINT(20) NOT NULL AUTO_INCREMENT,
+  exam_print_request_id CHAR(36) NOT NULL,
+  approved_at DATETIME(3) DEFAULT NULL,
+  denied_at DATETIME(3) DEFAULT NULL,
+  reason_denied VARCHAR(250) DEFAULT NULL,
+  CONSTRAINT pk_exam_request_id PRIMARY KEY (id),
+  CONSTRAINT fk_exam_request_event_exam_request_id FOREIGN KEY (exam_print_request_id) REFERENCES exam_print_request(id)
+);

--- a/service/src/test/java/tds/exam/repositories/impl/ExamPrintRequestRepositoryIntegrationTests.java
+++ b/service/src/test/java/tds/exam/repositories/impl/ExamPrintRequestRepositoryIntegrationTests.java
@@ -1,0 +1,121 @@
+package tds.exam.repositories.impl;
+
+import org.joda.time.Instant;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.beans.factory.annotation.Qualifier;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.jdbc.core.namedparam.NamedParameterJdbcTemplate;
+import org.springframework.test.context.junit4.SpringJUnit4ClassRunner;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.Map;
+import java.util.UUID;
+
+import tds.exam.Exam;
+import tds.exam.ExamPrintRequest;
+import tds.exam.builder.ExamBuilder;
+import tds.exam.repositories.ExamCommandRepository;
+import tds.exam.repositories.ExamPrintRequestCommandRepository;
+import tds.exam.repositories.ExamPrintRequestQueryRepository;
+
+import static io.github.benas.randombeans.api.EnhancedRandom.random;
+import static org.assertj.core.api.Assertions.assertThat;
+
+@RunWith(SpringJUnit4ClassRunner.class)
+@SpringBootTest
+@Transactional
+public class ExamPrintRequestRepositoryIntegrationTests {
+    @Autowired
+    @Qualifier("commandJdbcTemplate")
+    private NamedParameterJdbcTemplate commandJdbcTemplate;
+    private ExamPrintRequestQueryRepository examPrintRequestQueryRepository;
+    private ExamPrintRequestCommandRepository examPrintRequestCommandRepository;
+    private ExamCommandRepository examCommandRepository;
+
+    @Before
+    public void setUp() {
+        examPrintRequestQueryRepository = new ExamPrintRequestQueryRepositoryImpl(commandJdbcTemplate);
+        examPrintRequestCommandRepository = new ExamPrintRequestCommandRepositoryImpl(commandJdbcTemplate);
+        examCommandRepository = new ExamCommandRepositoryImpl(commandJdbcTemplate);
+    }
+
+    @Test
+    public void shouldReturnCountsForExamsInSession() {
+        UUID sessionId = UUID.randomUUID();
+        Exam exam1 = new ExamBuilder().withSessionId(sessionId).build();
+        Exam exam2 = new ExamBuilder().withSessionId(sessionId).build();
+        Exam diffSessionExam = new ExamBuilder().build();
+
+        examCommandRepository.insert(exam1);
+        examCommandRepository.insert(exam2);
+        examCommandRepository.insert(diffSessionExam);
+
+        // Exam 1
+        ExamPrintRequest exam1Request1 = new ExamPrintRequest.Builder()
+            .fromExamPrintRequest(random(ExamPrintRequest.class))
+            .withSessionId(sessionId)
+            .withExamId(exam1.getId())
+            .withCreatedAt(null)
+            .withDeniedAt(null)
+            .withApprovedAt(null)
+            .withType(ExamPrintRequest.REQUEST_TYPE_EMBOSS_ITEM)
+            .build();
+        ExamPrintRequest exam1Request2 = new ExamPrintRequest.Builder()
+            .fromExamPrintRequest(random(ExamPrintRequest.class))
+            .withSessionId(sessionId)
+            .withExamId(exam1.getId())
+            .withCreatedAt(null)
+            .withDeniedAt(null)
+            .withApprovedAt(null)
+            .withType(ExamPrintRequest.REQUEST_TYPE_EMBOSS_PASSAGE)
+            .build();
+
+        // Exam 2
+        ExamPrintRequest exam2Request = new ExamPrintRequest.Builder()
+            .fromExamPrintRequest(random(ExamPrintRequest.class))
+            .withSessionId(sessionId)
+            .withExamId(exam2.getId())
+            .withCreatedAt(null)
+            .withDeniedAt(null)
+            .withApprovedAt(null)
+            .withType(ExamPrintRequest.REQUEST_TYPE_EMBOSS_PASSAGE)
+            .build();
+        // Should not be included in count - fulfilled
+        ExamPrintRequest exam2FulfilledRequest = new ExamPrintRequest.Builder()
+            .fromExamPrintRequest(random(ExamPrintRequest.class))
+            .withSessionId(sessionId)
+            .withExamId(exam2.getId())
+            .withCreatedAt(null)
+            .withDeniedAt(null)
+            .withApprovedAt(Instant.now().minus(99999))
+            .withType(ExamPrintRequest.REQUEST_TYPE_EMBOSS_PASSAGE)
+            .build();
+
+        // Exam 3 - different session, should not be included
+        ExamPrintRequest diffSessionExamRequest = new ExamPrintRequest.Builder()
+            .fromExamPrintRequest(random(ExamPrintRequest.class))
+            .withSessionId(diffSessionExam.getSessionId())
+            .withExamId(diffSessionExam.getId())
+            .withCreatedAt(null)
+            .withDeniedAt(null)
+            .withApprovedAt(null)
+            .withType(ExamPrintRequest.REQUEST_TYPE_EMBOSS_PASSAGE)
+            .build();
+
+        examPrintRequestCommandRepository.insert(exam1Request1);
+        examPrintRequestCommandRepository.insert(exam1Request2);
+        examPrintRequestCommandRepository.insert(exam2Request);
+        examPrintRequestCommandRepository.insert(exam2FulfilledRequest);
+        examPrintRequestCommandRepository.insert(diffSessionExamRequest);
+
+        Map<UUID, Integer> requestCounts = examPrintRequestQueryRepository.findRequestCountsForExamIds(sessionId,
+            exam1.getId(), exam2.getId(), diffSessionExam.getId());
+        assertThat(requestCounts).hasSize(2);
+        assertThat(requestCounts.get(exam1.getId())).isEqualTo(2);
+        assertThat(requestCounts.get(exam2.getId())).isEqualTo(1);
+        assertThat(requestCounts.containsKey(diffSessionExam.getId())).isFalse();
+    }
+}

--- a/service/src/test/java/tds/exam/services/impl/ExamPrintRequestServiceImplTest.java
+++ b/service/src/test/java/tds/exam/services/impl/ExamPrintRequestServiceImplTest.java
@@ -1,0 +1,39 @@
+package tds.exam.services.impl;
+
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.Mock;
+import org.mockito.runners.MockitoJUnitRunner;
+
+import tds.exam.ExamPrintRequest;
+import tds.exam.repositories.ExamPrintRequestCommandRepository;
+import tds.exam.repositories.ExamPrintRequestQueryRepository;
+import tds.exam.services.ExamPrintRequestService;
+
+import static io.github.benas.randombeans.api.EnhancedRandom.random;
+import static org.mockito.Mockito.verify;
+
+@RunWith(MockitoJUnitRunner.class)
+public class ExamPrintRequestServiceImplTest {
+    private ExamPrintRequestService examPrintRequestService;
+
+    @Mock
+    private ExamPrintRequestQueryRepository mockExamPrintRequestQueryRepository;
+
+    @Mock
+    private ExamPrintRequestCommandRepository mockExamPrintRequestCommandRepository;
+
+    @Before
+    public void setup() {
+        examPrintRequestService = new ExamPrintRequestServiceImpl(mockExamPrintRequestCommandRepository,
+            mockExamPrintRequestQueryRepository);
+    }
+
+    @Test
+    public void shouldCreateExamPrintRequest() {
+        ExamPrintRequest examPrintRequest = random(ExamPrintRequest.class);
+        examPrintRequestService.insert(examPrintRequest);
+        verify(mockExamPrintRequestCommandRepository).insert(examPrintRequest);
+    }
+}

--- a/service/src/test/java/tds/exam/web/endpoints/ExamPrintRequestControllerIntegrationTests.java
+++ b/service/src/test/java/tds/exam/web/endpoints/ExamPrintRequestControllerIntegrationTests.java
@@ -1,0 +1,57 @@
+package tds.exam.web.endpoints;
+
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.ObjectWriter;
+import com.fasterxml.jackson.datatype.joda.JodaModule;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.context.annotation.Import;
+import org.springframework.http.MediaType;
+import org.springframework.test.context.junit4.SpringRunner;
+import org.springframework.test.web.servlet.MockMvc;
+
+import java.net.URI;
+
+import tds.common.configuration.JacksonObjectMapperConfiguration;
+import tds.common.configuration.SecurityConfiguration;
+import tds.common.web.advice.ExceptionAdvice;
+import tds.exam.ExamPrintRequest;
+import tds.exam.services.ExamPrintRequestService;
+
+import static io.github.benas.randombeans.api.EnhancedRandom.random;
+import static org.mockito.Matchers.any;
+import static org.mockito.Mockito.verify;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+@RunWith(SpringRunner.class)
+@WebMvcTest(ExamPrintRequestController.class)
+@Import({ExceptionAdvice.class, JacksonObjectMapperConfiguration.class, SecurityConfiguration.class})
+public class ExamPrintRequestControllerIntegrationTests {
+    @Autowired
+    private MockMvc http;
+
+    @MockBean
+    private ExamPrintRequestService mockExamPrintRequestService;
+
+    @Autowired
+    ObjectMapper objectMapper;
+
+    @Test
+    public void shouldCreateExamPrintRequest() throws Exception {
+        ExamPrintRequest printRequest = random(ExamPrintRequest.class);
+        ObjectWriter ow = objectMapper
+            .writer().withDefaultPrettyPrinter();
+
+        http.perform(post(new URI("/exam/print"))
+            .contentType(MediaType.APPLICATION_JSON)
+            .content(ow.writeValueAsString(printRequest)))
+            .andExpect(status().isNoContent());
+
+        verify(mockExamPrintRequestService).insert(any());
+    }
+}


### PR DESCRIPTION
[TDS-711] This PR is for creating an endpoint for creating exam print and emboss requests. The student application will call this endpoint whenever a student select to print or emboss a passage or item, or if the auto-embossing accommodation is enabled. The proctor application will consume these requests and decide whether to allow or deny a print request for a student.  

- For testing purposes, and because it will be required later, I have added the ExamPrintRequestQueryRepository/Impl classes and a method to read the counts of unfulfilled requests for a session and list of examIds. 