### PR TITLE
Exit Segment endpoint

### DIFF
--- a/client/src/main/java/tds/exam/error/ValidationErrorCode.java
+++ b/client/src/main/java/tds/exam/error/ValidationErrorCode.java
@@ -27,4 +27,7 @@ public class ValidationErrorCode {
     public static final String EXAM_DOES_NOT_EXIST = "examDoesNotExist";
     public static final String EXAM_NOT_ENROLLED_IN_SESSION = "examNotEnrolledInSession";
     public static final String STUDENT_SELF_APPROVE_UNPROCTORED_SESSION = "studentSelfApproveUnproctoredSession";
+
+    // Exam Segments
+    public static final String EXAM_SEGMENT_DOES_NOT_EXIST = "examSegmentDoesNotExist";
 }

--- a/service/src/main/java/tds/exam/services/ExamSegmentService.java
+++ b/service/src/main/java/tds/exam/services/ExamSegmentService.java
@@ -1,10 +1,12 @@
 package tds.exam.services;
 
 import java.util.List;
+import java.util.Optional;
 import java.util.UUID;
 
 import tds.assessment.Assessment;
 import tds.common.Response;
+import tds.common.ValidationError;
 import tds.exam.Exam;
 import tds.exam.ExamSegment;
 
@@ -47,4 +49,12 @@ public interface ExamSegmentService {
      * @param examSegments The {@link tds.exam.ExamSegment}s to update
      */
     void update(final ExamSegment... examSegments);
+
+    /**
+     * Marks an {@link tds.exam.ExamSegment} as exited
+     *
+     * @param examId          The exam id of the {@link tds.exam.ExamSegment} to exit
+     * @param segmentPosition The segment position of the {@link tds.exam.ExamSegment} to exit
+     */
+    Optional<ValidationError> exitSegment(final UUID examId, final int segmentPosition);
 }

--- a/service/src/main/java/tds/exam/services/impl/ExamSegmentServiceImpl.java
+++ b/service/src/main/java/tds/exam/services/impl/ExamSegmentServiceImpl.java
@@ -38,22 +38,22 @@ import tds.exam.services.SegmentPoolService;
 
 @Service
 public class ExamSegmentServiceImpl implements ExamSegmentService {
-    private final ExamSegmentCommandRepository commandRepository;
-    private final ExamSegmentQueryRepository queryRepository;
+    private final ExamSegmentCommandRepository examSegmentCommandRepository;
+    private final ExamSegmentQueryRepository examSegmentQueryRepository;
     private final SegmentPoolService segmentPoolService;
     private final FormSelector formSelector;
     private final FieldTestService fieldTestService;
     private final ExamApprovalService examApprovalService;
 
     @Autowired
-    public ExamSegmentServiceImpl(final ExamSegmentCommandRepository commandRepository,
-                                  final ExamSegmentQueryRepository queryRepository,
+    public ExamSegmentServiceImpl(final ExamSegmentCommandRepository examSegmentCommandRepository,
+                                  final ExamSegmentQueryRepository examSegmentQueryRepository,
                                   final SegmentPoolService segmentPoolService,
                                   final FormSelector formSelector,
                                   final FieldTestService fieldTestService,
                                   final ExamApprovalService examApprovalService) {
-        this.commandRepository = commandRepository;
-        this.queryRepository = queryRepository;
+        this.examSegmentCommandRepository = examSegmentCommandRepository;
+        this.examSegmentQueryRepository = examSegmentQueryRepository;
         this.segmentPoolService = segmentPoolService;
         this.fieldTestService = fieldTestService;
         this.formSelector = formSelector;
@@ -163,7 +163,7 @@ public class ExamSegmentServiceImpl implements ExamSegmentService {
             throw new IllegalStateException("There are no items available in the item pool for any segment.");
         }
         /* Lines [4753-4764] */
-        commandRepository.insert(examSegments);
+        examSegmentCommandRepository.insert(examSegments);
 
         return totalItems;
     }
@@ -180,12 +180,12 @@ public class ExamSegmentServiceImpl implements ExamSegmentService {
             return new Response<>(approval.getError().get());
         }
 
-        return new Response<>(queryRepository.findByExamId(examId));
+        return new Response<>(examSegmentQueryRepository.findByExamId(examId));
     }
 
     @Override
     public Response<ExamSegment> findByExamIdAndSegmentPosition(final UUID examId, final int segmentPosition) {
-        ExamSegment segment = queryRepository.findByExamIdAndSegmentPosition(examId, segmentPosition)
+        ExamSegment segment = examSegmentQueryRepository.findByExamIdAndSegmentPosition(examId, segmentPosition)
             .orElseThrow(() -> new NotFoundException(String.format("Could not find an exam segment for exam id %s and segment position %d", examId, segmentPosition)));
 
         return new Response<>(segment);
@@ -193,12 +193,12 @@ public class ExamSegmentServiceImpl implements ExamSegmentService {
 
     @Override
     public void update(final ExamSegment... examSegments) {
-        commandRepository.update(Arrays.asList(examSegments));
+        examSegmentCommandRepository.update(Arrays.asList(examSegments));
     }
 
     @Override
     public Optional<ValidationError> exitSegment(final UUID examId, final int segmentPosition) {
-        Optional<ExamSegment> maybeExamSegment = queryRepository.findByExamIdAndSegmentPosition(examId, segmentPosition);
+        Optional<ExamSegment> maybeExamSegment = examSegmentQueryRepository.findByExamIdAndSegmentPosition(examId, segmentPosition);
 
         if (!maybeExamSegment.isPresent()) {
             return Optional.of(new ValidationError(ValidationErrorCode.EXAM_SEGMENT_DOES_NOT_EXIST, "The exam segment does not exist"));
@@ -209,7 +209,7 @@ public class ExamSegmentServiceImpl implements ExamSegmentService {
             .withExitedAt(Instant.now())
             .build();
 
-        commandRepository.update(updatedExamSegment);
+        examSegmentCommandRepository.update(updatedExamSegment);
 
         return Optional.empty();
     }

--- a/service/src/main/java/tds/exam/web/endpoints/ExamSegmentController.java
+++ b/service/src/main/java/tds/exam/web/endpoints/ExamSegmentController.java
@@ -1,8 +1,6 @@
 package tds.exam.web.endpoints;
 
 import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.hateoas.Link;
-import org.springframework.http.HttpHeaders;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.MediaType;
 import org.springframework.http.ResponseEntity;
@@ -21,9 +19,6 @@ import tds.common.ValidationError;
 import tds.common.web.resources.NoContentResponseResource;
 import tds.exam.ExamSegment;
 import tds.exam.services.ExamSegmentService;
-
-import static org.springframework.hateoas.mvc.ControllerLinkBuilder.linkTo;
-import static org.springframework.hateoas.mvc.ControllerLinkBuilder.methodOn;
 
 @RestController
 @RequestMapping("/exam/segments")
@@ -60,10 +55,6 @@ public class ExamSegmentController {
             return new ResponseEntity<>(response, HttpStatus.UNPROCESSABLE_ENTITY);
         }
 
-        Link link = linkTo(methodOn(ExamController.class).getExamById(examId)).withSelfRel();
-        final HttpHeaders headers = new HttpHeaders();
-        headers.add("Location", link.getHref());
-
-        return new ResponseEntity<>(headers, HttpStatus.NO_CONTENT);
+        return new ResponseEntity<>(HttpStatus.NO_CONTENT);
     }
 }

--- a/service/src/test/java/tds/exam/services/impl/ExamSegmentServiceImplTest.java
+++ b/service/src/test/java/tds/exam/services/impl/ExamSegmentServiceImplTest.java
@@ -1,6 +1,5 @@
 package tds.exam.services.impl;
 
-import org.assertj.core.api.Assertions;
 import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
@@ -33,6 +32,7 @@ import tds.exam.builder.ExamBuilder;
 import tds.exam.builder.ExamSegmentBuilder;
 import tds.exam.builder.ItemBuilder;
 import tds.exam.builder.SegmentBuilder;
+import tds.exam.error.ValidationErrorCode;
 import tds.exam.models.SegmentPoolInfo;
 import tds.exam.repositories.ExamSegmentCommandRepository;
 import tds.exam.repositories.ExamSegmentQueryRepository;
@@ -41,8 +41,10 @@ import tds.exam.services.FieldTestService;
 import tds.exam.services.FormSelector;
 import tds.exam.services.SegmentPoolService;
 
-import static org.assertj.core.api.Java6Assertions.assertThat;
+import static io.github.benas.randombeans.api.EnhancedRandom.random;
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.Matchers.any;
+import static org.mockito.Matchers.isA;
 import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
@@ -70,7 +72,10 @@ public class ExamSegmentServiceImplTest {
     private ExamApprovalService mockExamApprovalService;
 
     @Captor
-    private ArgumentCaptor<List<ExamSegment>> examSegmentCaptor;
+    private ArgumentCaptor<List<ExamSegment>> examSegmentsCaptor;
+
+    @Captor
+    private ArgumentCaptor<ExamSegment> examSegmentCaptor;
 
     @Before
     public void setUp() {
@@ -205,8 +210,8 @@ public class ExamSegmentServiceImplTest {
         verify(mockFieldTestService).isFieldTestEligible(exam, assessment, segment1.getKey());
         verify(mockFieldTestService).selectItemGroups(exam, assessment, segment1.getKey());
         verify(mockFormSelector).selectForm(segment2, language);
-        verify(mockExamSegmentCommandRepository).insert(examSegmentCaptor.capture());
-        List<ExamSegment> examSegments = examSegmentCaptor.getValue();
+        verify(mockExamSegmentCommandRepository).insert(examSegmentsCaptor.capture());
+        List<ExamSegment> examSegments = examSegmentsCaptor.getValue();
         assertThat(examSegments).hasSize(2);
 
         ExamSegment examSegment1 = null;
@@ -292,8 +297,8 @@ public class ExamSegmentServiceImplTest {
             language);
         verify(mockFieldTestService).isFieldTestEligible(exam, assessment, segment2.getKey());
 
-        verify(mockExamSegmentCommandRepository).insert(examSegmentCaptor.capture());
-        List<ExamSegment> examSegments = examSegmentCaptor.getValue();
+        verify(mockExamSegmentCommandRepository).insert(examSegmentsCaptor.capture());
+        List<ExamSegment> examSegments = examSegmentsCaptor.getValue();
 
         assertThat(examSegments).hasSize(2);
         Optional<ExamSegment> maybeExamSegment2 = examSegments.stream()
@@ -338,9 +343,9 @@ public class ExamSegmentServiceImplTest {
         when(mockFormSelector.selectForm(segment, language)).thenReturn(Optional.of(enuForm));
         int totalItems = examSegmentService.initializeExamSegments(exam, assessment);
         assertThat(totalItems).isEqualTo(enuForm.getLength());
-        verify(mockExamSegmentCommandRepository).insert(examSegmentCaptor.capture());
+        verify(mockExamSegmentCommandRepository).insert(examSegmentsCaptor.capture());
         verify(mockFormSelector).selectForm(segment, language);
-        List<ExamSegment> examSegments = examSegmentCaptor.getValue();
+        List<ExamSegment> examSegments = examSegmentsCaptor.getValue();
         ExamSegment examSegment = examSegments.get(0);
         assertThat(examSegments).hasSize(1);
         assertThat(examSegment.getExamId()).isEqualTo(exam.getId());
@@ -385,8 +390,8 @@ public class ExamSegmentServiceImplTest {
             language);
         verify(mockFieldTestService).isFieldTestEligible(exam, assessment, segment.getKey());
 
-        verify(mockExamSegmentCommandRepository).insert(examSegmentCaptor.capture());
-        List<ExamSegment> examSegments = examSegmentCaptor.getValue();
+        verify(mockExamSegmentCommandRepository).insert(examSegmentsCaptor.capture());
+        List<ExamSegment> examSegments = examSegmentsCaptor.getValue();
         ExamSegment examSegment = examSegments.get(0);
         assertThat(examSegments).hasSize(1);
         assertThat(examSegment.getExamId()).isEqualTo(exam.getId());
@@ -432,8 +437,8 @@ public class ExamSegmentServiceImplTest {
             language);
         verify(mockFieldTestService).isFieldTestEligible(exam, assessment, segment.getKey());
 
-        verify(mockExamSegmentCommandRepository).insert(examSegmentCaptor.capture());
-        List<ExamSegment> examSegments = examSegmentCaptor.getValue();
+        verify(mockExamSegmentCommandRepository).insert(examSegmentsCaptor.capture());
+        List<ExamSegment> examSegments = examSegmentsCaptor.getValue();
         ExamSegment examSegment = examSegments.get(0);
         assertThat(examSegments).hasSize(1);
         assertThat(examSegment.getExamId()).isEqualTo(exam.getId());
@@ -505,9 +510,9 @@ public class ExamSegmentServiceImplTest {
         int totalItems = examSegmentService.initializeExamSegments(exam, assessment);
         assertThat(totalItems).isEqualTo(enuForm1Seg1.getLength() + enuForm1Seg2.getLength());
         verify(mockFormSelector).selectForm(segment1, language);
-        verify(mockExamSegmentCommandRepository).insert(examSegmentCaptor.capture());
+        verify(mockExamSegmentCommandRepository).insert(examSegmentsCaptor.capture());
 
-        List<ExamSegment> examSegments = examSegmentCaptor.getValue();
+        List<ExamSegment> examSegments = examSegmentsCaptor.getValue();
         assertThat(examSegments).hasSize(2);
         ExamSegment examSegment1 = examSegments.get(0);
         assertThat(examSegment1.getExamId()).isEqualTo(exam.getId());
@@ -573,8 +578,8 @@ public class ExamSegmentServiceImplTest {
         verify(mockFieldTestService).isFieldTestEligible(exam, assessment, segment.getKey());
         verify(mockFieldTestService).selectItemGroups(exam, assessment, segment.getKey());
 
-        verify(mockExamSegmentCommandRepository).insert(examSegmentCaptor.capture());
-        List<ExamSegment> examSegments = examSegmentCaptor.getValue();
+        verify(mockExamSegmentCommandRepository).insert(examSegmentsCaptor.capture());
+        List<ExamSegment> examSegments = examSegmentsCaptor.getValue();
         ExamSegment examSegment = examSegments.get(0);
         assertThat(examSegments).hasSize(1);
         assertThat(examSegment.getExamId()).isEqualTo(exam.getId());
@@ -613,8 +618,8 @@ public class ExamSegmentServiceImplTest {
         verify(mockExamApprovalService).getApproval(examInfo);
         verify(mockExamSegmentQueryRepository, never()).findByExamId(examId);
 
-        Assertions.assertThat(response.getError().isPresent()).isTrue();
-        Assertions.assertThat(response.getData().isPresent()).isFalse();
+        assertThat(response.getError().isPresent()).isTrue();
+        assertThat(response.getData().isPresent()).isFalse();
     }
 
     @Test
@@ -641,9 +646,9 @@ public class ExamSegmentServiceImplTest {
         verify(mockExamApprovalService).getApproval(examInfo);
         verify(mockExamSegmentQueryRepository).findByExamId(examId);
 
-        Assertions.assertThat(response.getError().isPresent()).isFalse();
-        Assertions.assertThat(response.getData().isPresent()).isTrue();
-        Assertions.assertThat(response.getData().get()).hasSize(2);
+        assertThat(response.getError().isPresent()).isFalse();
+        assertThat(response.getData().isPresent()).isTrue();
+        assertThat(response.getData().get()).hasSize(2);
     }
 
     @Test
@@ -671,5 +676,47 @@ public class ExamSegmentServiceImplTest {
             .thenReturn(Optional.empty());
 
         examSegmentService.findByExamIdAndSegmentPosition(mockExam.getId(), mockExam.getCurrentSegmentPosition());
+    }
+
+    @Test
+    public void shouldExitExamSegment() {
+        final UUID examId = UUID.randomUUID();
+        final int segmentPosition = 1;
+        ExamSegment segment = new ExamSegment.Builder()
+            .fromSegment(random(ExamSegment.class))
+            .withExitedAt(null)
+            .withSegmentPosition(segmentPosition)
+            .build();
+
+        when(mockExamSegmentQueryRepository.findByExamIdAndSegmentPosition(examId, segmentPosition))
+            .thenReturn(Optional.of(segment));
+
+        Optional<ValidationError> maybeError = examSegmentService.exitSegment(examId, segmentPosition);
+        assertThat(maybeError).isNotPresent();
+        verify(mockExamSegmentQueryRepository).findByExamIdAndSegmentPosition(examId, segmentPosition);
+        verify(mockExamSegmentCommandRepository).update(examSegmentCaptor.capture());
+
+        ExamSegment updatedExamSegment = examSegmentCaptor.getValue();
+
+        assertThat(updatedExamSegment.getSegmentId()).isEqualTo(segment.getSegmentId());
+        assertThat(updatedExamSegment.getSegmentPosition()).isEqualTo(segment.getSegmentPosition());
+        assertThat(updatedExamSegment.getExitedAt()).isNotNull();
+    }
+
+    @Test
+    public void shouldFailToExitSegmentDueToExamSegmentNotFound() {
+        final UUID examId = UUID.randomUUID();
+        final int segmentPosition = 1;
+
+        when(mockExamSegmentQueryRepository.findByExamIdAndSegmentPosition(examId, segmentPosition))
+            .thenReturn(Optional.empty());
+
+        Optional<ValidationError> maybeError = examSegmentService.exitSegment(examId, segmentPosition);
+        assertThat(maybeError).isPresent();
+        assertThat(maybeError.get().getCode()).isEqualTo(ValidationErrorCode.EXAM_SEGMENT_DOES_NOT_EXIST);
+        assertThat(maybeError.get().getMessage()).isEqualTo("The exam segment does not exist");
+
+        verify(mockExamSegmentQueryRepository).findByExamIdAndSegmentPosition(examId, segmentPosition);
+        verify(mockExamSegmentCommandRepository, never()).update(isA(ExamSegment.class));
     }
 }

--- a/service/src/test/java/tds/exam/web/endpoints/ExamSegmentControllerIntegrationTests.java
+++ b/service/src/test/java/tds/exam/web/endpoints/ExamSegmentControllerIntegrationTests.java
@@ -10,13 +10,6 @@ import org.springframework.context.annotation.Import;
 import org.springframework.http.MediaType;
 import org.springframework.test.context.junit4.SpringRunner;
 import org.springframework.test.web.servlet.MockMvc;
-import tds.common.Response;
-import tds.common.ValidationError;
-import tds.common.configuration.JacksonObjectMapperConfiguration;
-import tds.common.configuration.SecurityConfiguration;
-import tds.common.web.advice.ExceptionAdvice;
-import tds.exam.ExamSegment;
-import tds.exam.services.ExamSegmentService;
 
 import java.net.URI;
 import java.util.ArrayList;
@@ -25,12 +18,19 @@ import java.util.List;
 import java.util.Optional;
 import java.util.UUID;
 
+import tds.common.Response;
+import tds.common.ValidationError;
+import tds.common.configuration.JacksonObjectMapperConfiguration;
+import tds.common.configuration.SecurityConfiguration;
+import tds.common.web.advice.ExceptionAdvice;
+import tds.exam.ExamSegment;
+import tds.exam.services.ExamSegmentService;
+
 import static org.hamcrest.CoreMatchers.is;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.put;
-import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.header;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
@@ -119,8 +119,7 @@ public class ExamSegmentControllerIntegrationTests {
 
         http.perform(put(new URI(String.format("/exam/segments/%s/exit/%d", examId, segmentPosition)))
             .contentType(MediaType.APPLICATION_JSON))
-            .andExpect(status().isNoContent())
-            .andExpect(header().string("Location", String.format("http://localhost/exam/%s", examId)));
+            .andExpect(status().isNoContent());
 
         verify(mockExamSegmentService).exitSegment(examId, segmentPosition);
     }


### PR DESCRIPTION
This PR is for the Exam Service endpoint for exiting an exam segment. This endpoint, along with "waitForSegmentApproval" will be called by the student legacy application. The code for calling these two endpoints will be included in a separate PR on TDS_Student

For reference, the legacy code that this endpoint replace is found in `OpportunityService.exitSegment()` , `OpportunityRepository.exitSegment()`, and `StudentDLL.T_ExitSegment_SP`