### PR TITLE
Revert previous changes for stage - status mapping.

### DIFF
--- a/client/src/main/java/tds/exam/ExamStatusCode.java
+++ b/client/src/main/java/tds/exam/ExamStatusCode.java
@@ -34,11 +34,11 @@ public class ExamStatusCode {
     static {
         Map<String, ExamStatusStage> stageMap = new TreeMap<>(String.CASE_INSENSITIVE_ORDER);
         stageMap.put(STATUS_PAUSED, ExamStatusStage.INACTIVE);
-        stageMap.put(STATUS_PENDING, ExamStatusStage.NEW);
-        stageMap.put(STATUS_APPROVED, ExamStatusStage.NEW);
-        stageMap.put(STATUS_SUSPENDED, ExamStatusStage.IN_PROGRESS);
+        stageMap.put(STATUS_PENDING, ExamStatusStage.IN_USE);
+        stageMap.put(STATUS_APPROVED, ExamStatusStage.IN_USE);
+        stageMap.put(STATUS_SUSPENDED, ExamStatusStage.IN_USE);
         stageMap.put(STATUS_REVIEW, ExamStatusStage.IN_USE);
-        stageMap.put(STATUS_STARTED, ExamStatusStage.IN_PROGRESS);
+        stageMap.put(STATUS_STARTED, ExamStatusStage.IN_USE);
         stageMap.put(STATUS_DENIED, ExamStatusStage.INACTIVE);
         stageMap.put(STATUS_COMPLETED, ExamStatusStage.CLOSED);
         stageMap.put(STATUS_SCORED, ExamStatusStage.CLOSED);

--- a/client/src/main/java/tds/exam/ExamStatusStage.java
+++ b/client/src/main/java/tds/exam/ExamStatusStage.java
@@ -8,8 +8,7 @@ public enum ExamStatusStage {
     IN_USE("inuse"),
     CLOSED("closed"),
     INACTIVE("inactive"),
-    OPEN("open"),
-    NEW("new");
+    OPEN("open");
 
     private final String type;
 

--- a/service/src/main/resources/db/migration/V1488868904__exam_update_status_stages_revert.sql
+++ b/service/src/main/resources/db/migration/V1488868904__exam_update_status_stages_revert.sql
@@ -1,0 +1,10 @@
+/***********************************************************************************************************************
+  File: V1488868904__exam_update_status_stages_revert.sql
+
+  Desc: Revert previous changes to mapping tables
+
+***********************************************************************************************************************/
+
+USE exam;
+
+UPDATE exam_status_codes SET stage='inuse' WHERE status in ('started', 'suspended', 'approved', 'pending');

--- a/service/src/test/java/tds/exam/repositories/impl/ExamStatusQueryRepositoryImplIntegrationTests.java
+++ b/service/src/test/java/tds/exam/repositories/impl/ExamStatusQueryRepositoryImplIntegrationTests.java
@@ -38,7 +38,7 @@ public class ExamStatusQueryRepositoryImplIntegrationTests {
         ExamStatusCode code = examStatusQueryRepository.findExamStatusCode("started");
 
         assertThat(code.getCode()).isEqualTo("started");
-        assertThat(code.getStage()).isEqualTo(ExamStatusStage.IN_PROGRESS);
+        assertThat(code.getStage()).isEqualTo(ExamStatusStage.IN_USE);
     }
 
     @Test(expected = EmptyResultDataAccessException.class)


### PR DESCRIPTION
The legacy code does set the stage directly on the test opportunity table but queries always use the statuscodes table to get the stage.  So we need to keep that the same and not check the value of testopportunity.stage when doing our data testing.