### PR TITLE
Pending and approved exams did not have the changed_at column populat…

### DIFF
--- a/service/src/main/java/tds/exam/repositories/impl/ExamCommandRepositoryImpl.java
+++ b/service/src/main/java/tds/exam/repositories/impl/ExamCommandRepositoryImpl.java
@@ -1,5 +1,6 @@
 package tds.exam.repositories.impl;
 
+import org.joda.time.Instant;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.beans.factory.annotation.Qualifier;
 import org.springframework.jdbc.core.namedparam.MapSqlParameterSource;
@@ -85,6 +86,8 @@ class ExamCommandRepositoryImpl implements ExamCommandRepository {
 
     @Override
     public void update(final Exam... exams) {
+        Instant now = org.joda.time.Instant.now();
+
         SqlParameterSource[] batchParameters = Stream.of(exams)
             .map(exam -> new MapSqlParameterSource("examId", exam.getId().toString())
                 .addValue("attempts", exam.getAttempts())
@@ -95,7 +98,7 @@ class ExamCommandRepositoryImpl implements ExamCommandRepository {
                 .addValue("maxItems", exam.getMaxItems())
                 .addValue("languageCode", exam.getLanguageCode())
                 .addValue("statusChangeReason", exam.getStatusChangeReason())
-                .addValue("changedAt", mapJodaInstantToTimestamp(exam.getChangedAt()))
+                .addValue("changedAt", mapJodaInstantToTimestamp(now))
                 .addValue("deletedAt", mapJodaInstantToTimestamp(exam.getDeletedAt()))
                 .addValue("completedAt", mapJodaInstantToTimestamp(exam.getCompletedAt()))
                 .addValue("scoredAt", mapJodaInstantToTimestamp(exam.getScoredAt()))

--- a/service/src/main/java/tds/exam/services/impl/ExamServiceImpl.java
+++ b/service/src/main/java/tds/exam/services/impl/ExamServiceImpl.java
@@ -452,7 +452,6 @@ class ExamServiceImpl implements ExamService {
             Exam restartedExam = new Exam.Builder()
                 .fromExam(exam)
                 .withStatus(new ExamStatusCode(ExamStatusCode.STATUS_STARTED, ExamStatusStage.IN_PROGRESS), now)
-                .withChangedAt(now)
                 .withResumptions(resumptions)
                 .withRestartsAndResumptions(restartsAndResumptions)
                 .withStartedAt(now)
@@ -477,7 +476,6 @@ class ExamServiceImpl implements ExamService {
             .fromExam(exam)
             .withStatus(new ExamStatusCode(ExamStatusCode.STATUS_STARTED, ExamStatusStage.IN_PROGRESS), org.joda.time.Instant.now())
             .withStartedAt(now)
-            .withChangedAt(now)
             .withExpiresAt(now)
             .withRestartsAndResumptions(0)
             .withMaxItems(testLength)
@@ -678,7 +676,6 @@ class ExamServiceImpl implements ExamService {
             .withStatus(status, org.joda.time.Instant.now())
             .withBrowserId(openExamRequest.getBrowserId())
             .withSessionId(openExamRequest.getSessionId())
-            .withChangedAt(org.joda.time.Instant.now())
             .withAbnormalStarts(previousExam.getAbnormalStarts() + abnormalIncrement)
             .build();
 

--- a/service/src/test/java/tds/exam/repositories/impl/ExamCommandRepositoryImplIntegrationTests.java
+++ b/service/src/test/java/tds/exam/repositories/impl/ExamCommandRepositoryImplIntegrationTests.java
@@ -83,7 +83,7 @@ public class ExamCommandRepositoryImplIntegrationTests {
         assertThat(savedExam.getAssessmentKey()).isEqualTo(exam.getAssessmentKey());
         assertThat(savedExam.getAssessmentWindowId()).isEqualTo(exam.getAssessmentWindowId());
         assertThat(savedExam.getDateJoined()).isEqualTo(now);
-        assertThat(savedExam.getChangedAt()).isEqualTo(exam.getChangedAt());
+        assertThat(savedExam.getChangedAt()).isGreaterThanOrEqualTo(now);
         assertThat(savedExam.getStartedAt()).isEqualTo(exam.getStartedAt());
         assertThat(savedExam.getScoredAt()).isEqualTo(exam.getScoredAt());
         assertThat(savedExam.getCompletedAt()).isEqualTo(exam.getCompletedAt());

--- a/service/src/test/java/tds/exam/repositories/impl/ExamQueryRepositoryImplIntegrationTests.java
+++ b/service/src/test/java/tds/exam/repositories/impl/ExamQueryRepositoryImplIntegrationTests.java
@@ -177,23 +177,24 @@ public class ExamQueryRepositoryImplIntegrationTests {
 
     @Test
     public void shouldReturnLastPausedDate() {
-        Instant pausedAt = Instant.now().minus(99999);
+        Instant now = Instant.now();
+        Instant pausedAt = now.minus(99999);
+
         Exam exam = new ExamBuilder()
             .withStatus(new ExamStatusCode(ExamStatusCode.STATUS_PAUSED, ExamStatusStage.INACTIVE), pausedAt)
-            .withChangedAt(pausedAt)
             .build();
         examCommandRepository.insert(exam);
 
         Exam approvedExam = new Exam.Builder()
             .fromExam(exam)
-            .withStatus(new ExamStatusCode(ExamStatusCode.STATUS_APPROVED, ExamStatusStage.IN_PROGRESS), Instant.now().minus(5000))
+            .withStatus(new ExamStatusCode(ExamStatusCode.STATUS_APPROVED, ExamStatusStage.IN_PROGRESS), now.minus(5000))
             .build();
 
         examCommandRepository.update(approvedExam);
 
         Optional<Instant> maybeLastTimePaused = examQueryRepository.findLastStudentActivity(exam.getId());
         assertThat(maybeLastTimePaused).isPresent();
-        assertThat(maybeLastTimePaused.get()).isEqualTo(pausedAt);
+        assertThat(maybeLastTimePaused.get()).isGreaterThanOrEqualTo(now);
     }
     
     @Test
@@ -238,7 +239,6 @@ public class ExamQueryRepositoryImplIntegrationTests {
 
         Exam exam = new ExamBuilder()
             .withStatus(new ExamStatusCode(ExamStatusCode.STATUS_PAUSED, ExamStatusStage.INACTIVE), pausedAt)
-            .withChangedAt(pausedAt)
             .build();
         examCommandRepository.insert(exam);
 
@@ -246,7 +246,7 @@ public class ExamQueryRepositoryImplIntegrationTests {
 
         Optional<Instant> maybeLastTimeStudentResponded = examQueryRepository.findLastStudentActivity(exam.getId());
         assertThat(maybeLastTimeStudentResponded).isPresent();
-        assertThat(maybeLastTimeStudentResponded.get()).isEqualTo(lastResponseSubmittedAt);
+        assertThat(maybeLastTimeStudentResponded.get()).isGreaterThanOrEqualTo(lastResponseSubmittedAt);
     }
 
     @Test
@@ -266,7 +266,7 @@ public class ExamQueryRepositoryImplIntegrationTests {
 
         Optional<Instant> maybeLastTimeStudentResponded = examQueryRepository.findLastStudentActivity(exam.getId());
         assertThat(maybeLastTimeStudentResponded).isPresent();
-        assertThat(maybeLastTimeStudentResponded.get()).isEqualTo(pageCreatedAt);
+        assertThat(maybeLastTimeStudentResponded.get()).isGreaterThanOrEqualTo(pageCreatedAt);
     }
 
     private void insertTestDataForResponses(Instant pageCreatedAt, Instant lastResponseSubmittedAt, Instant earlierResponseSubmittedAt, Exam exam) {

--- a/service/src/test/java/tds/exam/services/impl/ExamServiceImplTest.java
+++ b/service/src/test/java/tds/exam/services/impl/ExamServiceImplTest.java
@@ -818,7 +818,6 @@ public class ExamServiceImplTest {
         assertThat(savedExam.getBrowserId()).isNotEqualTo(previousExam.getBrowserId());
         assertThat(savedExam.getStatus().getCode()).isEqualTo(STATUS_SUSPENDED);
         assertThat(savedExam.getStatusChangedAt()).isGreaterThan(approvedStatusDate);
-        assertThat(savedExam.getChangedAt()).isNotNull();
         assertThat(savedExam.getStartedAt()).isEqualTo(previousExam.getStartedAt());
         assertThat(savedExam.getSessionId()).isEqualTo(request.getSessionId());
     }
@@ -1087,11 +1086,11 @@ public class ExamServiceImplTest {
     @Test
     public void shouldStartNewExam() throws InterruptedException {
         Session session = new SessionBuilder().build();
-        Instant approvedStatusDate = org.joda.time.Instant.now().minus(5000);
+        Instant now = org.joda.time.Instant.now().minus(5000);
+        Instant approvedStatusDate = now.minus(5000);
         Exam exam = new ExamBuilder()
             .withStatus(new ExamStatusCode(ExamStatusCode.STATUS_APPROVED, ExamStatusStage.OPEN), approvedStatusDate)
             .withSessionId(session.getId())
-            .withChangedAt(Instant.now().minus(50000))
             .withStartedAt(null)
             .build();
         Assessment assessment = new AssessmentBuilder().build();
@@ -1147,7 +1146,6 @@ public class ExamServiceImplTest {
         assertThat(updatedExam.getId()).isEqualTo(exam.getId());
         assertThat(updatedExam.getMaxItems()).isEqualTo(testLength);
         assertThat(updatedExam.getStartedAt()).isNotNull();
-        assertThat(updatedExam.getChangedAt()).isGreaterThan(exam.getChangedAt());
         assertThat(updatedExam.getExpiresAt()).isNotNull();
         assertThat(updatedExam.getStatus().getStage()).isEqualTo(ExamStatusStage.IN_PROGRESS);
         assertThat(updatedExam.getStatus().getCode()).isEqualTo(ExamStatusCode.STATUS_STARTED);
@@ -1158,15 +1156,15 @@ public class ExamServiceImplTest {
     @Test
     public void shouldRestartExistingExamOutsideGracePeriodPausedExam() throws InterruptedException {
         Session session = new SessionBuilder().build();
-        final Instant approvedStatusDate = org.joda.time.Instant.now().minus(5000);
-        final Instant lastStudentActivityTime = org.joda.time.Instant.now().minus(25 * 60 * 1000); // minus 25 minutes
+        final Instant now = org.joda.time.Instant.now().minus(5000);
+        final Instant approvedStatusDate = now.minus(5000);
+        final Instant lastStudentActivityTime = now.minus(25 * 60 * 1000); // minus 25 minutes
         final int testLength = 10;
 
         Exam exam = new ExamBuilder()
             .withStatus(new ExamStatusCode(ExamStatusCode.STATUS_APPROVED, ExamStatusStage.OPEN), approvedStatusDate)
             .withSessionId(session.getId())
             .withResumptions(3)
-            .withChangedAt(Instant.now().minus(50000))
             .withRestartsAndResumptions(5)
             .withMaxItems(10)
             .withStartedAt(Instant.now().minus(60000))
@@ -1223,7 +1221,6 @@ public class ExamServiceImplTest {
         assertThat(updatedExam.getStartedAt()).isNotNull();
         assertThat(updatedExam.getResumptions()).isEqualTo(3);
         assertThat(updatedExam.getRestartsAndResumptions()).isEqualTo(6);
-        assertThat(updatedExam.getChangedAt()).isGreaterThan(exam.getChangedAt());
         assertThat(updatedExam.getExpiresAt()).isNull();
         assertThat(updatedExam.getStatus().getStage()).isEqualTo(ExamStatusStage.IN_PROGRESS);
         assertThat(updatedExam.getStatus().getCode()).isEqualTo(ExamStatusCode.STATUS_STARTED);
@@ -1233,8 +1230,9 @@ public class ExamServiceImplTest {
     @Test
     public void shouldResumeExistingExamWithinGracePeriodPausedExam() throws InterruptedException {
         Session session = new SessionBuilder().build();
-        final Instant approvedStatusDate = org.joda.time.Instant.now().minus(5000);
-        final Instant lastStudentActivityTime = org.joda.time.Instant.now().minus(15 * 60 * 1000); // minus 15 minutes, within grace period
+        final Instant now = org.joda.time.Instant.now();
+        final Instant approvedStatusDate = now.minus(5000);
+        final Instant lastStudentActivityTime = now.minus(15 * 60 * 1000); // minus 15 minutes, within grace period
         final int resumePosition = 5;
         final int testLength = 10;
 
@@ -1242,10 +1240,9 @@ public class ExamServiceImplTest {
             .withStatus(new ExamStatusCode(ExamStatusCode.STATUS_APPROVED, ExamStatusStage.OPEN), approvedStatusDate)
             .withSessionId(session.getId())
             .withResumptions(3)
-            .withChangedAt(Instant.now().minus(50000))
             .withRestartsAndResumptions(5)
             .withMaxItems(10)
-            .withStartedAt(Instant.now().minus(60000))
+            .withStartedAt(now.minus(60000))
             .build();
         Assessment assessment = new AssessmentBuilder().build();
         TimeLimitConfiguration timeLimitConfiguration = new TimeLimitConfiguration.Builder()
@@ -1303,7 +1300,6 @@ public class ExamServiceImplTest {
         assertThat(updatedExam.getStartedAt()).isNotNull();
         assertThat(updatedExam.getResumptions()).isEqualTo(4);
         assertThat(updatedExam.getRestartsAndResumptions()).isEqualTo(6);
-        assertThat(updatedExam.getChangedAt()).isGreaterThan(exam.getChangedAt());
         assertThat(updatedExam.getExpiresAt()).isNull();
         assertThat(updatedExam.getStatus().getStage()).isEqualTo(ExamStatusStage.IN_PROGRESS);
         assertThat(updatedExam.getStatus().getCode()).isEqualTo(ExamStatusCode.STATUS_STARTED);


### PR DESCRIPTION
…ed.  Moved the logic into the repository update so it’s always populated with current timestamp on all update calls.