### PR TITLE
Proctor Print request endpoints - Deny, approve, fetch approved

### DIFF
--- a/client/src/main/java/tds/exam/ExamPrintRequest.java
+++ b/client/src/main/java/tds/exam/ExamPrintRequest.java
@@ -25,8 +25,8 @@ public class ExamPrintRequest {
     private String parameters;
     private String description;
     private Instant createdAt;
-    private Instant approvedAt;
-    private Instant deniedAt;
+    private Instant changedAt;
+    private ExamPrintRequestStatus status;
     private String reasonDenied;
 
     private ExamPrintRequest() {
@@ -36,10 +36,10 @@ public class ExamPrintRequest {
         this.createdAt = builder.createdAt;
         this.pagePosition = builder.pagePosition;
         this.itemPosition = builder.itemPosition;
-        this.approvedAt = builder.approvedAt;
+        this.changedAt = builder.changedAt;
         this.examId = builder.examId;
         this.parameters = builder.parameters;
-        this.deniedAt = builder.deniedAt;
+        this.status = builder.status;
         this.value = builder.value;
         this.id = builder.id;
         this.sessionId = builder.sessionId;
@@ -59,8 +59,8 @@ public class ExamPrintRequest {
         private String parameters;
         private String description;
         private Instant createdAt;
-        private Instant approvedAt;
-        private Instant deniedAt;
+        private Instant changedAt;
+        private ExamPrintRequestStatus status;
         private String reasonDenied;
 
         public Builder(UUID id) {
@@ -112,13 +112,13 @@ public class ExamPrintRequest {
             return this;
         }
 
-        public Builder withApprovedAt(Instant approvedAt) {
-            this.approvedAt = approvedAt;
+        public Builder withChangedAt(Instant changedAt) {
+            this.changedAt = changedAt;
             return this;
         }
 
-        public Builder withDeniedAt(Instant deniedAt) {
-            this.deniedAt = deniedAt;
+        public Builder withStatus(ExamPrintRequestStatus status) {
+            this.status = status;
             return this;
         }
 
@@ -131,10 +131,10 @@ public class ExamPrintRequest {
             this.createdAt = request.createdAt;
             this.pagePosition = request.pagePosition;
             this.itemPosition = request.itemPosition;
-            this.approvedAt = request.approvedAt;
+            this.changedAt = request.changedAt;
             this.examId = request.examId;
             this.parameters = request.parameters;
-            this.deniedAt = request.deniedAt;
+            this.status = request.status;
             this.value = request.value;
             this.id = request.id;
             this.sessionId = request.sessionId;
@@ -220,17 +220,17 @@ public class ExamPrintRequest {
     }
 
     /**
-     * @return If approved, the {@link org.joda.time.Instant} the request was approved by a proctor
+     * @return The {@link org.joda.time.Instant} of when the {@link tds.exam.ExamPrintRequestStatus} last changed
      */
-    public Instant getApprovedAt() {
-        return approvedAt;
+    public Instant getChangedAt() {
+        return changedAt;
     }
 
     /**
-     * @return If denied, the {@link org.joda.time.Instant} the request was denied by a proctor
+     * @return The {@link tds.exam.ExamPrintRequestStatus} of the {@link tds.exam.ExamPrintRequest}
      */
-    public Instant getDeniedAt() {
-        return deniedAt;
+    public ExamPrintRequestStatus getStatus() {
+        return status;
     }
 
     /**
@@ -255,8 +255,7 @@ public class ExamPrintRequest {
         if (value != null ? !value.equals(that.value) : that.value != null) return false;
         if (parameters != null ? !parameters.equals(that.parameters) : that.parameters != null) return false;
         if (description != null ? !description.equals(that.description) : that.description != null) return false;
-        if (approvedAt != null ? !approvedAt.equals(that.approvedAt) : that.approvedAt != null) return false;
-        if (deniedAt != null ? !deniedAt.equals(that.deniedAt) : that.deniedAt != null) return false;
+        if (status != null ? !status.equals(that.status) : that.status != null) return false;
         return reasonDenied != null ? reasonDenied.equals(that.reasonDenied) : that.reasonDenied == null;
     }
 
@@ -270,8 +269,8 @@ public class ExamPrintRequest {
         result = 31 * result + pagePosition;
         result = 31 * result + (parameters != null ? parameters.hashCode() : 0);
         result = 31 * result + (description != null ? description.hashCode() : 0);
-        result = 31 * result + (approvedAt != null ? approvedAt.hashCode() : 0);
-        result = 31 * result + (deniedAt != null ? deniedAt.hashCode() : 0);
+        result = 31 * result + (changedAt != null ? changedAt.hashCode() : 0);
+        result = 31 * result + (status != null ? status.hashCode() : 0);
         result = 31 * result + (reasonDenied != null ? reasonDenied.hashCode() : 0);
         return result;
     }

--- a/client/src/main/java/tds/exam/ExamPrintRequest.java
+++ b/client/src/main/java/tds/exam/ExamPrintRequest.java
@@ -239,4 +239,40 @@ public class ExamPrintRequest {
     public String getReasonDenied() {
         return reasonDenied;
     }
+
+    @Override
+    public boolean equals(final Object o) {
+        if (this == o) return true;
+        if (o == null || getClass() != o.getClass()) return false;
+
+        final ExamPrintRequest that = (ExamPrintRequest) o;
+
+        if (itemPosition != that.itemPosition) return false;
+        if (pagePosition != that.pagePosition) return false;
+        if (!examId.equals(that.examId)) return false;
+        if (!sessionId.equals(that.sessionId)) return false;
+        if (!type.equals(that.type)) return false;
+        if (value != null ? !value.equals(that.value) : that.value != null) return false;
+        if (parameters != null ? !parameters.equals(that.parameters) : that.parameters != null) return false;
+        if (description != null ? !description.equals(that.description) : that.description != null) return false;
+        if (approvedAt != null ? !approvedAt.equals(that.approvedAt) : that.approvedAt != null) return false;
+        if (deniedAt != null ? !deniedAt.equals(that.deniedAt) : that.deniedAt != null) return false;
+        return reasonDenied != null ? reasonDenied.equals(that.reasonDenied) : that.reasonDenied == null;
+    }
+
+    @Override
+    public int hashCode() {
+        int result = examId.hashCode();
+        result = 31 * result + sessionId.hashCode();
+        result = 31 * result + type.hashCode();
+        result = 31 * result + (value != null ? value.hashCode() : 0);
+        result = 31 * result + itemPosition;
+        result = 31 * result + pagePosition;
+        result = 31 * result + (parameters != null ? parameters.hashCode() : 0);
+        result = 31 * result + (description != null ? description.hashCode() : 0);
+        result = 31 * result + (approvedAt != null ? approvedAt.hashCode() : 0);
+        result = 31 * result + (deniedAt != null ? deniedAt.hashCode() : 0);
+        result = 31 * result + (reasonDenied != null ? reasonDenied.hashCode() : 0);
+        return result;
+    }
 }

--- a/client/src/main/java/tds/exam/ExamPrintRequestStatus.java
+++ b/client/src/main/java/tds/exam/ExamPrintRequestStatus.java
@@ -1,0 +1,12 @@
+package tds.exam;
+
+import tds.common.Algorithm;
+
+/**
+ * An enumeration for statuses of {@link tds.exam.ExamPrintRequest}
+ */
+public enum ExamPrintRequestStatus {
+    APPROVED,
+    DENIED,
+    SUBMITTED
+}

--- a/service/src/main/java/tds/exam/repositories/ExamPrintRequestCommandRepository.java
+++ b/service/src/main/java/tds/exam/repositories/ExamPrintRequestCommandRepository.java
@@ -13,4 +13,11 @@ public interface ExamPrintRequestCommandRepository {
      * @param examPrintRequest
      */
     void insert(final ExamPrintRequest examPrintRequest);
+
+    /**
+     * Updates an exam print request
+     *
+     * @param examPrintRequest
+     */
+    void update(final ExamPrintRequest examPrintRequest);
 }

--- a/service/src/main/java/tds/exam/repositories/ExamPrintRequestQueryRepository.java
+++ b/service/src/main/java/tds/exam/repositories/ExamPrintRequestQueryRepository.java
@@ -1,7 +1,11 @@
 package tds.exam.repositories;
 
+import java.util.List;
 import java.util.Map;
+import java.util.Optional;
 import java.util.UUID;
+
+import tds.exam.ExamPrintRequest;
 
 /**
  * A repository for reading {@link tds.exam.ExamPrintRequest} data
@@ -16,4 +20,29 @@ public interface ExamPrintRequestQueryRepository {
      * @return A map of exam ids to their request count
      */
     Map<UUID, Integer> findRequestCountsForExamIds(final UUID sessionId, final UUID... examIds);
+
+    /**
+     * Retrieves a list of unfulfilled requests. These are request that have been neither approved nor denied.
+     *
+     * @param examId    The id of the exam for the {@link tds.exam.ExamPrintRequest}s
+     * @param sessionId The id of the session for the {@link tds.exam.ExamPrintRequest}s
+     * @return The list of the unfulfilled {@link tds.exam.ExamPrintRequest}s
+     */
+    List<ExamPrintRequest> findUnfulfilledRequests(final UUID examId, final UUID sessionId);
+
+    /**
+     * Retrieves an {@link tds.exam.ExamPrintRequest} with the specified id
+     *
+     * @param id The id of the {@link tds.exam.ExamPrintRequest} to fetch
+     * @return The {@link tds.exam.ExamPrintRequest}
+     */
+    Optional<ExamPrintRequest> findExamPrintRequest(final UUID id);
+
+    /**
+     * Retrieves a list of approved requests for the session.
+     *
+     * @param sessionId The session id of the approved {@link tds.exam.ExamPrintRequest}s
+     * @return A {@link List<tds.exam.ExamPrintRequest>} that have been approved
+     */
+    List<ExamPrintRequest> findApprovedRequests(final UUID sessionId);
 }

--- a/service/src/main/java/tds/exam/repositories/impl/ExamPrintRequestCommandRepositoryImpl.java
+++ b/service/src/main/java/tds/exam/repositories/impl/ExamPrintRequestCommandRepositoryImpl.java
@@ -1,13 +1,12 @@
 package tds.exam.repositories.impl;
 
+import org.joda.time.Instant;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.beans.factory.annotation.Qualifier;
 import org.springframework.jdbc.core.namedparam.MapSqlParameterSource;
 import org.springframework.jdbc.core.namedparam.NamedParameterJdbcTemplate;
 import org.springframework.jdbc.core.namedparam.SqlParameterSource;
 import org.springframework.stereotype.Repository;
-
-import java.util.UUID;
 
 import tds.exam.ExamPrintRequest;
 import tds.exam.repositories.ExamPrintRequestCommandRepository;
@@ -33,7 +32,8 @@ public class ExamPrintRequestCommandRepositoryImpl implements ExamPrintRequestCo
             .addValue("itemPosition", examPrintRequest.getItemPosition())
             .addValue("pagePosition", examPrintRequest.getPagePosition())
             .addValue("parameters", examPrintRequest.getParameters())
-            .addValue("description", examPrintRequest.getDescription());
+            .addValue("description", examPrintRequest.getDescription())
+            .addValue("createdAt", mapJodaInstantToTimestamp(Instant.now()));
 
         final String examPrintRequestSQL =
             "INSERT INTO \n" +
@@ -46,7 +46,8 @@ public class ExamPrintRequestCommandRepositoryImpl implements ExamPrintRequestCo
                 "   item_position, \n" +
                 "   page_position, \n" +
                 "   parameters, \n" +
-                "   description \n" +
+                "   description, \n" +
+                "   created_at \n" +
                 ") \n" +
                 "VALUES ( \n" +
                 "   :id, \n" +
@@ -57,7 +58,8 @@ public class ExamPrintRequestCommandRepositoryImpl implements ExamPrintRequestCo
                 "   :itemPosition, \n" +
                 "   :pagePosition, \n" +
                 "   :parameters, \n" +
-                "   :description \n" +
+                "   :description, \n" +
+                "   :createdAt \n" +
                 ")";
 
         jdbcTemplate.update(examPrintRequestSQL, params);
@@ -67,22 +69,22 @@ public class ExamPrintRequestCommandRepositoryImpl implements ExamPrintRequestCo
     @Override
     public void update(final ExamPrintRequest examPrintRequest) {
         final SqlParameterSource params = new MapSqlParameterSource("examRequestId", examPrintRequest.getId().toString())
-            .addValue("approvedAt", mapJodaInstantToTimestamp(examPrintRequest.getApprovedAt()))
-            .addValue("deniedAt", mapJodaInstantToTimestamp(examPrintRequest.getDeniedAt()))
+            .addValue("status", examPrintRequest.getStatus().name())
+            .addValue("createdAt", mapJodaInstantToTimestamp(Instant.now()))
             .addValue("reasonDenied", examPrintRequest.getReasonDenied());
 
         final String updateExamPrintRequestSQL =
             "INSERT INTO \n" +
                 "exam.exam_print_request_event ( \n" +
                 "   exam_print_request_id, \n" +
-                "   approved_at, \n" +
-                "   denied_at, \n" +
+                "   status, \n" +
+                "   created_at, \n" +
                 "   reason_denied \n" +
                 ") \n" +
                 "VALUES ( \n" +
                 "   :examRequestId, \n" +
-                "   :approvedAt, \n" +
-                "   :deniedAt, \n" +
+                "   :status, \n" +
+                "   :createdAt, \n" +
                 "   :reasonDenied \n" +
                 ")";
 

--- a/service/src/main/java/tds/exam/repositories/impl/ExamPrintRequestCommandRepositoryImpl.java
+++ b/service/src/main/java/tds/exam/repositories/impl/ExamPrintRequestCommandRepositoryImpl.java
@@ -7,6 +7,8 @@ import org.springframework.jdbc.core.namedparam.NamedParameterJdbcTemplate;
 import org.springframework.jdbc.core.namedparam.SqlParameterSource;
 import org.springframework.stereotype.Repository;
 
+import java.util.UUID;
+
 import tds.exam.ExamPrintRequest;
 import tds.exam.repositories.ExamPrintRequestCommandRepository;
 
@@ -62,7 +64,8 @@ public class ExamPrintRequestCommandRepositoryImpl implements ExamPrintRequestCo
         update(examPrintRequest);
     }
 
-    private void update(final ExamPrintRequest examPrintRequest) {
+    @Override
+    public void update(final ExamPrintRequest examPrintRequest) {
         final SqlParameterSource params = new MapSqlParameterSource("examRequestId", examPrintRequest.getId().toString())
             .addValue("approvedAt", mapJodaInstantToTimestamp(examPrintRequest.getApprovedAt()))
             .addValue("deniedAt", mapJodaInstantToTimestamp(examPrintRequest.getDeniedAt()))

--- a/service/src/main/java/tds/exam/repositories/impl/ExamPrintRequestQueryRepositoryImpl.java
+++ b/service/src/main/java/tds/exam/repositories/impl/ExamPrintRequestQueryRepositoryImpl.java
@@ -2,23 +2,34 @@ package tds.exam.repositories.impl;
 
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.beans.factory.annotation.Qualifier;
+import org.springframework.dao.EmptyResultDataAccessException;
 import org.springframework.jdbc.core.ResultSetExtractor;
+import org.springframework.jdbc.core.RowMapper;
 import org.springframework.jdbc.core.namedparam.MapSqlParameterSource;
 import org.springframework.jdbc.core.namedparam.NamedParameterJdbcTemplate;
 import org.springframework.jdbc.core.namedparam.SqlParameterSource;
 import org.springframework.stereotype.Repository;
 
+import java.sql.ResultSet;
+import java.sql.SQLException;
 import java.util.Arrays;
 import java.util.HashMap;
+import java.util.List;
 import java.util.Map;
+import java.util.Optional;
 import java.util.UUID;
 import java.util.stream.Collectors;
 
+import tds.exam.Exam;
+import tds.exam.ExamPrintRequest;
 import tds.exam.repositories.ExamPrintRequestQueryRepository;
+
+import static tds.common.data.mapping.ResultSetMapperUtility.mapTimestampToJodaInstant;
 
 @Repository
 public class ExamPrintRequestQueryRepositoryImpl implements ExamPrintRequestQueryRepository {
     private final NamedParameterJdbcTemplate jdbcTemplate;
+    private static final ExamPrintRequestRowMapper examPrintRequestRowMapper = new ExamPrintRequestRowMapper();
 
     @Autowired
     public ExamPrintRequestQueryRepositoryImpl(@Qualifier("queryJdbcTemplate") final NamedParameterJdbcTemplate queryJdbcTemplate) {
@@ -62,5 +73,157 @@ public class ExamPrintRequestQueryRepositoryImpl implements ExamPrintRequestQuer
             }
             return examIdResponseCounts;
         });
+    }
+
+    @Override
+    public List<ExamPrintRequest> findUnfulfilledRequests(final UUID examId, final UUID sessionId) {
+        final SqlParameterSource params = new MapSqlParameterSource("examId", examId.toString())
+            .addValue("sessionId", sessionId.toString());
+
+        final String SQL =
+            "SELECT \n" +
+                "   PR.id, \n" +
+                "   PR.exam_id, \n" +
+                "   PR.session_id, \n" +
+                "   PR.type, \n" +
+                "   PR.value, \n" +
+                "   PR.item_position, \n" +
+                "   PR.page_position, \n" +
+                "   PR.parameters, \n" +
+                "   PR.description, \n" +
+                "   PR.created_at, \n" +
+                "   PRE.approved_at, \n" +
+                "   PRE.denied_at, \n" +
+                "   PRE.reason_denied \n" +
+                "FROM  \n" +
+                "   exam.exam_print_request PR \n" +
+                "JOIN ( \n" +
+                "   SELECT \n" +
+                "       exam_print_request_id, \n" +
+                "       MAX(id) AS id \n" +
+                "   FROM \n" +
+                "       exam.exam_print_request_event \n" +
+                "   GROUP BY exam_print_request_id \n" +
+                ") last_event \n" +
+                "   ON PR.id = last_event.exam_print_request_id \n" +
+                "JOIN exam.exam_print_request_event PRE \n" +
+                "   ON last_event.exam_print_request_id = PRE.exam_print_request_id \n" +
+                "   AND last_event.id = PRE.id \n" +
+                "WHERE \n" +
+                "   exam_id = :examId \n" +
+                "   AND approved_at IS NULL \n" +
+                "   AND denied_at IS NULL \n" +
+                "   AND session_id = :sessionId \n" +
+                "ORDER BY PR.created_at";
+
+        return jdbcTemplate.query(SQL, params, examPrintRequestRowMapper);
+    }
+
+    @Override
+    public Optional<ExamPrintRequest> findExamPrintRequest(final UUID id) {
+        final SqlParameterSource params = new MapSqlParameterSource("id", id.toString());
+        final String SQL =
+            "SELECT \n" +
+                "   PR.id, \n" +
+                "   PR.exam_id, \n" +
+                "   PR.session_id, \n" +
+                "   PR.type, \n" +
+                "   PR.value, \n" +
+                "   PR.item_position, \n" +
+                "   PR.page_position, \n" +
+                "   PR.parameters, \n" +
+                "   PR.description, \n" +
+                "   PR.created_at, \n" +
+                "   PRE.approved_at, \n" +
+                "   PRE.denied_at, \n" +
+                "   PRE.reason_denied \n" +
+                "FROM  \n" +
+                "   exam.exam_print_request PR \n" +
+                "JOIN ( \n" +
+                "   SELECT \n" +
+                "       exam_print_request_id, \n" +
+                "       MAX(id) AS id \n" +
+                "   FROM \n" +
+                "       exam.exam_print_request_event \n" +
+                "   GROUP BY exam_print_request_id \n" +
+                ") last_event \n" +
+                "   ON PR.id = last_event.exam_print_request_id \n" +
+                "JOIN exam.exam_print_request_event PRE \n" +
+                "   ON last_event.exam_print_request_id = PRE.exam_print_request_id \n" +
+                "   AND last_event.id = PRE.id \n" +
+                "WHERE \n" +
+                "   PR.id = :id";
+
+        Optional<ExamPrintRequest> maybeExamPrintRequest;
+
+        try {
+            maybeExamPrintRequest = Optional.of(jdbcTemplate.queryForObject(SQL, params, examPrintRequestRowMapper));
+        } catch (EmptyResultDataAccessException e) {
+            maybeExamPrintRequest = Optional.empty();
+        }
+
+        return maybeExamPrintRequest;
+    }
+
+    @Override
+    public List<ExamPrintRequest> findApprovedRequests(final UUID sessionId) {
+        final SqlParameterSource params = new MapSqlParameterSource("sessionId", sessionId.toString());
+
+        final String SQL =
+            "SELECT \n" +
+                "   PR.id, \n" +
+                "   PR.exam_id, \n" +
+                "   PR.session_id, \n" +
+                "   PR.type, \n" +
+                "   PR.value, \n" +
+                "   PR.item_position, \n" +
+                "   PR.page_position, \n" +
+                "   PR.parameters, \n" +
+                "   PR.description, \n" +
+                "   PR.created_at, \n" +
+                "   PRE.approved_at, \n" +
+                "   PRE.denied_at, \n" +
+                "   PRE.reason_denied \n" +
+                "FROM  \n" +
+                "   exam.exam_print_request PR \n" +
+                "JOIN ( \n" +
+                "   SELECT \n" +
+                "       exam_print_request_id, \n" +
+                "       MAX(id) AS id \n" +
+                "   FROM \n" +
+                "       exam.exam_print_request_event \n" +
+                "   GROUP BY exam_print_request_id \n" +
+                ") last_event \n" +
+                "   ON PR.id = last_event.exam_print_request_id \n" +
+                "JOIN exam.exam_print_request_event PRE \n" +
+                "   ON last_event.exam_print_request_id = PRE.exam_print_request_id \n" +
+                "   AND last_event.id = PRE.id \n" +
+                "WHERE \n" +
+                "   approved_at IS NOT NULL \n" +
+                "   AND denied_at IS NULL \n" +
+                "   AND session_id = :sessionId \n" +
+                "ORDER BY PR.exam_id, PR.created_at";
+
+        return jdbcTemplate.query(SQL, params, examPrintRequestRowMapper);
+    }
+
+    private static class ExamPrintRequestRowMapper implements RowMapper<ExamPrintRequest> {
+        @Override
+        public ExamPrintRequest mapRow(final ResultSet rs, final int i) throws SQLException {
+            return new ExamPrintRequest.Builder(UUID.fromString(rs.getString("id")))
+                .withExamId(UUID.fromString(rs.getString("exam_id")))
+                .withSessionId(UUID.fromString(rs.getString("session_id")))
+                .withType(rs.getString("type"))
+                .withValue(rs.getString("value"))
+                .withItemPosition(rs.getInt("item_position"))
+                .withPagePosition(rs.getInt("page_position"))
+                .withParameters(rs.getString("parameters"))
+                .withDescription(rs.getString("description"))
+                .withCreatedAt(mapTimestampToJodaInstant(rs, "created_at"))
+                .withApprovedAt(mapTimestampToJodaInstant(rs, "approved_at"))
+                .withDeniedAt(mapTimestampToJodaInstant(rs, "denied_at"))
+                .withReasonDenied(rs.getString("reason_denied"))
+                .build();
+        }
     }
 }

--- a/service/src/main/java/tds/exam/services/ExamPrintRequestService.java
+++ b/service/src/main/java/tds/exam/services/ExamPrintRequestService.java
@@ -6,6 +6,7 @@ import java.util.Optional;
 import java.util.UUID;
 
 import tds.exam.ExamPrintRequest;
+import tds.exam.ExamPrintRequestStatus;
 
 /**
  * Service used to create, read, and update exam print and emboss requests
@@ -38,20 +39,14 @@ public interface ExamPrintRequestService {
     List<ExamPrintRequest> findUnfulfilledRequests(final UUID examId, final UUID sessionId);
 
     /**
-     * Denies the {@link tds.exam.ExamPrintRequest} with the provided reason.
+     * Updates and fetches the {@link tds.exam.ExamPrintRequest} with the provided reason.
      *
+     * @param status The {@link tds.exam.ExamPrintRequestStatus} of the request - either approved or denied
      * @param id     The id of the {@link tds.exam.ExamPrintRequest} being denied
      * @param reason The reason for the denial of the request
+     * @return The approved/denied {@link tds.exam.ExamPrintRequest}
      */
-    void denyRequest(final UUID id, final String reason);
-
-    /**
-     * Fetches and marks as approved the specified {@link tds.exam.ExamPrintRequest}
-     *
-     * @param id the identifier of the {@link tds.exam.ExamPrintRequest} to approve
-     * @return The approved {@link tds.exam.ExamPrintRequest}
-     */
-    Optional<ExamPrintRequest> findAndApprovePrintRequest(final UUID id);
+    Optional<ExamPrintRequest> updateAndGetRequest(final ExamPrintRequestStatus status, final UUID id, final String reason);
 
     /**
      * Retrieves a list of approved requests for the session.

--- a/service/src/main/java/tds/exam/services/ExamPrintRequestService.java
+++ b/service/src/main/java/tds/exam/services/ExamPrintRequestService.java
@@ -1,6 +1,8 @@
 package tds.exam.services;
 
+import java.util.List;
 import java.util.Map;
+import java.util.Optional;
 import java.util.UUID;
 
 import tds.exam.ExamPrintRequest;
@@ -25,4 +27,37 @@ public interface ExamPrintRequestService {
      * @return A map of exam ids to their request count
      */
     Map<UUID, Integer> findRequestCountsForExamIds(final UUID sessionId, final UUID... examIds);
+
+    /**
+     * Retrieves a list of unfulfilled requests. These are request that have been neither approved nor denied.
+     *
+     * @param examId    The id of the exam for the {@link tds.exam.ExamPrintRequest}s
+     * @param sessionId The id of the session for the {@link tds.exam.ExamPrintRequest}s
+     * @return The list of the unfulfilled {@link tds.exam.ExamPrintRequest}s
+     */
+    List<ExamPrintRequest> findUnfulfilledRequests(final UUID examId, final UUID sessionId);
+
+    /**
+     * Denies the {@link tds.exam.ExamPrintRequest} with the provided reason.
+     *
+     * @param id     The id of the {@link tds.exam.ExamPrintRequest} being denied
+     * @param reason The reason for the denial of the request
+     */
+    void denyRequest(final UUID id, final String reason);
+
+    /**
+     * Fetches and marks as approved the specified {@link tds.exam.ExamPrintRequest}
+     *
+     * @param id the identifier of the {@link tds.exam.ExamPrintRequest} to approve
+     * @return The approved {@link tds.exam.ExamPrintRequest}
+     */
+    Optional<ExamPrintRequest> findAndApprovePrintRequest(final UUID id);
+
+    /**
+     * Retrieves a list of approved requests for the session.
+     *
+     * @param sessionId The session id of the approved {@link tds.exam.ExamPrintRequest}s
+     * @return A {@link List<tds.exam.ExamPrintRequest>} that have been approved
+     */
+    List<ExamPrintRequest> findApprovedRequests(final UUID sessionId);
 }

--- a/service/src/main/java/tds/exam/services/impl/ExamPrintRequestServiceImpl.java
+++ b/service/src/main/java/tds/exam/services/impl/ExamPrintRequestServiceImpl.java
@@ -1,10 +1,13 @@
 package tds.exam.services.impl;
 
+import org.joda.time.Instant;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
+import java.util.List;
 import java.util.Map;
+import java.util.Optional;
 import java.util.UUID;
 
 import tds.exam.ExamPrintRequest;
@@ -13,7 +16,7 @@ import tds.exam.repositories.ExamPrintRequestQueryRepository;
 import tds.exam.services.ExamPrintRequestService;
 
 @Service
-public class ExamPrintRequestServiceImpl implements ExamPrintRequestService{
+public class ExamPrintRequestServiceImpl implements ExamPrintRequestService {
     private final ExamPrintRequestCommandRepository examPrintRequestCommandRepository;
     private final ExamPrintRequestQueryRepository examPrintRequestQueryRepository;
 
@@ -33,5 +36,43 @@ public class ExamPrintRequestServiceImpl implements ExamPrintRequestService{
     @Override
     public Map<UUID, Integer> findRequestCountsForExamIds(final UUID sessionId, final UUID... examIds) {
         return examPrintRequestQueryRepository.findRequestCountsForExamIds(sessionId, examIds);
+    }
+
+    @Override
+    public List<ExamPrintRequest> findUnfulfilledRequests(final UUID examId, final UUID sessionId) {
+        return examPrintRequestQueryRepository.findUnfulfilledRequests(examId, sessionId);
+    }
+
+    @Override
+    public void denyRequest(final UUID id, final String reason) {
+        final ExamPrintRequest request = new ExamPrintRequest.Builder(id)
+            .withDeniedAt(Instant.now())
+            .withReasonDenied(reason)
+            .build();
+
+        examPrintRequestCommandRepository.update(request);
+    }
+
+    @Override
+    public Optional<ExamPrintRequest> findAndApprovePrintRequest(final UUID id) {
+        final Optional<ExamPrintRequest> maybePrintRequest = examPrintRequestQueryRepository.findExamPrintRequest(id);
+
+        if (!maybePrintRequest.isPresent()) {
+            return Optional.empty();
+        }
+
+        final ExamPrintRequest approvedRequest = new ExamPrintRequest.Builder(id)
+            .fromExamPrintRequest(maybePrintRequest.get())
+            .withApprovedAt(Instant.now())
+            .build();
+
+        examPrintRequestCommandRepository.update(approvedRequest);
+
+        return Optional.of(approvedRequest);
+    }
+
+    @Override
+    public List<ExamPrintRequest> findApprovedRequests(final UUID sessionId) {
+        return examPrintRequestQueryRepository.findApprovedRequests(sessionId);
     }
 }

--- a/service/src/main/java/tds/exam/services/impl/ExamPrintRequestServiceImpl.java
+++ b/service/src/main/java/tds/exam/services/impl/ExamPrintRequestServiceImpl.java
@@ -11,6 +11,7 @@ import java.util.Optional;
 import java.util.UUID;
 
 import tds.exam.ExamPrintRequest;
+import tds.exam.ExamPrintRequestStatus;
 import tds.exam.repositories.ExamPrintRequestCommandRepository;
 import tds.exam.repositories.ExamPrintRequestQueryRepository;
 import tds.exam.services.ExamPrintRequestService;
@@ -44,31 +45,22 @@ public class ExamPrintRequestServiceImpl implements ExamPrintRequestService {
     }
 
     @Override
-    public void denyRequest(final UUID id, final String reason) {
-        final ExamPrintRequest request = new ExamPrintRequest.Builder(id)
-            .withDeniedAt(Instant.now())
-            .withReasonDenied(reason)
-            .build();
-
-        examPrintRequestCommandRepository.update(request);
-    }
-
-    @Override
-    public Optional<ExamPrintRequest> findAndApprovePrintRequest(final UUID id) {
+    public Optional<ExamPrintRequest> updateAndGetRequest(final ExamPrintRequestStatus status, final UUID id, final String reason) {
         final Optional<ExamPrintRequest> maybePrintRequest = examPrintRequestQueryRepository.findExamPrintRequest(id);
 
         if (!maybePrintRequest.isPresent()) {
             return Optional.empty();
         }
 
-        final ExamPrintRequest approvedRequest = new ExamPrintRequest.Builder(id)
+        final ExamPrintRequest deniedRequest = new ExamPrintRequest.Builder(id)
             .fromExamPrintRequest(maybePrintRequest.get())
-            .withApprovedAt(Instant.now())
+            .withStatus(status)
+            .withReasonDenied(reason)
             .build();
 
-        examPrintRequestCommandRepository.update(approvedRequest);
+        examPrintRequestCommandRepository.update(deniedRequest);
 
-        return Optional.of(approvedRequest);
+        return Optional.of(deniedRequest);
     }
 
     @Override

--- a/service/src/main/java/tds/exam/web/endpoints/ExamPrintRequestController.java
+++ b/service/src/main/java/tds/exam/web/endpoints/ExamPrintRequestController.java
@@ -35,7 +35,7 @@ public class ExamPrintRequestController {
     }
 
     @RequestMapping(value = "/approved/{sessionId}", method = RequestMethod.GET, produces = MediaType.APPLICATION_JSON_VALUE)
-    public ResponseEntity<List<ExamPrintRequest>> findUnfulfilledRequests(@PathVariable UUID sessionId) {
+    public ResponseEntity<List<ExamPrintRequest>> findApprovedRequests(@PathVariable UUID sessionId) {
         return ResponseEntity.ok(examPrintRequestService.findApprovedRequests(sessionId));
     }
 

--- a/service/src/main/java/tds/exam/web/endpoints/ExamPrintRequestController.java
+++ b/service/src/main/java/tds/exam/web/endpoints/ExamPrintRequestController.java
@@ -16,6 +16,7 @@ import java.util.Optional;
 import java.util.UUID;
 
 import tds.exam.ExamPrintRequest;
+import tds.exam.ExamPrintRequestStatus;
 import tds.exam.services.ExamPrintRequestService;
 
 @RestController
@@ -45,17 +46,22 @@ public class ExamPrintRequestController {
     }
 
     @RequestMapping(value = "/deny/{id}", method = RequestMethod.PUT, produces = MediaType.APPLICATION_JSON_VALUE)
-    @ResponseStatus(HttpStatus.NO_CONTENT)
-    public void findUnfulfilledRequests(final @PathVariable UUID id, final @RequestBody String reason) {
-        examPrintRequestService.denyRequest(id, reason);
+    public ResponseEntity<ExamPrintRequest> denyRequest(final @PathVariable UUID id, final @RequestBody String reason) {
+        Optional<ExamPrintRequest> maybeExamPrintRequest = examPrintRequestService.updateAndGetRequest(ExamPrintRequestStatus.DENIED, id, reason);
+
+        if (!maybeExamPrintRequest.isPresent()) {
+            return new ResponseEntity<>(HttpStatus.NOT_FOUND);
+        }
+
+        return ResponseEntity.ok(maybeExamPrintRequest.get());
     }
 
     @RequestMapping(value = "/approve/{id}", method = RequestMethod.PUT, produces = MediaType.APPLICATION_JSON_VALUE)
     public ResponseEntity<ExamPrintRequest> findAndApprovePrintRequest(final @PathVariable UUID id) {
-        Optional<ExamPrintRequest> maybeExamPrintRequest = examPrintRequestService.findAndApprovePrintRequest(id);
+        Optional<ExamPrintRequest> maybeExamPrintRequest = examPrintRequestService.updateAndGetRequest(ExamPrintRequestStatus.APPROVED, id, null);
 
         if (!maybeExamPrintRequest.isPresent()) {
-            return new ResponseEntity<>(HttpStatus.UNPROCESSABLE_ENTITY);
+            return new ResponseEntity<>(HttpStatus.NOT_FOUND);
         }
 
         return ResponseEntity.ok(maybeExamPrintRequest.get());

--- a/service/src/main/java/tds/exam/web/endpoints/ExamPrintRequestController.java
+++ b/service/src/main/java/tds/exam/web/endpoints/ExamPrintRequestController.java
@@ -3,11 +3,17 @@ package tds.exam.web.endpoints;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.MediaType;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestMethod;
 import org.springframework.web.bind.annotation.ResponseStatus;
 import org.springframework.web.bind.annotation.RestController;
+
+import java.util.List;
+import java.util.Optional;
+import java.util.UUID;
 
 import tds.exam.ExamPrintRequest;
 import tds.exam.services.ExamPrintRequestService;
@@ -26,5 +32,32 @@ public class ExamPrintRequestController {
     @ResponseStatus(HttpStatus.NO_CONTENT)
     public void createExamRequest(@RequestBody ExamPrintRequest request) {
         examPrintRequestService.insert(request);
+    }
+
+    @RequestMapping(value = "/approved/{sessionId}", method = RequestMethod.GET, produces = MediaType.APPLICATION_JSON_VALUE)
+    public ResponseEntity<List<ExamPrintRequest>> findUnfulfilledRequests(@PathVariable UUID sessionId) {
+        return ResponseEntity.ok(examPrintRequestService.findApprovedRequests(sessionId));
+    }
+
+    @RequestMapping(value = "/{sessionId}/{examId}", method = RequestMethod.GET, produces = MediaType.APPLICATION_JSON_VALUE)
+    public ResponseEntity<List<ExamPrintRequest>> findUnfulfilledRequests(final @PathVariable UUID examId, final @PathVariable UUID sessionId) {
+        return ResponseEntity.ok(examPrintRequestService.findUnfulfilledRequests(examId, sessionId));
+    }
+
+    @RequestMapping(value = "/deny/{id}", method = RequestMethod.PUT, produces = MediaType.APPLICATION_JSON_VALUE)
+    @ResponseStatus(HttpStatus.NO_CONTENT)
+    public void findUnfulfilledRequests(final @PathVariable UUID id, final @RequestBody String reason) {
+        examPrintRequestService.denyRequest(id, reason);
+    }
+
+    @RequestMapping(value = "/approve/{id}", method = RequestMethod.PUT, produces = MediaType.APPLICATION_JSON_VALUE)
+    public ResponseEntity<ExamPrintRequest> findAndApprovePrintRequest(final @PathVariable UUID id) {
+        Optional<ExamPrintRequest> maybeExamPrintRequest = examPrintRequestService.findAndApprovePrintRequest(id);
+
+        if (!maybeExamPrintRequest.isPresent()) {
+            return new ResponseEntity<>(HttpStatus.UNPROCESSABLE_ENTITY);
+        }
+
+        return ResponseEntity.ok(maybeExamPrintRequest.get());
     }
 }

--- a/service/src/main/resources/db/migration/V1489427303__exam_update_print_request_status_columns.sql
+++ b/service/src/main/resources/db/migration/V1489427303__exam_update_print_request_status_columns.sql
@@ -1,0 +1,17 @@
+/***********************************************************************************************************************
+  File: V1489427303__exam_update_print_request_status_columns.sql
+
+  Desc: Update to remove approved_at and denied_at columns and adding "status" column
+
+***********************************************************************************************************************/
+
+use exam;
+
+ALTER TABLE exam_print_request_event
+	CHANGE `approved_at` `created_at` DATETIME;
+
+ALTER TABLE exam_print_request_event
+	DROP COLUMN `denied_at`;
+
+ALTER TABLE exam_print_request_event
+	ADD COLUMN `status` VARCHAR(20) NOT NULL DEFAULT 'SUBMITTED';

--- a/service/src/test/java/tds/exam/repositories/impl/ExamPrintRequestRepositoryIntegrationTests.java
+++ b/service/src/test/java/tds/exam/repositories/impl/ExamPrintRequestRepositoryIntegrationTests.java
@@ -18,6 +18,7 @@ import java.util.UUID;
 
 import tds.exam.Exam;
 import tds.exam.ExamPrintRequest;
+import tds.exam.ExamPrintRequestStatus;
 import tds.exam.builder.ExamBuilder;
 import tds.exam.repositories.ExamCommandRepository;
 import tds.exam.repositories.ExamPrintRequestCommandRepository;
@@ -96,8 +97,8 @@ public class ExamPrintRequestRepositoryIntegrationTests {
             .withSessionId(sessionId)
             .withExamId(exam1.getId())
             .withCreatedAt(null)
-            .withDeniedAt(null)
-            .withApprovedAt(null)
+            .withChangedAt(null)
+            .withStatus(ExamPrintRequestStatus.SUBMITTED)
             .withType(ExamPrintRequest.REQUEST_TYPE_EMBOSS_ITEM)
             .build();
         ExamPrintRequest exam1Request2 = new ExamPrintRequest.Builder(UUID.randomUUID())
@@ -105,8 +106,8 @@ public class ExamPrintRequestRepositoryIntegrationTests {
             .withSessionId(sessionId)
             .withExamId(exam1.getId())
             .withCreatedAt(null)
-            .withDeniedAt(null)
-            .withApprovedAt(null)
+            .withChangedAt(null)
+            .withStatus(ExamPrintRequestStatus.SUBMITTED)
             .withType(ExamPrintRequest.REQUEST_TYPE_EMBOSS_PASSAGE)
             .build();
 
@@ -116,8 +117,8 @@ public class ExamPrintRequestRepositoryIntegrationTests {
             .withSessionId(sessionId)
             .withExamId(exam2.getId())
             .withCreatedAt(null)
-            .withDeniedAt(null)
-            .withApprovedAt(null)
+            .withChangedAt(null)
+            .withStatus(ExamPrintRequestStatus.SUBMITTED)
             .withType(ExamPrintRequest.REQUEST_TYPE_EMBOSS_PASSAGE)
             .build();
         // Should not be included in count - fulfilled
@@ -126,8 +127,8 @@ public class ExamPrintRequestRepositoryIntegrationTests {
             .withSessionId(sessionId)
             .withExamId(exam2.getId())
             .withCreatedAt(null)
-            .withDeniedAt(null)
-            .withApprovedAt(Instant.now().minus(99999))
+            .withChangedAt(Instant.now().minus(99999))
+            .withStatus(ExamPrintRequestStatus.APPROVED)
             .withType(ExamPrintRequest.REQUEST_TYPE_EMBOSS_PASSAGE)
             .build();
 
@@ -137,8 +138,8 @@ public class ExamPrintRequestRepositoryIntegrationTests {
             .withSessionId(diffSessionExam.getSessionId())
             .withExamId(diffSessionExam.getId())
             .withCreatedAt(null)
-            .withDeniedAt(null)
-            .withApprovedAt(null)
+            .withChangedAt(null)
+            .withStatus(ExamPrintRequestStatus.SUBMITTED)
             .withType(ExamPrintRequest.REQUEST_TYPE_EMBOSS_PASSAGE)
             .build();
 
@@ -173,8 +174,8 @@ public class ExamPrintRequestRepositoryIntegrationTests {
             .withSessionId(sessionId)
             .withExamId(exam1.getId())
             .withCreatedAt(Instant.now().minus(33333))
-            .withDeniedAt(null)
-            .withApprovedAt(Instant.now().minus(4444))
+            .withChangedAt(Instant.now().minus(4444))
+            .withStatus(ExamPrintRequestStatus.APPROVED)
             .withType(ExamPrintRequest.REQUEST_TYPE_EMBOSS_ITEM)
             .build();
         ExamPrintRequest exam1Request2 = new ExamPrintRequest.Builder(UUID.randomUUID())
@@ -182,8 +183,8 @@ public class ExamPrintRequestRepositoryIntegrationTests {
             .withSessionId(sessionId)
             .withExamId(exam1.getId())
             .withCreatedAt(Instant.now().minus(55555))
-            .withDeniedAt(null)
-            .withApprovedAt(Instant.now())
+            .withChangedAt(Instant.now())
+            .withStatus(ExamPrintRequestStatus.APPROVED)
             .withType(ExamPrintRequest.REQUEST_TYPE_EMBOSS_PASSAGE)
             .build();
         ExamPrintRequest exam1RequestNotApproved = new ExamPrintRequest.Builder(UUID.randomUUID())
@@ -191,8 +192,8 @@ public class ExamPrintRequestRepositoryIntegrationTests {
             .withSessionId(sessionId)
             .withExamId(exam1.getId())
             .withCreatedAt(Instant.now().minus(55555))
-            .withDeniedAt(null)
-            .withApprovedAt(null)
+            .withChangedAt(null)
+            .withStatus(ExamPrintRequestStatus.SUBMITTED)
             .withType(ExamPrintRequest.REQUEST_TYPE_EMBOSS_PASSAGE)
             .build();
 
@@ -202,18 +203,18 @@ public class ExamPrintRequestRepositoryIntegrationTests {
             .withSessionId(sessionId)
             .withExamId(exam2.getId())
             .withCreatedAt(Instant.now().minus(55555))
-            .withDeniedAt(null)
-            .withApprovedAt(Instant.now())
+            .withChangedAt(Instant.now())
+            .withStatus(ExamPrintRequestStatus.APPROVED)
             .withType(ExamPrintRequest.REQUEST_TYPE_EMBOSS_PASSAGE)
             .build();
-        // Should not be included in count - fulfilled
+        // Should not be included in count - denied
         ExamPrintRequest exam2DeniedRequest = new ExamPrintRequest.Builder(UUID.randomUUID())
             .fromExamPrintRequest(random(ExamPrintRequest.class))
             .withSessionId(sessionId)
             .withExamId(exam2.getId())
             .withCreatedAt(Instant.now())
-            .withDeniedAt(Instant.now())
-            .withApprovedAt(Instant.now().minus(99999))
+            .withChangedAt(Instant.now())
+            .withStatus(ExamPrintRequestStatus.DENIED)
             .withType(ExamPrintRequest.REQUEST_TYPE_EMBOSS_PASSAGE)
             .build();
 
@@ -223,8 +224,8 @@ public class ExamPrintRequestRepositoryIntegrationTests {
             .withSessionId(diffSessionExam.getSessionId())
             .withExamId(diffSessionExam.getId())
             .withCreatedAt(null)
-            .withDeniedAt(null)
-            .withApprovedAt(Instant.now())
+            .withStatus(ExamPrintRequestStatus.APPROVED)
+            .withChangedAt(Instant.now())
             .withType(ExamPrintRequest.REQUEST_TYPE_EMBOSS_PASSAGE)
             .build();
 
@@ -258,8 +259,8 @@ public class ExamPrintRequestRepositoryIntegrationTests {
             .withSessionId(sessionId)
             .withExamId(exam1.getId())
             .withCreatedAt(null)
-            .withDeniedAt(null)
-            .withApprovedAt(null)
+            .withChangedAt(null)
+            .withStatus(ExamPrintRequestStatus.SUBMITTED)
             .withType(ExamPrintRequest.REQUEST_TYPE_EMBOSS_ITEM)
             .build();
         ExamPrintRequest exam1Request2 = new ExamPrintRequest.Builder(UUID.randomUUID())
@@ -267,8 +268,8 @@ public class ExamPrintRequestRepositoryIntegrationTests {
             .withSessionId(sessionId)
             .withExamId(exam1.getId())
             .withCreatedAt(null)
-            .withDeniedAt(null)
-            .withApprovedAt(null)
+            .withChangedAt(null)
+            .withStatus(ExamPrintRequestStatus.SUBMITTED)
             .withType(ExamPrintRequest.REQUEST_TYPE_EMBOSS_PASSAGE)
             .build();
 
@@ -278,8 +279,8 @@ public class ExamPrintRequestRepositoryIntegrationTests {
             .withSessionId(sessionId)
             .withExamId(exam2.getId())
             .withCreatedAt(null)
-            .withDeniedAt(null)
-            .withApprovedAt(null)
+            .withChangedAt(null)
+            .withStatus(ExamPrintRequestStatus.SUBMITTED)
             .withType(ExamPrintRequest.REQUEST_TYPE_EMBOSS_PASSAGE)
             .build();
         // Should not be included in count - fulfilled
@@ -288,8 +289,8 @@ public class ExamPrintRequestRepositoryIntegrationTests {
             .withSessionId(sessionId)
             .withExamId(exam2.getId())
             .withCreatedAt(null)
-            .withDeniedAt(null)
-            .withApprovedAt(Instant.now().minus(99999))
+            .withStatus(ExamPrintRequestStatus.APPROVED)
+            .withChangedAt(Instant.now().minus(99999))
             .withType(ExamPrintRequest.REQUEST_TYPE_EMBOSS_PASSAGE)
             .build();
 
@@ -299,8 +300,8 @@ public class ExamPrintRequestRepositoryIntegrationTests {
             .withSessionId(diffSessionExam.getSessionId())
             .withExamId(diffSessionExam.getId())
             .withCreatedAt(null)
-            .withDeniedAt(null)
-            .withApprovedAt(null)
+            .withChangedAt(null)
+            .withStatus(ExamPrintRequestStatus.SUBMITTED)
             .withType(ExamPrintRequest.REQUEST_TYPE_EMBOSS_PASSAGE)
             .build();
 

--- a/service/src/test/java/tds/exam/repositories/impl/ExamPrintRequestRepositoryIntegrationTests.java
+++ b/service/src/test/java/tds/exam/repositories/impl/ExamPrintRequestRepositoryIntegrationTests.java
@@ -11,7 +11,9 @@ import org.springframework.jdbc.core.namedparam.NamedParameterJdbcTemplate;
 import org.springframework.test.context.junit4.SpringJUnit4ClassRunner;
 import org.springframework.transaction.annotation.Transactional;
 
+import java.util.List;
 import java.util.Map;
+import java.util.Optional;
 import java.util.UUID;
 
 import tds.exam.Exam;
@@ -43,9 +45,206 @@ public class ExamPrintRequestRepositoryIntegrationTests {
     }
 
     @Test
+    public void shouldReturnExamPrintRequest() {
+        Exam exam = new ExamBuilder().build();
+        examCommandRepository.insert(exam);
+
+        ExamPrintRequest request = new ExamPrintRequest.Builder(UUID.randomUUID())
+            .fromExamPrintRequest(random(ExamPrintRequest.class))
+            .withExamId(exam.getId())
+            .build();
+
+        examPrintRequestCommandRepository.insert(request);
+
+        Optional<ExamPrintRequest> maybeRequest = examPrintRequestQueryRepository.findExamPrintRequest(request.getId());
+        assertThat(maybeRequest).isPresent();
+        assertThat(maybeRequest.get()).isEqualTo(request);
+    }
+
+    @Test
+    public void shouldReturnEmptyExamPrintRequest() {
+        Exam exam = new ExamBuilder().build();
+        examCommandRepository.insert(exam);
+
+        ExamPrintRequest request = new ExamPrintRequest.Builder(UUID.randomUUID())
+            .fromExamPrintRequest(random(ExamPrintRequest.class))
+            .withExamId(exam.getId())
+            .build();
+
+        examPrintRequestCommandRepository.insert(request);
+
+        Optional<ExamPrintRequest> maybeRequest = examPrintRequestQueryRepository.findExamPrintRequest(UUID.randomUUID());
+        assertThat(maybeRequest).isNotPresent();
+    }
+
+    @Test
+    public void shouldReturnUnfulfilledPrintRequestsForExamAndSession() {
+        UUID sessionId = UUID.randomUUID();
+        // Has 2 requests
+        Exam exam1 = new ExamBuilder().withSessionId(sessionId).build();
+        // Has 1 request
+        Exam exam2 = new ExamBuilder().withSessionId(sessionId).build();
+        Exam diffSessionExam = new ExamBuilder().build();
+
+        examCommandRepository.insert(exam1);
+        examCommandRepository.insert(exam2);
+        examCommandRepository.insert(diffSessionExam);
+
+        // Exam 1
+        ExamPrintRequest exam1Request1 = new ExamPrintRequest.Builder(UUID.randomUUID())
+            .fromExamPrintRequest(random(ExamPrintRequest.class))
+            .withSessionId(sessionId)
+            .withExamId(exam1.getId())
+            .withCreatedAt(null)
+            .withDeniedAt(null)
+            .withApprovedAt(null)
+            .withType(ExamPrintRequest.REQUEST_TYPE_EMBOSS_ITEM)
+            .build();
+        ExamPrintRequest exam1Request2 = new ExamPrintRequest.Builder(UUID.randomUUID())
+            .fromExamPrintRequest(random(ExamPrintRequest.class))
+            .withSessionId(sessionId)
+            .withExamId(exam1.getId())
+            .withCreatedAt(null)
+            .withDeniedAt(null)
+            .withApprovedAt(null)
+            .withType(ExamPrintRequest.REQUEST_TYPE_EMBOSS_PASSAGE)
+            .build();
+
+        // Exam 2
+        ExamPrintRequest exam2Request = new ExamPrintRequest.Builder(UUID.randomUUID())
+            .fromExamPrintRequest(random(ExamPrintRequest.class))
+            .withSessionId(sessionId)
+            .withExamId(exam2.getId())
+            .withCreatedAt(null)
+            .withDeniedAt(null)
+            .withApprovedAt(null)
+            .withType(ExamPrintRequest.REQUEST_TYPE_EMBOSS_PASSAGE)
+            .build();
+        // Should not be included in count - fulfilled
+        ExamPrintRequest exam2FulfilledRequest = new ExamPrintRequest.Builder(UUID.randomUUID())
+            .fromExamPrintRequest(random(ExamPrintRequest.class))
+            .withSessionId(sessionId)
+            .withExamId(exam2.getId())
+            .withCreatedAt(null)
+            .withDeniedAt(null)
+            .withApprovedAt(Instant.now().minus(99999))
+            .withType(ExamPrintRequest.REQUEST_TYPE_EMBOSS_PASSAGE)
+            .build();
+
+        // Exam 3 - different session, should not be included
+        ExamPrintRequest diffSessionExamRequest = new ExamPrintRequest.Builder(UUID.randomUUID())
+            .fromExamPrintRequest(random(ExamPrintRequest.class))
+            .withSessionId(diffSessionExam.getSessionId())
+            .withExamId(diffSessionExam.getId())
+            .withCreatedAt(null)
+            .withDeniedAt(null)
+            .withApprovedAt(null)
+            .withType(ExamPrintRequest.REQUEST_TYPE_EMBOSS_PASSAGE)
+            .build();
+
+        examPrintRequestCommandRepository.insert(exam1Request1);
+        examPrintRequestCommandRepository.insert(exam1Request2);
+        examPrintRequestCommandRepository.insert(exam2Request);
+        examPrintRequestCommandRepository.insert(exam2FulfilledRequest);
+        examPrintRequestCommandRepository.insert(diffSessionExamRequest);
+
+        List<ExamPrintRequest> exam1Requests = examPrintRequestQueryRepository.findUnfulfilledRequests(exam1.getId(), sessionId);
+        assertThat(exam1Requests).containsExactly(exam1Request1, exam1Request2);
+        List<ExamPrintRequest> exam2Requests = examPrintRequestQueryRepository.findUnfulfilledRequests(exam2.getId(), sessionId);
+        assertThat(exam2Requests).containsExactly(exam2Request);
+    }
+
+    @Test
+    public void shouldReturnApprovedPrintRequestsForSession() {
+        UUID sessionId = UUID.randomUUID();
+        // Has 2 requests
+        Exam exam1 = new ExamBuilder().withSessionId(sessionId).build();
+        // Has 1 request
+        Exam exam2 = new ExamBuilder().withSessionId(sessionId).build();
+        Exam diffSessionExam = new ExamBuilder().build();
+
+        examCommandRepository.insert(exam1);
+        examCommandRepository.insert(exam2);
+        examCommandRepository.insert(diffSessionExam);
+
+        // Exam 1
+        ExamPrintRequest exam1Request1 = new ExamPrintRequest.Builder(UUID.randomUUID())
+            .fromExamPrintRequest(random(ExamPrintRequest.class))
+            .withSessionId(sessionId)
+            .withExamId(exam1.getId())
+            .withCreatedAt(Instant.now().minus(33333))
+            .withDeniedAt(null)
+            .withApprovedAt(Instant.now().minus(4444))
+            .withType(ExamPrintRequest.REQUEST_TYPE_EMBOSS_ITEM)
+            .build();
+        ExamPrintRequest exam1Request2 = new ExamPrintRequest.Builder(UUID.randomUUID())
+            .fromExamPrintRequest(random(ExamPrintRequest.class))
+            .withSessionId(sessionId)
+            .withExamId(exam1.getId())
+            .withCreatedAt(Instant.now().minus(55555))
+            .withDeniedAt(null)
+            .withApprovedAt(Instant.now())
+            .withType(ExamPrintRequest.REQUEST_TYPE_EMBOSS_PASSAGE)
+            .build();
+        ExamPrintRequest exam1RequestNotApproved = new ExamPrintRequest.Builder(UUID.randomUUID())
+            .fromExamPrintRequest(random(ExamPrintRequest.class))
+            .withSessionId(sessionId)
+            .withExamId(exam1.getId())
+            .withCreatedAt(Instant.now().minus(55555))
+            .withDeniedAt(null)
+            .withApprovedAt(null)
+            .withType(ExamPrintRequest.REQUEST_TYPE_EMBOSS_PASSAGE)
+            .build();
+
+        // Exam 2
+        ExamPrintRequest exam2Request = new ExamPrintRequest.Builder(UUID.randomUUID())
+            .fromExamPrintRequest(random(ExamPrintRequest.class))
+            .withSessionId(sessionId)
+            .withExamId(exam2.getId())
+            .withCreatedAt(Instant.now().minus(55555))
+            .withDeniedAt(null)
+            .withApprovedAt(Instant.now())
+            .withType(ExamPrintRequest.REQUEST_TYPE_EMBOSS_PASSAGE)
+            .build();
+        // Should not be included in count - fulfilled
+        ExamPrintRequest exam2DeniedRequest = new ExamPrintRequest.Builder(UUID.randomUUID())
+            .fromExamPrintRequest(random(ExamPrintRequest.class))
+            .withSessionId(sessionId)
+            .withExamId(exam2.getId())
+            .withCreatedAt(Instant.now())
+            .withDeniedAt(Instant.now())
+            .withApprovedAt(Instant.now().minus(99999))
+            .withType(ExamPrintRequest.REQUEST_TYPE_EMBOSS_PASSAGE)
+            .build();
+
+        // Exam 3 - different session, should not be included
+        ExamPrintRequest diffSessionExamRequest = new ExamPrintRequest.Builder(UUID.randomUUID())
+            .fromExamPrintRequest(random(ExamPrintRequest.class))
+            .withSessionId(diffSessionExam.getSessionId())
+            .withExamId(diffSessionExam.getId())
+            .withCreatedAt(null)
+            .withDeniedAt(null)
+            .withApprovedAt(Instant.now())
+            .withType(ExamPrintRequest.REQUEST_TYPE_EMBOSS_PASSAGE)
+            .build();
+
+        examPrintRequestCommandRepository.insert(exam1Request1);
+        examPrintRequestCommandRepository.insert(exam1Request2);
+        examPrintRequestCommandRepository.insert(exam1RequestNotApproved);
+        examPrintRequestCommandRepository.insert(exam2Request);
+        examPrintRequestCommandRepository.insert(exam2DeniedRequest);
+        examPrintRequestCommandRepository.insert(diffSessionExamRequest);
+
+        List<ExamPrintRequest> exam1Requests = examPrintRequestQueryRepository.findApprovedRequests(sessionId);
+        assertThat(exam1Requests).containsExactlyInAnyOrder(exam1Request1, exam1Request2, exam2Request);
+    }
+
+    @Test
     public void shouldReturnCountsForExamsInSession() {
         UUID sessionId = UUID.randomUUID();
+        // Has 2 requests
         Exam exam1 = new ExamBuilder().withSessionId(sessionId).build();
+        // Has 1 request
         Exam exam2 = new ExamBuilder().withSessionId(sessionId).build();
         Exam diffSessionExam = new ExamBuilder().build();
 
@@ -118,4 +317,5 @@ public class ExamPrintRequestRepositoryIntegrationTests {
         assertThat(requestCounts.get(exam2.getId())).isEqualTo(1);
         assertThat(requestCounts.containsKey(diffSessionExam.getId())).isFalse();
     }
+
 }

--- a/service/src/test/java/tds/exam/services/impl/ExamPrintRequestServiceImplTest.java
+++ b/service/src/test/java/tds/exam/services/impl/ExamPrintRequestServiceImplTest.java
@@ -3,8 +3,15 @@ package tds.exam.services.impl;
 import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
+import org.mockito.ArgumentCaptor;
+import org.mockito.Captor;
 import org.mockito.Mock;
 import org.mockito.runners.MockitoJUnitRunner;
+
+import java.util.Arrays;
+import java.util.List;
+import java.util.Optional;
+import java.util.UUID;
 
 import tds.exam.ExamPrintRequest;
 import tds.exam.repositories.ExamPrintRequestCommandRepository;
@@ -12,7 +19,11 @@ import tds.exam.repositories.ExamPrintRequestQueryRepository;
 import tds.exam.services.ExamPrintRequestService;
 
 import static io.github.benas.randombeans.api.EnhancedRandom.random;
+import static org.assertj.core.api.AssertionsForInterfaceTypes.assertThat;
+import static org.mockito.Matchers.isA;
+import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
 
 @RunWith(MockitoJUnitRunner.class)
 public class ExamPrintRequestServiceImplTest {
@@ -23,6 +34,9 @@ public class ExamPrintRequestServiceImplTest {
 
     @Mock
     private ExamPrintRequestCommandRepository mockExamPrintRequestCommandRepository;
+
+    @Captor
+    ArgumentCaptor<ExamPrintRequest> examPrintRequestArgumentCaptor;
 
     @Before
     public void setup() {
@@ -35,5 +49,71 @@ public class ExamPrintRequestServiceImplTest {
         ExamPrintRequest examPrintRequest = random(ExamPrintRequest.class);
         examPrintRequestService.insert(examPrintRequest);
         verify(mockExamPrintRequestCommandRepository).insert(examPrintRequest);
+    }
+
+    @Test
+    public void shouldReturnListOfUnfulfilledExamPrintRequests() {
+        List<ExamPrintRequest> examPrintRequests = Arrays.asList(random(ExamPrintRequest.class));
+        when(mockExamPrintRequestQueryRepository.findUnfulfilledRequests(isA(UUID.class), isA(UUID.class)))
+            .thenReturn(examPrintRequests);
+        List<ExamPrintRequest> retRequests = examPrintRequestService.findUnfulfilledRequests(UUID.randomUUID(), UUID.randomUUID());
+        verify(mockExamPrintRequestQueryRepository).findUnfulfilledRequests(isA(UUID.class), isA(UUID.class));
+
+        assertThat(retRequests).isEqualTo(examPrintRequests);
+    }
+
+    @Test
+    public void shouldDenyPrintRequest() {
+        final UUID id = UUID.randomUUID();
+        final String denyReason = "You enjoyed the movie 'Cloud Atlas'";
+        examPrintRequestService.denyRequest(id, denyReason);
+        verify(mockExamPrintRequestCommandRepository).update(examPrintRequestArgumentCaptor.capture());
+        ExamPrintRequest printRequest = examPrintRequestArgumentCaptor.getValue();
+
+        assertThat(printRequest.getId()).isEqualTo(id);
+        assertThat(printRequest.getReasonDenied()).isEqualTo(denyReason);
+        assertThat(printRequest.getDeniedAt()).isNotNull();
+    }
+
+    @Test
+    public void shouldFindAllApprovedPrintRequests() {
+        final UUID sessionId = UUID.randomUUID();
+        ExamPrintRequest request1 = random(ExamPrintRequest.class);
+        ExamPrintRequest request2 = random(ExamPrintRequest.class);
+
+        when(mockExamPrintRequestQueryRepository.findApprovedRequests(sessionId)).thenReturn(Arrays.asList(request1, request2));
+        List<ExamPrintRequest> examPrintRequests = examPrintRequestService.findApprovedRequests(sessionId);
+        assertThat(examPrintRequests).containsExactly(request1, request2);
+        verify(mockExamPrintRequestQueryRepository).findApprovedRequests(sessionId);
+    }
+
+    @Test
+    public void shouldFindAndApprovePrintRequest() {
+        final UUID id = UUID.randomUUID();
+        final ExamPrintRequest request = random(ExamPrintRequest.class);
+        when(mockExamPrintRequestQueryRepository.findExamPrintRequest(id)).thenReturn(Optional.of(request));
+
+        Optional<ExamPrintRequest> maybeApprovedRequest = examPrintRequestService.findAndApprovePrintRequest(id);
+        assertThat(maybeApprovedRequest).isPresent();
+
+        verify(mockExamPrintRequestQueryRepository).findExamPrintRequest(id);
+        verify(mockExamPrintRequestCommandRepository).update(examPrintRequestArgumentCaptor.capture());
+
+        ExamPrintRequest approvedRequest = examPrintRequestArgumentCaptor.getValue();
+        assertThat(approvedRequest.getId()).isEqualTo(request.getId());
+        assertThat(approvedRequest.getApprovedAt()).isNotNull();
+    }
+
+    @Test
+    public void shouldReturnEmptyAndNotApproveForNoExamPrintRequestFound() {
+        final UUID id = UUID.randomUUID();
+        final ExamPrintRequest request = random(ExamPrintRequest.class);
+        when(mockExamPrintRequestQueryRepository.findExamPrintRequest(id)).thenReturn(Optional.empty());
+
+        Optional<ExamPrintRequest> maybeApprovedRequest = examPrintRequestService.findAndApprovePrintRequest(id);
+        assertThat(maybeApprovedRequest).isNotPresent();
+
+        verify(mockExamPrintRequestQueryRepository).findExamPrintRequest(id);
+        verify(mockExamPrintRequestCommandRepository, never()).update(isA(ExamPrintRequest.class));
     }
 }

--- a/service/src/test/java/tds/exam/web/endpoints/ExamPrintRequestControllerIntegrationTests.java
+++ b/service/src/test/java/tds/exam/web/endpoints/ExamPrintRequestControllerIntegrationTests.java
@@ -3,7 +3,6 @@ package tds.exam.web.endpoints;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.databind.ObjectWriter;
-import com.fasterxml.jackson.datatype.joda.JodaModule;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -15,6 +14,10 @@ import org.springframework.test.context.junit4.SpringRunner;
 import org.springframework.test.web.servlet.MockMvc;
 
 import java.net.URI;
+import java.util.Arrays;
+import java.util.List;
+import java.util.Optional;
+import java.util.UUID;
 
 import tds.common.configuration.JacksonObjectMapperConfiguration;
 import tds.common.configuration.SecurityConfiguration;
@@ -23,9 +26,15 @@ import tds.exam.ExamPrintRequest;
 import tds.exam.services.ExamPrintRequestService;
 
 import static io.github.benas.randombeans.api.EnhancedRandom.random;
+import static org.hamcrest.CoreMatchers.is;
 import static org.mockito.Matchers.any;
+import static org.mockito.Matchers.isA;
 import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.put;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
 @RunWith(SpringRunner.class)
@@ -53,5 +62,101 @@ public class ExamPrintRequestControllerIntegrationTests {
             .andExpect(status().isNoContent());
 
         verify(mockExamPrintRequestService).insert(any());
+    }
+
+    @Test
+    public void shouldDenyPrintRequest() throws Exception {
+        final UUID id = UUID.randomUUID();
+        final String reason = "I don't like your tie";
+
+        http.perform(put("/exam/print/deny/{id}", id)
+            .contentType(MediaType.APPLICATION_JSON)
+            .content(reason))
+            .andExpect(status().isNoContent());
+
+        verify(mockExamPrintRequestService).denyRequest(id, reason);
+    }
+
+    @Test
+    public void shouldRetrieveListOfExamPrintRequests() throws Exception {
+        final ExamPrintRequest examPrintRequest = random(ExamPrintRequest.class);
+        final UUID examId = UUID.randomUUID();
+        final UUID sessionId = UUID.randomUUID();
+
+        when(mockExamPrintRequestService.findUnfulfilledRequests(examId, sessionId)).thenReturn(Arrays.asList(examPrintRequest));
+
+        http.perform(get("/exam/print/{sessionId}/{examId}", sessionId, examId)
+            .contentType(MediaType.APPLICATION_JSON))
+            .andExpect(status().isOk())
+            .andExpect(jsonPath("[0].id", is(examPrintRequest.getId().toString())))
+            .andExpect(jsonPath("[0].sessionId", is(examPrintRequest.getSessionId().toString())))
+            .andExpect(jsonPath("[0].type", is(examPrintRequest.getType())))
+            .andExpect(jsonPath("[0].value", is(examPrintRequest.getValue())))
+            .andExpect(jsonPath("[0].reasonDenied", is(examPrintRequest.getReasonDenied())))
+            .andExpect(jsonPath("[0].description", is(examPrintRequest.getDescription())))
+            .andExpect(jsonPath("[0].itemPosition", is(examPrintRequest.getItemPosition())))
+            .andExpect(jsonPath("[0].pagePosition", is(examPrintRequest.getPagePosition())))
+            .andExpect(jsonPath("[0].examId", is(examPrintRequest.getExamId().toString())));
+
+        verify(mockExamPrintRequestService).findUnfulfilledRequests(examId, sessionId);
+    }
+
+    @Test
+    public void shouldRetrieveListOfApprovedExamPrintRequests() throws Exception {
+        final ExamPrintRequest examPrintRequest = random(ExamPrintRequest.class);
+        final UUID examId = UUID.randomUUID();
+        final UUID sessionId = UUID.randomUUID();
+
+        when(mockExamPrintRequestService.findApprovedRequests(sessionId)).thenReturn(Arrays.asList(examPrintRequest));
+
+        http.perform(get("/exam/print/approved/{sessionId}", sessionId)
+            .contentType(MediaType.APPLICATION_JSON))
+            .andExpect(status().isOk())
+            .andExpect(jsonPath("[0].id", is(examPrintRequest.getId().toString())))
+            .andExpect(jsonPath("[0].sessionId", is(examPrintRequest.getSessionId().toString())))
+            .andExpect(jsonPath("[0].type", is(examPrintRequest.getType())))
+            .andExpect(jsonPath("[0].value", is(examPrintRequest.getValue())))
+            .andExpect(jsonPath("[0].reasonDenied", is(examPrintRequest.getReasonDenied())))
+            .andExpect(jsonPath("[0].description", is(examPrintRequest.getDescription())))
+            .andExpect(jsonPath("[0].itemPosition", is(examPrintRequest.getItemPosition())))
+            .andExpect(jsonPath("[0].pagePosition", is(examPrintRequest.getPagePosition())))
+            .andExpect(jsonPath("[0].examId", is(examPrintRequest.getExamId().toString())));
+
+        verify(mockExamPrintRequestService).findApprovedRequests(sessionId);
+    }
+
+    @Test
+    public void shouldApproveAndFindPrintRequest() throws Exception {
+        final UUID id = UUID.randomUUID();
+        final ExamPrintRequest examPrintRequest = new ExamPrintRequest.Builder(id)
+            .fromExamPrintRequest(random(ExamPrintRequest.class))
+            .build();
+
+        when(mockExamPrintRequestService.findAndApprovePrintRequest(id)).thenReturn(Optional.of(examPrintRequest));
+
+        http.perform(put("/exam/print/approve/{id}", id)
+            .contentType(MediaType.APPLICATION_JSON))
+            .andExpect(status().isOk())
+            .andExpect(jsonPath("id", is(examPrintRequest.getId().toString())))
+            .andExpect(jsonPath("sessionId", is(examPrintRequest.getSessionId().toString())))
+            .andExpect(jsonPath("type", is(examPrintRequest.getType())))
+            .andExpect(jsonPath("value", is(examPrintRequest.getValue())))
+            .andExpect(jsonPath("reasonDenied", is(examPrintRequest.getReasonDenied())))
+            .andExpect(jsonPath("description", is(examPrintRequest.getDescription())))
+            .andExpect(jsonPath("itemPosition", is(examPrintRequest.getItemPosition())))
+            .andExpect(jsonPath("pagePosition", is(examPrintRequest.getPagePosition())))
+            .andExpect(jsonPath("examId", is(examPrintRequest.getExamId().toString())));
+
+        verify(mockExamPrintRequestService).findAndApprovePrintRequest(id);
+    }
+
+    @Test
+    public void shouldReturnUnprocessableEntityErrorForNoRequestFound() throws Exception {
+        final UUID id = UUID.randomUUID();
+        when(mockExamPrintRequestService.findAndApprovePrintRequest(id)).thenReturn(Optional.empty());
+        http.perform(put("/exam/print/approve/{id}", id)
+            .contentType(MediaType.APPLICATION_JSON))
+            .andExpect(status().isUnprocessableEntity());
+        verify(mockExamPrintRequestService).findAndApprovePrintRequest(id);
     }
 }

--- a/service/src/test/java/tds/exam/web/endpoints/ExamPrintRequestControllerIntegrationTests.java
+++ b/service/src/test/java/tds/exam/web/endpoints/ExamPrintRequestControllerIntegrationTests.java
@@ -15,7 +15,6 @@ import org.springframework.test.web.servlet.MockMvc;
 
 import java.net.URI;
 import java.util.Arrays;
-import java.util.List;
 import java.util.Optional;
 import java.util.UUID;
 
@@ -23,16 +22,16 @@ import tds.common.configuration.JacksonObjectMapperConfiguration;
 import tds.common.configuration.SecurityConfiguration;
 import tds.common.web.advice.ExceptionAdvice;
 import tds.exam.ExamPrintRequest;
+import tds.exam.ExamPrintRequestStatus;
 import tds.exam.services.ExamPrintRequestService;
 
 import static io.github.benas.randombeans.api.EnhancedRandom.random;
 import static org.hamcrest.CoreMatchers.is;
 import static org.mockito.Matchers.any;
-import static org.mockito.Matchers.isA;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
-import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.put;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
@@ -68,13 +67,36 @@ public class ExamPrintRequestControllerIntegrationTests {
     public void shouldDenyPrintRequest() throws Exception {
         final UUID id = UUID.randomUUID();
         final String reason = "I don't like your tie";
+        ExamPrintRequest examPrintRequest = random(ExamPrintRequest.class);
+        when(mockExamPrintRequestService.updateAndGetRequest(ExamPrintRequestStatus.DENIED, id, reason)).thenReturn(Optional.of(examPrintRequest));
 
         http.perform(put("/exam/print/deny/{id}", id)
             .contentType(MediaType.APPLICATION_JSON)
             .content(reason))
-            .andExpect(status().isNoContent());
+            .andExpect(status().isOk())
+            .andExpect(jsonPath("id", is(examPrintRequest.getId().toString())))
+            .andExpect(jsonPath("sessionId", is(examPrintRequest.getSessionId().toString())))
+            .andExpect(jsonPath("type", is(examPrintRequest.getType())))
+            .andExpect(jsonPath("value", is(examPrintRequest.getValue())))
+            .andExpect(jsonPath("reasonDenied", is(examPrintRequest.getReasonDenied())))
+            .andExpect(jsonPath("description", is(examPrintRequest.getDescription())))
+            .andExpect(jsonPath("itemPosition", is(examPrintRequest.getItemPosition())))
+            .andExpect(jsonPath("pagePosition", is(examPrintRequest.getPagePosition())))
+            .andExpect(jsonPath("examId", is(examPrintRequest.getExamId().toString())));
 
-        verify(mockExamPrintRequestService).denyRequest(id, reason);
+        verify(mockExamPrintRequestService).updateAndGetRequest(ExamPrintRequestStatus.DENIED, id, reason);
+    }
+
+    @Test
+    public void shouldReturnNotFoundErrorForNoRequestFoundDenied() throws Exception {
+        final UUID id = UUID.randomUUID();
+        final String reason = "A reason";
+        when(mockExamPrintRequestService.updateAndGetRequest(ExamPrintRequestStatus.DENIED, id, reason)).thenReturn(Optional.empty());
+        http.perform(put("/exam/print/deny/{id}", id)
+            .content(reason)
+            .contentType(MediaType.APPLICATION_JSON))
+            .andExpect(status().isNotFound());
+        verify(mockExamPrintRequestService).updateAndGetRequest(ExamPrintRequestStatus.DENIED, id, reason);
     }
 
     @Test
@@ -104,7 +126,6 @@ public class ExamPrintRequestControllerIntegrationTests {
     @Test
     public void shouldRetrieveListOfApprovedExamPrintRequests() throws Exception {
         final ExamPrintRequest examPrintRequest = random(ExamPrintRequest.class);
-        final UUID examId = UUID.randomUUID();
         final UUID sessionId = UUID.randomUUID();
 
         when(mockExamPrintRequestService.findApprovedRequests(sessionId)).thenReturn(Arrays.asList(examPrintRequest));
@@ -132,7 +153,7 @@ public class ExamPrintRequestControllerIntegrationTests {
             .fromExamPrintRequest(random(ExamPrintRequest.class))
             .build();
 
-        when(mockExamPrintRequestService.findAndApprovePrintRequest(id)).thenReturn(Optional.of(examPrintRequest));
+        when(mockExamPrintRequestService.updateAndGetRequest(ExamPrintRequestStatus.APPROVED, id, null)).thenReturn(Optional.of(examPrintRequest));
 
         http.perform(put("/exam/print/approve/{id}", id)
             .contentType(MediaType.APPLICATION_JSON))
@@ -147,16 +168,16 @@ public class ExamPrintRequestControllerIntegrationTests {
             .andExpect(jsonPath("pagePosition", is(examPrintRequest.getPagePosition())))
             .andExpect(jsonPath("examId", is(examPrintRequest.getExamId().toString())));
 
-        verify(mockExamPrintRequestService).findAndApprovePrintRequest(id);
+        verify(mockExamPrintRequestService).updateAndGetRequest(ExamPrintRequestStatus.APPROVED, id, null);
     }
 
     @Test
-    public void shouldReturnUnprocessableEntityErrorForNoRequestFound() throws Exception {
+    public void shouldReturnNotFoundErrorForNoRequestFound() throws Exception {
         final UUID id = UUID.randomUUID();
-        when(mockExamPrintRequestService.findAndApprovePrintRequest(id)).thenReturn(Optional.empty());
+        when(mockExamPrintRequestService.updateAndGetRequest(ExamPrintRequestStatus.APPROVED, id, null)).thenReturn(Optional.empty());
         http.perform(put("/exam/print/approve/{id}", id)
             .contentType(MediaType.APPLICATION_JSON))
-            .andExpect(status().isUnprocessableEntity());
-        verify(mockExamPrintRequestService).findAndApprovePrintRequest(id);
+            .andExpect(status().isNotFound());
+        verify(mockExamPrintRequestService).updateAndGetRequest(ExamPrintRequestStatus.APPROVED, id, null);
     }
 }


### PR DESCRIPTION
Implementation of multiple endpoints used by TDS_Proctor print request interaction.

The following APIs have been added:
- find and approve print request
- find all approved print requests for session
- deny print request
- find unfulfilled requests

These endpoints will be called by TDS_Proctor. Those changes will be made in a separate PR.

These are ports of data-access code found in StudentDLL and TesteeRequestRepository. For reference, please see the following methods in TesteeRequestRepository.java (TDS_Proctor)

- getTesteeRequestValues() (find and approve)
- getApprovedTesteeRequests() (find approved requests for session)
- getCurrentTesteeRequests() (find unfulfilled requests for session and exam)
- denyTesteeRequest()