### PR TITLE
Bugfix/student default accommodations

### DIFF
--- a/service/src/main/java/tds/exam/services/ExamAccommodationService.java
+++ b/service/src/main/java/tds/exam/services/ExamAccommodationService.java
@@ -36,16 +36,9 @@ public interface ExamAccommodationService {
      * Initializes and inserts exam accommodations for the exam;
      *
      * @param exam exam to use to initialize the {@link tds.exam.ExamAccommodation}
+     * @param studentAccommodationCodes the separated list of accommodations from the student package retrieved from ART
      */
-    List<ExamAccommodation> initializeExamAccommodations(Exam exam);
-
-    /**
-     * Initializes and inserts exam accommodations for the exam;
-     *
-     * @param exam exam to use to initialize the {@link tds.exam.ExamAccommodation}
-     * @param studentAccommodations the separated list of accommodations from the student package retrieved from ART
-     */
-    List<ExamAccommodation> initializeExamAccommodations(Exam exam, String studentAccommodations);
+    List<ExamAccommodation> initializeExamAccommodations(Exam exam, String studentAccommodationCodes);
 
     /**
      * Finds the approved {@link tds.exam.ExamAccommodation}
@@ -62,11 +55,11 @@ public interface ExamAccommodationService {
      * @param assessment          {@link tds.assessment.Assessment}
      * @param segmentPosition     the segment position for the accommodations
      * @param restoreRts          {@code true} if the restore rts
-     * @param guestAccommodations the guest accommodations String
+     * @param studentAccommodationCodes the student accommodations String
      *
      * @return list of {@link tds.exam.ExamAccommodation}
      */
-    List<ExamAccommodation> initializeAccommodationsOnPreviousExam(Exam exam, Assessment assessment, int segmentPosition, boolean restoreRts, String guestAccommodations);
+    List<ExamAccommodation> initializeAccommodationsOnPreviousExam(Exam exam, Assessment assessment, int segmentPosition, boolean restoreRts, String studentAccommodationCodes);
     
     /**
      * Approves {@link tds.exam.ExamAccommodation}s for an exam and set of accommodation codes.

--- a/service/src/main/java/tds/exam/services/ExamAccommodationService.java
+++ b/service/src/main/java/tds/exam/services/ExamAccommodationService.java
@@ -40,6 +40,14 @@ public interface ExamAccommodationService {
     List<ExamAccommodation> initializeExamAccommodations(Exam exam);
 
     /**
+     * Initializes and inserts exam accommodations for the exam;
+     *
+     * @param exam exam to use to initialize the {@link tds.exam.ExamAccommodation}
+     * @param studentAccommodations the separated list of accommodations from the student package retrieved from ART
+     */
+    List<ExamAccommodation> initializeExamAccommodations(Exam exam, String studentAccommodations);
+
+    /**
      * Finds the approved {@link tds.exam.ExamAccommodation}
      *
      * @param examIds the exam ids

--- a/service/src/main/java/tds/exam/services/impl/ExamAccommodationServiceImpl.java
+++ b/service/src/main/java/tds/exam/services/impl/ExamAccommodationServiceImpl.java
@@ -76,12 +76,6 @@ class ExamAccommodationServiceImpl implements ExamAccommodationService {
 
     @Transactional
     @Override
-    public List<ExamAccommodation> initializeExamAccommodations(final Exam exam) {
-        return initializeExamAccommodations(exam, "");
-    }
-
-    @Transactional
-    @Override
     public List<ExamAccommodation> initializeExamAccommodations(final Exam exam, final String studentAccommodationCodes) {
         Instant now = Instant.now();
         // This method replaces StudentDLL._InitOpportunityAccommodations_SP.  One note is that the calls to testopportunity_readonly were not implemented because
@@ -104,7 +98,7 @@ class ExamAccommodationServiceImpl implements ExamAccommodationService {
 
         // StudentDLL line 6645 - the query filters the results of the temporary table fetched above by these two values.
         // It was decided the record usage and report usage values that are also queried are not actually used.
-        // Do not include accommodations that are included in the student accommodations from the student package
+        // Exclude accommodations that are included in the student accommodations from the student package
         List<Accommodation> accommodations = assessmentAccommodations.stream().filter(
             accommodation ->
                 accommodation.isDefaultAccommodation()
@@ -149,7 +143,7 @@ class ExamAccommodationServiceImpl implements ExamAccommodationService {
                                                                           final Assessment assessment,
                                                                           final int segmentPosition,
                                                                           final boolean restoreRts,
-                                                                          final String guestAccommodations) {
+                                                                          final String studentAccommodationCodes) {
         /*
          This replaces the functionality of the following bits of code
          - StudentDLL 6834 - 6843
@@ -158,10 +152,10 @@ class ExamAccommodationServiceImpl implements ExamAccommodationService {
          */
         List<ExamAccommodation> examAccommodations = findAllAccommodations(exam.getId());
         if (examAccommodations.isEmpty()) {
-            examAccommodations = initializeExamAccommodations(exam);
+            examAccommodations = initializeExamAccommodations(exam, studentAccommodationCodes);
         } else {
             //CommonDLL line 2590 - gets the accommodation codes based on guest accommodations and the accommodation family for the assessment
-            Set<String> accommodationCodes = splitAccommodationCodes(assessment.getAccommodationFamily(), guestAccommodations);
+            Set<String> accommodationCodes = splitAccommodationCodes(assessment.getAccommodationFamily(), studentAccommodationCodes);
             examAccommodations = initializePreviousAccommodations(exam, segmentPosition, restoreRts, examAccommodations, accommodationCodes, false);
         }
 

--- a/service/src/main/java/tds/exam/services/impl/ExamServiceImpl.java
+++ b/service/src/main/java/tds/exam/services/impl/ExamServiceImpl.java
@@ -499,7 +499,7 @@ class ExamServiceImpl implements ExamService {
             examBuilder.withStatus(examStatusQueryRepository.findExamStatusCode(ExamStatusCode.STATUS_PENDING), org.joda.time.Instant.now());
         }
 
-        String guestAccommodations = openExamRequest.getGuestAccommodations();
+        String studentAccommodations = openExamRequest.getGuestAccommodations();
         if (openExamRequest.isGuestStudent()) {
             examBuilder.withStudentName("GUEST");
             examBuilder.withLoginSSID("GUEST");
@@ -511,8 +511,8 @@ class ExamServiceImpl implements ExamService {
                     examBuilder.withLoginSSID(attribute.getValue());
                 } else if (ENTITY_NAME.equals(attribute.getName())) {
                     examBuilder.withStudentName(attribute.getValue());
-                } else if (StringUtils.isEmpty(guestAccommodations) && ACCOMMODATIONS.equals(attribute.getName())) {
-                    guestAccommodations = attribute.getValue();
+                } else if (StringUtils.isEmpty(studentAccommodations) && ACCOMMODATIONS.equals(attribute.getName())) {
+                    studentAccommodations = attribute.getValue();
                 }
             }
         }
@@ -574,7 +574,7 @@ class ExamServiceImpl implements ExamService {
 
         //Lines 412 - 421 OpenTestServiceImpl is not implemented.  After talking with data warehouse and Smarter Balanced
         //The initial student attributes are not used and smarter balance suggested removing them
-        List<ExamAccommodation> examAccommodations = examAccommodationService.initializeExamAccommodations(exam);
+        List<ExamAccommodation> examAccommodations = examAccommodationService.initializeExamAccommodations(exam, studentAccommodations);
 
         exam = updateExamWithCustomAccommodations(exam, examAccommodations);
 

--- a/service/src/test/java/tds/exam/services/impl/ExamAccommodationServiceImplTest.java
+++ b/service/src/test/java/tds/exam/services/impl/ExamAccommodationServiceImplTest.java
@@ -167,7 +167,7 @@ public class ExamAccommodationServiceImplTest {
             .build();
 
         when(mockAssessmentService.findAssessmentAccommodationsByAssessmentKey(exam.getClientName(), exam.getAssessmentKey())).thenReturn(Arrays.asList(accommodation, nonDefaultAccommodation, dependsOnToolTypeAccommodation));
-        examAccommodationService.initializeExamAccommodations(exam);
+        examAccommodationService.initializeExamAccommodations(exam, "");
         verify(mockExamAccommodationCommandRepository).insert(examAccommodationInsertCaptor.capture());
 
         List<ExamAccommodation> accommodations = examAccommodationInsertCaptor.getValue();
@@ -175,6 +175,59 @@ public class ExamAccommodationServiceImplTest {
         ExamAccommodation examAccommodation = accommodations.get(0);
         assertThat(examAccommodation.getCode()).isEqualTo("code");
         assertThat(examAccommodation.getType()).isEqualTo("type");
+        assertThat(examAccommodation.getSegmentPosition()).isEqualTo(0);
+        assertThat(examAccommodation.getSegmentKey()).isEqualTo("segmentKey");
+    }
+
+    @Test
+    public void shouldInitializeExamAccommodationsWithStudentDefaults() {
+        Exam exam = new ExamBuilder()
+            .withSubject("MATH")
+            .build();
+
+        Accommodation englishAccommodation = new Accommodation.Builder()
+            .withAccommodationCode("ENU")
+            .withAccommodationType("Language")
+            .withSegmentKey("segmentKey")
+            .withSegmentPosition(0)
+            .withDefaultAccommodation(true)
+            .withDependsOnToolType(null)
+            .build();
+
+        Accommodation spanishAccommodation = new Accommodation.Builder()
+            .withAccommodationCode("ESN")
+            .withAccommodationType("Language")
+            .withSegmentKey("segmentKey")
+            .withSegmentPosition(0)
+            .withDefaultAccommodation(false)
+            .withDependsOnToolType(null)
+            .build();
+
+        Accommodation nonDefaultAccommodation = new Accommodation.Builder()
+            .withAccommodationCode("code1")
+            .withAccommodationType("type1")
+            .withDefaultAccommodation(false)
+            .withDependsOnToolType(null)
+            .build();
+
+        Accommodation dependsOnToolTypeAccommodation = new Accommodation.Builder()
+            .withAccommodationCode("code2")
+            .withAccommodationType("type2")
+            .withDefaultAccommodation(true)
+            .withDependsOnToolType("dependingSoCool")
+            .build();
+
+        String studentAccommodationCodes = "MATH:ESN;MATH:TDS_CC0;ELA:ENU";
+
+        when(mockAssessmentService.findAssessmentAccommodationsByAssessmentKey(exam.getClientName(), exam.getAssessmentKey())).thenReturn(Arrays.asList(englishAccommodation, spanishAccommodation, nonDefaultAccommodation, dependsOnToolTypeAccommodation));
+        examAccommodationService.initializeExamAccommodations(exam, studentAccommodationCodes);
+        verify(mockExamAccommodationCommandRepository).insert(examAccommodationInsertCaptor.capture());
+
+        List<ExamAccommodation> accommodations = examAccommodationInsertCaptor.getValue();
+        assertThat(accommodations).hasSize(1);
+        ExamAccommodation examAccommodation = accommodations.get(0);
+        assertThat(examAccommodation.getCode()).isEqualTo("ESN");
+        assertThat(examAccommodation.getType()).isEqualTo("Language");
         assertThat(examAccommodation.getSegmentPosition()).isEqualTo(0);
         assertThat(examAccommodation.getSegmentKey()).isEqualTo("segmentKey");
     }

--- a/service/src/test/java/tds/exam/services/impl/ExamServiceImplTest.java
+++ b/service/src/test/java/tds/exam/services/impl/ExamServiceImplTest.java
@@ -79,6 +79,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.Matchers.any;
 import static org.mockito.Matchers.eq;
 import static org.mockito.Matchers.isA;
+import static org.mockito.Matchers.isNull;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
@@ -456,6 +457,7 @@ public class ExamServiceImplTest {
 
         RtsStudentPackageAttribute externalIdAttribute = new RtsStudentPackageAttribute(EXTERNAL_ID, "External Id");
         RtsStudentPackageAttribute entityNameAttribute = new RtsStudentPackageAttribute(ENTITY_NAME, "Entity Id");
+        RtsStudentPackageAttribute entityAccommodationAttribute = new RtsStudentPackageAttribute(ACCOMMODATIONS, "MATH:Code1;ELA:Code2");
 
         TimeLimitConfiguration configuration = new TimeLimitConfiguration.Builder().withExamDelayDays(0).build();
 
@@ -465,7 +467,7 @@ public class ExamServiceImplTest {
         when(mockExamQueryRepository.getLastAvailableExam(openExamRequest.getStudentId(), assessment.getAssessmentId(), "SBAC_PT")).thenReturn(Optional.empty());
         when(mockSessionService.findExternalSessionConfigurationByClientName("SBAC_PT")).thenReturn(Optional.of(extSessionConfig));
         when(mockStudentService.findStudentPackageAttributes(openExamRequest.getStudentId(), "SBAC_PT", EXTERNAL_ID, ENTITY_NAME, ACCOMMODATIONS))
-            .thenReturn(Arrays.asList(externalIdAttribute, entityNameAttribute));
+            .thenReturn(Arrays.asList(externalIdAttribute, entityNameAttribute, entityAccommodationAttribute));
         when(mockAssessmentService.findAssessmentWindows(currentSession.getClientName(), assessment.getAssessmentId(), openExamRequest.getStudentId(), extSessionConfig))
             .thenReturn(Collections.singletonList(window));
         when(mockTimeLimitConfigurationService.findTimeLimitConfiguration("SBAC_PT", openExamRequest.getAssessmentKey())).thenReturn(Optional.of(configuration));
@@ -473,7 +475,7 @@ public class ExamServiceImplTest {
 
         Response<Exam> examResponse = examService.openExam(openExamRequest);
         verify(mockExamCommandRepository).insert(isA(Exam.class));
-        verify(mockExamAccommodationService).initializeExamAccommodations(isA(Exam.class));
+        verify(mockExamAccommodationService).initializeExamAccommodations(isA(Exam.class), isA(String.class));
         verify(mockExamineeService).insertAttributesAndRelationships(isA(Exam.class), isA(Student.class), isA(ExamineeContext.class));
 
         assertThat(examResponse.hasError()).isFalse();
@@ -506,6 +508,7 @@ public class ExamServiceImplTest {
 
         RtsStudentPackageAttribute externalIdAttribute = new RtsStudentPackageAttribute(EXTERNAL_ID, "External Id");
         RtsStudentPackageAttribute entityNameAttribute = new RtsStudentPackageAttribute(ENTITY_NAME, "Entity Id");
+        RtsStudentPackageAttribute entityAccommodationsAttribute = new RtsStudentPackageAttribute(ACCOMMODATIONS, "MATH:CODE1;ELA:CODE2");
 
         TimeLimitConfiguration configuration = new TimeLimitConfiguration.Builder().withExamDelayDays(0).build();
 
@@ -519,16 +522,16 @@ public class ExamServiceImplTest {
         when(mockExamQueryRepository.getLastAvailableExam(openExamRequest.getStudentId(), assessment.getAssessmentId(), "SBAC_PT")).thenReturn(Optional.empty());
         when(mockSessionService.findExternalSessionConfigurationByClientName("SBAC_PT")).thenReturn(Optional.of(extSessionConfig));
         when(mockStudentService.findStudentPackageAttributes(openExamRequest.getStudentId(), "SBAC_PT", EXTERNAL_ID, ENTITY_NAME, ACCOMMODATIONS))
-            .thenReturn(Arrays.asList(externalIdAttribute, entityNameAttribute));
+            .thenReturn(Arrays.asList(externalIdAttribute, entityNameAttribute, entityAccommodationsAttribute));
         when(mockAssessmentService.findAssessmentWindows(currentSession.getClientName(), assessment.getAssessmentId(), openExamRequest.getStudentId(), extSessionConfig))
             .thenReturn(Collections.singletonList(window));
         when(mockTimeLimitConfigurationService.findTimeLimitConfiguration("SBAC_PT", openExamRequest.getAssessmentKey())).thenReturn(Optional.of(configuration));
         when(mockExamStatusQueryRepository.findExamStatusCode(STATUS_PENDING)).thenReturn(new ExamStatusCode(STATUS_PENDING, OPEN));
-        when(mockExamAccommodationService.initializeExamAccommodations(isA(Exam.class))).thenReturn(Collections.singletonList(customExamAccommodation));
+        when(mockExamAccommodationService.initializeExamAccommodations(isA(Exam.class), isA(String.class))).thenReturn(Collections.singletonList(customExamAccommodation));
 
         Response<Exam> examResponse = examService.openExam(openExamRequest);
         verify(mockExamCommandRepository).insert(isA(Exam.class));
-        verify(mockExamAccommodationService).initializeExamAccommodations(isA(Exam.class));
+        verify(mockExamAccommodationService).initializeExamAccommodations(isA(Exam.class), isA(String.class));
         verify(mockExamineeService).insertAttributesAndRelationships(isA(Exam.class), isA(Student.class), isA(ExamineeContext.class));
 
         assertThat(examResponse.hasError()).isFalse();


### PR DESCRIPTION
Fixed bug TDS-740 where the student accommodations from ART are not being respected.

Student codes are now passed into initializeExamAccommodations so that the student accommodations are always used then the default assessment accommodations from the database are included for other accommodation types. 

Also, renamed `guestAccommodations` to `studentAccommodation` since it can be either guest or student accommodations from ART.

Since I'll be gone tomorrow, I'm going to merge this later tonight in a couple hours.