### PR TITLE
Bugfix/waiting for segment fix

### DIFF
--- a/service/src/main/java/tds/exam/services/impl/ExamServiceImpl.java
+++ b/service/src/main/java/tds/exam/services/impl/ExamServiceImpl.java
@@ -453,6 +453,7 @@ class ExamServiceImpl implements ExamService {
             .withExpiresAt(now)
             .withRestartsAndResumptions(0)
             .withMaxItems(testLength)
+            .withWaitingForSegmentApproval(false)
             .build();
 
         updateExam(exam, initializedExam);
@@ -561,6 +562,7 @@ class ExamServiceImpl implements ExamService {
             .withAssessmentWindowId(assessmentWindow.getWindowId())
             .withEnvironment(externalSessionConfiguration.getEnvironment())
             .withSubject(assessment.getSubject())
+            .withWaitingForSegmentApproval(true)
             .build();
 
         examCommandRepository.insert(exam);

--- a/service/src/test/java/tds/exam/services/impl/ExamServiceImplTest.java
+++ b/service/src/test/java/tds/exam/services/impl/ExamServiceImplTest.java
@@ -345,6 +345,7 @@ public class ExamServiceImplTest {
         assertThat(exam.getEnvironment()).isEqualTo(extSessionConfig.getEnvironment());
         assertThat(exam.getStatus().getCode()).isEqualTo(STATUS_PENDING);
         assertThat(exam.getSubject()).isEqualTo(assessment.getSubject());
+        assertThat(exam.isWaitingForSegmentApproval()).isTrue();
     }
 
     @Test(expected = IllegalStateException.class)
@@ -1145,6 +1146,7 @@ public class ExamServiceImplTest {
         assertThat(updatedExam.getStatus().getStage()).isEqualTo(ExamStatusStage.IN_PROGRESS);
         assertThat(updatedExam.getStatus().getCode()).isEqualTo(ExamStatusCode.STATUS_STARTED);
         assertThat(updatedExam.getStatusChangedAt()).isGreaterThan(approvedStatusDate);
+        assertThat(updatedExam.isWaitingForSegmentApproval()).isFalse();
     }
 
     @Test


### PR DESCRIPTION
When opening an exam in legacy it sets the waiting for segment approval to true in StudentDLL._OpenNewOpportunity_SP() line 7059

```
    final String SQL_QUERY5 = "insert into testopportunity (_key, _version, clientname, _efk_Testee, _efk_TestID, Opportunity, "
        + "     Status,  Subject, TesteeID, TesteeName, _fk_Browser, DateChanged,  ReportingID,  windowID,"
        + "     mode, isSegmented, algorithm,_efk_AdminSubject, environment, SessID, ProctorName, waitingForSegment, datejoined) "
        + " select ${testoppkey}, ${version}, ${clientname}, ${testee}, ${testID}, ${opportunity},  "
        + "        'paused', ${subject}, ${testeeID}, ${testeeName}, ${browserKey}, ${today}, ${newID}, ${windowID}, "
        + "         ${mode}, ${segmented}, ${algorithm}, ${testkey}, ${environment}, SessionID, ProctorName, 1, now(3)"
        + " from session where _Key = ${sessionKey}";
```

When starting an exam in legacy it sets the waiting for segment approval to false in StudentDLL.T_StartTestOpportunity_SP() line 5403

```
    final String SQL_UPDATE1 = "update testopportunity set prevStatus = status,  status = ${started}, Restart = ${rcnt} + 1, DateRestarted = ${now}, DateChanged = ${now},"
        + " GracePeriodRestarts = ${gpRestarts}, maxitems = ${testlength}, waitingForSegment = null where _key = ${oppkey}";
```