### PR TITLE
Wait for segment approval endpoint/service

### DIFF
--- a/client/src/main/java/tds/exam/Exam.java
+++ b/client/src/main/java/tds/exam/Exam.java
@@ -39,7 +39,7 @@ public class Exam {
     private String languageCode;
     private boolean segmented;
     private int abnormalStarts;
-    private boolean waitingForSegmentApproval;
+    private int waitingForSegmentApprovalPosition;
     private int currentSegmentPosition;
     private boolean customAccommodations;
     private int resumptions;
@@ -81,7 +81,7 @@ public class Exam {
         private String languageCode;
         private boolean segmented;
         private int abnormalStarts;
-        private boolean waitingForSegmentApproval;
+        private int waitingForSegmentApprovalPosition;
         private int currentSegmentPosition;
         private boolean customAccommodations;
         private int resumptions;
@@ -226,8 +226,8 @@ public class Exam {
             return this;
         }
 
-        public Builder withWaitingForSegmentApproval(boolean waitingForSegmentApproval) {
-            this.waitingForSegmentApproval = waitingForSegmentApproval;
+        public Builder withWaitingForSegmentApprovalPosition(int waitingForSegmentApprovalPosition) {
+            this.waitingForSegmentApprovalPosition = waitingForSegmentApprovalPosition;
             return this;
         }
 
@@ -285,7 +285,7 @@ public class Exam {
             environment = exam.environment;
             segmented = exam.segmented;
             abnormalStarts = exam.abnormalStarts;
-            waitingForSegmentApproval = exam.waitingForSegmentApproval;
+            waitingForSegmentApprovalPosition = exam.waitingForSegmentApprovalPosition;
             currentSegmentPosition = exam.currentSegmentPosition;
             languageCode = exam.languageCode;
             customAccommodations = exam.isCustomAccommodations();
@@ -328,7 +328,7 @@ public class Exam {
         environment = builder.environment;
         segmented = builder.segmented;
         abnormalStarts = builder.abnormalStarts;
-        waitingForSegmentApproval = builder.waitingForSegmentApproval;
+        waitingForSegmentApprovalPosition = builder.waitingForSegmentApprovalPosition;
         currentSegmentPosition = builder.currentSegmentPosition;
         customAccommodations = builder.customAccommodations;
         languageCode = builder.languageCode;
@@ -547,8 +547,8 @@ public class Exam {
     /**
      * @return {@code true} when approval is required before the student can move onto the next segment
      */
-    public boolean isWaitingForSegmentApproval() {
-        return waitingForSegmentApproval;
+    public int getWaitingForSegmentApprovalPosition() {
+        return waitingForSegmentApprovalPosition;
     }
 
     /**

--- a/client/src/main/java/tds/exam/SegmentApprovalRequest.java
+++ b/client/src/main/java/tds/exam/SegmentApprovalRequest.java
@@ -1,0 +1,51 @@
+package tds.exam;
+
+import java.util.UUID;
+
+/**
+ * A request to wait for a segment approval
+ */
+public class SegmentApprovalRequest {
+    private UUID sessionId;
+    private UUID browserId;
+    private int segmentPosition;
+    private boolean entryApproval;
+
+    private SegmentApprovalRequest() {
+    }
+
+    public SegmentApprovalRequest(final UUID sessionId, final UUID browserId, final int segmentPosition, final boolean entryApproval) {
+      this.sessionId = sessionId;
+      this.browserId = browserId;
+      this.segmentPosition = segmentPosition;
+      this.entryApproval = entryApproval;
+    }
+
+    /**
+     * @return The session id of the exam requesting segment approval
+     */
+    public UUID getSessionId() {
+        return sessionId;
+    }
+
+    /**
+     * @return The browser id of the exam requesting segment approval
+     */
+    public UUID getBrowserId() {
+        return browserId;
+    }
+
+    /**
+     * @return The position of the exam segment to seek entry/exit approval for
+     */
+    public int getSegmentPosition() {
+        return segmentPosition;
+    }
+
+    /**
+     * @return If {@code true}, this is an entry approval request. If {@code false} this is an exit segment approval request
+     */
+    public boolean isEntryApproval() {
+        return entryApproval;
+    }
+}

--- a/service/src/main/java/tds/exam/repositories/impl/ExamCommandRepositoryImpl.java
+++ b/service/src/main/java/tds/exam/repositories/impl/ExamCommandRepositoryImpl.java
@@ -101,7 +101,7 @@ class ExamCommandRepositoryImpl implements ExamCommandRepository {
                 .addValue("scoredAt", mapJodaInstantToTimestamp(exam.getScoredAt()))
                 .addValue("expiresAt", mapJodaInstantToTimestamp(exam.getExpiresAt()))
                 .addValue("abnormalStarts", exam.getAbnormalStarts())
-                .addValue("waitingForSegmentApproval", exam.isWaitingForSegmentApproval())
+                .addValue("waitingForSegmentApprovalPosition", exam.getWaitingForSegmentApprovalPosition())
                 .addValue("currentSegmentPosition", exam.getCurrentSegmentPosition())
                 .addValue("customAccommodations", exam.isCustomAccommodations())
                 .addValue("startedAt", mapJodaInstantToTimestamp(exam.getStartedAt())))
@@ -124,7 +124,7 @@ class ExamCommandRepositoryImpl implements ExamCommandRepository {
                 "completed_at, \n" +
                 "scored_at, \n" +
                 "started_at, \n" +
-                "waiting_for_segment_approval, \n" +
+                "waiting_for_segment_approval_position, \n" +
                 "current_segment_position, \n" +
                 "custom_accommodations, \n" +
                 "abnormal_starts \n" +
@@ -146,7 +146,7 @@ class ExamCommandRepositoryImpl implements ExamCommandRepository {
                 ":completedAt, \n" +
                 ":scoredAt, \n" +
                 ":startedAt, \n" +
-                ":waitingForSegmentApproval,\n" +
+                ":waitingForSegmentApprovalPosition,\n" +
                 ":currentSegmentPosition, \n" +
                 ":customAccommodations, \n" +
                 ":abnormalStarts \n" +

--- a/service/src/main/java/tds/exam/repositories/impl/ExamQueryRepositoryImpl.java
+++ b/service/src/main/java/tds/exam/repositories/impl/ExamQueryRepositoryImpl.java
@@ -69,7 +69,7 @@ public class ExamQueryRepositoryImpl implements ExamQueryRepository {
         "ee.started_at, \n" +
         "ee.scored_at, \n" +
         "ee.abnormal_starts, \n" +
-        "ee.waiting_for_segment_approval, \n" +
+        "ee.waiting_for_segment_approval_position, \n" +
         "ee.current_segment_position, \n" +
         "ee.custom_accommodations, \n" +
         "e.created_at, \n" +
@@ -446,7 +446,7 @@ public class ExamQueryRepositoryImpl implements ExamQueryRepository {
                 ), mapTimestampToJodaInstant(rs, "status_changed_at"))
                 .withStatusChangeReason(rs.getString("status_change_reason"))
                 .withAbnormalStarts(rs.getInt("abnormal_starts"))
-                .withWaitingForSegmentApproval(rs.getBoolean("waiting_for_segment_approval"))
+                .withWaitingForSegmentApprovalPosition(rs.getInt("waiting_for_segment_approval_position"))
                 .withCurrentSegmentPosition(rs.getInt("current_segment_position"))
                 .withCustomAccommodation(rs.getBoolean("custom_accommodations"))
                 .build();

--- a/service/src/main/java/tds/exam/services/ExamService.java
+++ b/service/src/main/java/tds/exam/services/ExamService.java
@@ -13,6 +13,7 @@ import tds.exam.ExamConfiguration;
 import tds.exam.ExamStatusCode;
 import tds.exam.ExpandableExam;
 import tds.exam.OpenExamRequest;
+import tds.exam.SegmentApprovalRequest;
 
 /**
  * Main entry point for interacting with {@link Exam}
@@ -55,11 +56,24 @@ public interface ExamService {
     /**
      * Change the {@link tds.exam.Exam}'s status to a new status.
      *
+     * @param examId                    The id of the exam whose status is being changed
+     * @param newStatus                 The {@link tds.exam.ExamStatusCode} to transition to
+     * @param statusChangeReason        The reason why the {@link tds.exam.Exam} status is being updated
+     * @param waitingForSegmentPosition The position of the exam segment to pause for approval
+     * @return {@code Optional<ValidationError>} if the {@link tds.exam.Exam} cannot be updated from its current status
+     * to the new status; otherwise {@code Optional.empty()}.
+     */
+    Optional<ValidationError> updateExamStatus(final UUID examId, final ExamStatusCode newStatus, final String statusChangeReason,
+                                               final int waitingForSegmentPosition);
+
+    /**
+     * Change the {@link tds.exam.Exam}'s status to a new status.
+     *
      * @param examId             The id of the exam whose status is being changed
      * @param newStatus          The {@link tds.exam.ExamStatusCode} to transition to
      * @param statusChangeReason The reason why the {@link tds.exam.Exam} status is being updated
      * @return {@code Optional<ValidationError>} if the {@link tds.exam.Exam} cannot be updated from its current status
-     * to the new status; otherwise {@code Optional.empty()}.\
+     * to the new status; otherwise {@code Optional.empty()}.
      */
     Optional<ValidationError> updateExamStatus(final UUID examId, final ExamStatusCode newStatus, final String statusChangeReason);
 
@@ -69,7 +83,7 @@ public interface ExamService {
      * @param examId    The id of the exam whose status is being changed
      * @param newStatus The {@link tds.exam.ExamStatusCode} to transition to
      * @return {@code Optional<ValidationError>} if the {@link tds.exam.Exam} cannot be updated from its current status
-     * to the new status; otherwise {@code Optional.empty()}.\
+     * to the new status; otherwise {@code Optional.empty()}.
      */
     Optional<ValidationError> updateExamStatus(final UUID examId, final ExamStatusCode newStatus);
 
@@ -89,4 +103,14 @@ public interface ExamService {
      * @return a list of {@link tds.exam.ExpandableExam}s in the session
      */
     List<ExpandableExam> findExamsBySessionId(final UUID sessionId, final Set<String> invalidStatuses, final String... expandableParams);
+
+    /**
+     * Performs exam access validation and updates the {@link Exam} status to wait for segment approval.
+     *
+     * @param examId The id of the exam seeking segment approval
+     * @param request A request object containing data related to the segment approval request
+     * @return {@code Optional<ValidationError>} if the {@link tds.exam.Exam} cannot be updated from its current status
+     * to the new status of if the approval request fails.
+     */
+    Optional<ValidationError> waitForSegmentApproval(UUID examId, SegmentApprovalRequest request);
 }

--- a/service/src/main/java/tds/exam/services/ExamService.java
+++ b/service/src/main/java/tds/exam/services/ExamService.java
@@ -56,19 +56,6 @@ public interface ExamService {
     /**
      * Change the {@link tds.exam.Exam}'s status to a new status.
      *
-     * @param examId                    The id of the exam whose status is being changed
-     * @param newStatus                 The {@link tds.exam.ExamStatusCode} to transition to
-     * @param statusChangeReason        The reason why the {@link tds.exam.Exam} status is being updated
-     * @param waitingForSegmentPosition The position of the exam segment to pause for approval
-     * @return {@code Optional<ValidationError>} if the {@link tds.exam.Exam} cannot be updated from its current status
-     * to the new status; otherwise {@code Optional.empty()}.
-     */
-    Optional<ValidationError> updateExamStatus(final UUID examId, final ExamStatusCode newStatus, final String statusChangeReason,
-                                               final int waitingForSegmentPosition);
-
-    /**
-     * Change the {@link tds.exam.Exam}'s status to a new status.
-     *
      * @param examId             The id of the exam whose status is being changed
      * @param newStatus          The {@link tds.exam.ExamStatusCode} to transition to
      * @param statusChangeReason The reason why the {@link tds.exam.Exam} status is being updated

--- a/service/src/main/java/tds/exam/services/impl/ExamServiceImpl.java
+++ b/service/src/main/java/tds/exam/services/impl/ExamServiceImpl.java
@@ -269,20 +269,18 @@ class ExamServiceImpl implements ExamService {
         return ability;
     }
 
-    @Transactional
     @Override
     public Optional<ValidationError> updateExamStatus(final UUID examId, final ExamStatusCode newStatus) {
         return updateExamStatus(examId, newStatus, null);
     }
 
-    @Transactional
     @Override
     public Optional<ValidationError> updateExamStatus(final UUID examId, final ExamStatusCode newStatus, final String statusChangeReason) {
         return updateExamStatus(examId, newStatus, statusChangeReason, -1);
     }
 
-    @Override
-    public Optional<ValidationError> updateExamStatus(final UUID examId, final ExamStatusCode newStatus, final String statusChangeReason,
+    @Transactional
+    private Optional<ValidationError> updateExamStatus(final UUID examId, final ExamStatusCode newStatus, final String statusChangeReason,
                                                       final int waitingForSegmentPosition) {
         Exam exam = examQueryRepository.getExamById(examId)
             .orElseThrow(() -> new NotFoundException(String.format("Exam could not be found for id %s", examId)));

--- a/service/src/main/java/tds/exam/services/impl/ExamServiceImpl.java
+++ b/service/src/main/java/tds/exam/services/impl/ExamServiceImpl.java
@@ -33,6 +33,7 @@ import tds.config.ClientSystemFlag;
 import tds.config.TimeLimitConfiguration;
 import tds.exam.Exam;
 import tds.exam.ExamAccommodation;
+import tds.exam.ExamApproval;
 import tds.exam.ExamConfiguration;
 import tds.exam.ExamInfo;
 import tds.exam.ExamStatusCode;
@@ -40,6 +41,7 @@ import tds.exam.ExamStatusStage;
 import tds.exam.ExamineeContext;
 import tds.exam.ExpandableExam;
 import tds.exam.OpenExamRequest;
+import tds.exam.SegmentApprovalRequest;
 import tds.exam.error.ValidationErrorCode;
 import tds.exam.models.Ability;
 import tds.exam.repositories.ExamCommandRepository;
@@ -52,7 +54,6 @@ import tds.exam.services.ExamAccommodationService;
 import tds.exam.services.ExamApprovalService;
 import tds.exam.services.ExamItemService;
 import tds.exam.services.ExamPageService;
-import tds.exam.services.ExamPrintRequestService;
 import tds.exam.services.ExamSegmentService;
 import tds.exam.services.ExamService;
 import tds.exam.services.ExamineeService;
@@ -277,6 +278,12 @@ class ExamServiceImpl implements ExamService {
     @Transactional
     @Override
     public Optional<ValidationError> updateExamStatus(final UUID examId, final ExamStatusCode newStatus, final String statusChangeReason) {
+        return updateExamStatus(examId, newStatus, statusChangeReason, -1);
+    }
+
+    @Override
+    public Optional<ValidationError> updateExamStatus(final UUID examId, final ExamStatusCode newStatus, final String statusChangeReason,
+                                                      final int waitingForSegmentPosition) {
         Exam exam = examQueryRepository.getExamById(examId)
             .orElseThrow(() -> new NotFoundException(String.format("Exam could not be found for id %s", examId)));
 
@@ -289,6 +296,7 @@ class ExamServiceImpl implements ExamService {
             .fromExam(exam)
             .withStatus(newStatus, org.joda.time.Instant.now())
             .withStatusChangeReason(statusChangeReason)
+            .withWaitingForSegmentApprovalPosition(waitingForSegmentPosition)
             .build();
 
         updateExam(exam, updatedExam);
@@ -336,6 +344,28 @@ class ExamServiceImpl implements ExamService {
         return examBuilders.values().stream()
             .map(builders -> builders.build())
             .collect(Collectors.toList());
+    }
+
+    @Override
+    public Optional<ValidationError> waitForSegmentApproval(final UUID examId, final SegmentApprovalRequest request) {
+        Response<ExamApproval> approvalResponse = examApprovalService.getApproval(new ExamInfo(examId, request.getSessionId(), request.getBrowserId()));
+
+        if (approvalResponse.getError().isPresent()) {
+            return Optional.of(approvalResponse.getError().get());
+        }
+
+        Optional<ValidationError> maybeError;
+
+        /* StudentDLL - T_WaitForSegment_SP lines [1859 - 1864] + 1876*/
+        if (request.isEntryApproval()) {
+            maybeError = updateExamStatus(examId, new ExamStatusCode(ExamStatusCode.STATUS_SEGMENT_ENTRY), null,
+                request.getSegmentPosition());
+        } else {
+            maybeError = updateExamStatus(examId, new ExamStatusCode(ExamStatusCode.STATUS_SEGMENT_EXIT), null,
+                request.getSegmentPosition());
+        }
+
+        return maybeError;
     }
 
     @Transactional
@@ -453,7 +483,7 @@ class ExamServiceImpl implements ExamService {
             .withExpiresAt(now)
             .withRestartsAndResumptions(0)
             .withMaxItems(testLength)
-            .withWaitingForSegmentApproval(false)
+            .withWaitingForSegmentApprovalPosition(-1)
             .build();
 
         updateExam(exam, initializedExam);
@@ -562,7 +592,7 @@ class ExamServiceImpl implements ExamService {
             .withAssessmentWindowId(assessmentWindow.getWindowId())
             .withEnvironment(externalSessionConfiguration.getEnvironment())
             .withSubject(assessment.getSubject())
-            .withWaitingForSegmentApproval(true)
+            .withWaitingForSegmentApprovalPosition(1)
             .build();
 
         examCommandRepository.insert(exam);

--- a/service/src/main/java/tds/exam/utils/StatusTransitionValidator.java
+++ b/service/src/main/java/tds/exam/utils/StatusTransitionValidator.java
@@ -44,8 +44,8 @@ public class StatusTransitionValidator {
             ExamStatusCode.STATUS_COMPLETED,
             ExamStatusCode.STATUS_EXPIRED,
             ExamStatusCode.STATUS_INVALIDATED,
-            ExamStatusCode.STATUS_SEGMENT_ENTRY,
-            ExamStatusCode.STATUS_SEGMENT_EXIT,
+            ExamStatusCode.STATUS_SEGMENT_ENTRY.toLowerCase(),
+            ExamStatusCode.STATUS_SEGMENT_EXIT.toLowerCase(),
             ExamStatusCode.STATUS_FORCE_COMPLETED
         ))
         .put(ExamStatusCode.STATUS_APPROVED.toLowerCase(), Sets.newHashSet(
@@ -64,8 +64,8 @@ public class StatusTransitionValidator {
             ExamStatusCode.STATUS_EXPIRED,
             ExamStatusCode.STATUS_INVALIDATED,
             ExamStatusCode.STATUS_FORCE_COMPLETED,
-            ExamStatusCode.STATUS_SEGMENT_ENTRY,
-            ExamStatusCode.STATUS_SEGMENT_EXIT
+            ExamStatusCode.STATUS_SEGMENT_ENTRY.toLowerCase(),
+            ExamStatusCode.STATUS_SEGMENT_EXIT.toLowerCase()
         ))
         .put(ExamStatusCode.STATUS_PAUSED.toLowerCase(), Sets.newHashSet(
             ExamStatusCode.STATUS_PAUSED,

--- a/service/src/main/resources/db/migration/V1488580873__exam_update_column_exam_event_waiting_for_segment_approval_int.sql
+++ b/service/src/main/resources/db/migration/V1488580873__exam_update_column_exam_event_waiting_for_segment_approval_int.sql
@@ -1,0 +1,11 @@
+/***********************************************************************************************************************
+  File: V1488580873__exam_update_column_exam_event_waiting_for_segment_approval_int.sql
+
+  Desc: Updates the waiting_for_segment_approval column from a BIT to INT and renames it.
+  This column stores a segment position of the segment waiting for approval.
+
+***********************************************************************************************************************/
+USE exam;
+
+ALTER TABLE exam.exam_event
+    CHANGE waiting_for_segment_approval waiting_for_segment_approval_position INT DEFAULT -1;

--- a/service/src/test/java/tds/exam/builder/ExamBuilder.java
+++ b/service/src/test/java/tds/exam/builder/ExamBuilder.java
@@ -42,7 +42,7 @@ public class ExamBuilder {
     private String languageCode = "ENU";
     private boolean segmented = false;
     private int abnormalStarts = 1;
-    private boolean waitingForSegmentApproval = false;
+    private int waitingForSegmentApprovalPosition = -1;
     private int currentSegmentPosition = 1;
     private boolean customAccommodations = true;
     private String language = "English";
@@ -77,7 +77,7 @@ public class ExamBuilder {
             .withAbnormalStarts(abnormalStarts)
             .withLanguageCode(languageCode)
             .withExpiresAt(expiresAt)
-            .withWaitingForSegmentApproval(waitingForSegmentApproval)
+            .withWaitingForSegmentApprovalPosition(waitingForSegmentApprovalPosition)
             .withCurrentSegmentPosition(currentSegmentPosition)
             .withCustomAccommodation(customAccommodations)
             .withResumptions(resumptions)
@@ -214,8 +214,8 @@ public class ExamBuilder {
         return this;
     }
 
-    public ExamBuilder withWaitingForSegmentApproval(boolean waitingForSegmentApproval) {
-        this.waitingForSegmentApproval = waitingForSegmentApproval;
+    public ExamBuilder withWaitingForSegmentApproval(int waitingForSegmentApprovalPosition) {
+        this.waitingForSegmentApprovalPosition = waitingForSegmentApprovalPosition;
         return this;
     }
 

--- a/service/src/test/java/tds/exam/repositories/impl/ExamCommandRepositoryImplIntegrationTests.java
+++ b/service/src/test/java/tds/exam/repositories/impl/ExamCommandRepositoryImplIntegrationTests.java
@@ -92,7 +92,7 @@ public class ExamCommandRepositoryImplIntegrationTests {
         assertThat(savedExam.getLoginSSID()).isEqualTo(exam.getLoginSSID());
         assertThat(savedExam.getStatusChangeReason()).isEqualTo(exam.getStatusChangeReason());
         assertThat(savedExam.getAbnormalStarts()).isEqualTo(5);
-        assertThat(savedExam.isWaitingForSegmentApproval()).isEqualTo(exam.isWaitingForSegmentApproval());
+        assertThat(savedExam.getWaitingForSegmentApprovalPosition()).isEqualTo(exam.getWaitingForSegmentApprovalPosition());
         assertThat(savedExam.getCurrentSegmentPosition()).isEqualTo(exam.getCurrentSegmentPosition());
         assertThat(savedExam.isCustomAccommodations()).isEqualTo(exam.isCustomAccommodations());
     }

--- a/service/src/test/java/tds/exam/web/endpoints/ExamControllerIntegrationTests.java
+++ b/service/src/test/java/tds/exam/web/endpoints/ExamControllerIntegrationTests.java
@@ -239,6 +239,7 @@ public class ExamControllerIntegrationTests {
         http.perform(put(new URI(String.format("/exam/%s/segmentApproval/", examId)))
             .contentType(MediaType.APPLICATION_JSON)
             .content(ow.writeValueAsString(request)))
+            .andExpect(header().string("Location", String.format("http://localhost/exam/%s", examId)))
             .andExpect(status().isNoContent());
 
         verify(mockExamService).waitForSegmentApproval(eq(examId), any());
@@ -257,6 +258,7 @@ public class ExamControllerIntegrationTests {
             .contentType(MediaType.APPLICATION_JSON)
             .content(ow.writeValueAsString(request)))
             .andExpect(status().isUnprocessableEntity());
+
 
         verify(mockExamService).waitForSegmentApproval(eq(examId), any());
     }

--- a/service/src/test/java/tds/exam/web/endpoints/ExamControllerIntegrationTests.java
+++ b/service/src/test/java/tds/exam/web/endpoints/ExamControllerIntegrationTests.java
@@ -1,5 +1,7 @@
 package tds.exam.web.endpoints;
 
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.ObjectWriter;
 import com.google.common.collect.ImmutableSet;
 import org.junit.Test;
 import org.junit.runner.RunWith;
@@ -26,6 +28,7 @@ import tds.exam.Exam;
 import tds.exam.ExamStatusCode;
 import tds.exam.ExamStatusStage;
 import tds.exam.ExpandableExam;
+import tds.exam.SegmentApprovalRequest;
 import tds.exam.builder.ExamBuilder;
 import tds.exam.error.ValidationErrorCode;
 import tds.exam.services.ExamPageService;
@@ -58,6 +61,9 @@ public class ExamControllerIntegrationTests {
 
     @MockBean
     private ExamPageService mockExamPageService;
+
+    @Autowired
+    private ObjectMapper objectMapper;
 
     @Test
     public void shouldReturnExam() throws Exception {
@@ -219,5 +225,39 @@ public class ExamControllerIntegrationTests {
             .contentType(MediaType.APPLICATION_JSON))
             .andExpect(status().isInternalServerError());
 
+    }
+
+    @Test
+    public void shouldWaitForSegmentSuccessfully() throws Exception {
+        UUID examId = UUID.randomUUID();
+        SegmentApprovalRequest request = random(SegmentApprovalRequest.class);
+        when(mockExamService.waitForSegmentApproval(eq(examId), any())).thenReturn(Optional.empty());
+
+        ObjectWriter ow = objectMapper
+            .writer().withDefaultPrettyPrinter();
+
+        http.perform(put(new URI(String.format("/exam/%s/segmentApproval/", examId)))
+            .contentType(MediaType.APPLICATION_JSON)
+            .content(ow.writeValueAsString(request)))
+            .andExpect(status().isNoContent());
+
+        verify(mockExamService).waitForSegmentApproval(eq(examId), any());
+    }
+
+    @Test
+    public void shouldReturnErrorWaitForSegment() throws Exception {
+        UUID examId = UUID.randomUUID();
+        SegmentApprovalRequest request = random(SegmentApprovalRequest.class);
+        when(mockExamService.waitForSegmentApproval(eq(examId), any())).thenReturn(Optional.of(new ValidationError("some", "error")));
+
+        ObjectWriter ow = objectMapper
+            .writer().withDefaultPrettyPrinter();
+
+        http.perform(put(new URI(String.format("/exam/%s/segmentApproval/", examId)))
+            .contentType(MediaType.APPLICATION_JSON)
+            .content(ow.writeValueAsString(request)))
+            .andExpect(status().isUnprocessableEntity());
+
+        verify(mockExamService).waitForSegmentApproval(eq(examId), any());
     }
 }


### PR DESCRIPTION
This endpoint will be called by legacy student whenever approval is needed for segment entry or exit. A separate PR in TDS_Student will cover the changes to call this endpoint.

The entry point in the legacy for this port is in StudentDLL.T_WaitForSegment_SP, line 1840. This is called on the student side from OpportunityRepository.waitForSegment().
