### PR TITLE
Change ExamSegmentService to return Optional instead of throwing when…

### DIFF
--- a/service/src/main/java/tds/exam/services/ExamSegmentService.java
+++ b/service/src/main/java/tds/exam/services/ExamSegmentService.java
@@ -41,7 +41,7 @@ public interface ExamSegmentService {
      * @param segmentPosition The position/sequence of the {@link tds.exam.ExamSegment} to find
      * @return The {@link tds.exam.ExamSegment} for the specified exam id and position
      */
-    Response<ExamSegment> findByExamIdAndSegmentPosition(final UUID examId, final int segmentPosition);
+    Optional<ExamSegment> findByExamIdAndSegmentPosition(final UUID examId, final int segmentPosition);
 
     /**
      * Update a one or more {@link tds.exam.ExamSegment}s with new values.

--- a/service/src/main/java/tds/exam/services/impl/ExamSegmentServiceImpl.java
+++ b/service/src/main/java/tds/exam/services/impl/ExamSegmentServiceImpl.java
@@ -184,11 +184,8 @@ public class ExamSegmentServiceImpl implements ExamSegmentService {
     }
 
     @Override
-    public Response<ExamSegment> findByExamIdAndSegmentPosition(final UUID examId, final int segmentPosition) {
-        ExamSegment segment = examSegmentQueryRepository.findByExamIdAndSegmentPosition(examId, segmentPosition)
-            .orElseThrow(() -> new NotFoundException(String.format("Could not find an exam segment for exam id %s and segment position %d", examId, segmentPosition)));
-
-        return new Response<>(segment);
+    public Optional<ExamSegment> findByExamIdAndSegmentPosition(final UUID examId, final int segmentPosition) {
+        return examSegmentQueryRepository.findByExamIdAndSegmentPosition(examId, segmentPosition);
     }
 
     @Override

--- a/service/src/main/java/tds/exam/utils/listeners/OnCompletedStatusExamChangeListener.java
+++ b/service/src/main/java/tds/exam/utils/listeners/OnCompletedStatusExamChangeListener.java
@@ -5,6 +5,7 @@ import org.springframework.stereotype.Component;
 import org.springframework.transaction.annotation.Transactional;
 
 import java.util.List;
+import java.util.Optional;
 
 import tds.common.Response;
 import tds.common.entity.utils.ChangeListener;
@@ -51,12 +52,12 @@ public class OnCompletedStatusExamChangeListener implements ChangeListener<Exam>
 
         // CommonDLL#_OnStatus_Completed_SP, line 1425: Update the exam to indicate this segment is not permeable,
         // meaning the segment cannot be accessed/visited again.  Legacy code sets isPermeable to -1
-        Response<ExamSegment> examSegmentResponse = examSegmentService.findByExamIdAndSegmentPosition(newExam.getId(),
+        Optional<ExamSegment> maybeExamSegment = examSegmentService.findByExamIdAndSegmentPosition(newExam.getId(),
             newExam.getCurrentSegmentPosition());
 
-        if (examSegmentResponse.getData().isPresent()) {
+        if (maybeExamSegment.isPresent()) {
             examSegmentService.update(ExamSegment.Builder
-                .fromSegment(examSegmentResponse.getData().get())
+                .fromSegment(maybeExamSegment.get())
                 .withPermeable(false)
                 .build());
         }

--- a/service/src/main/java/tds/exam/utils/listeners/OnPausedStatusExamChangeListener.java
+++ b/service/src/main/java/tds/exam/utils/listeners/OnPausedStatusExamChangeListener.java
@@ -4,6 +4,8 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Component;
 import org.springframework.transaction.annotation.Transactional;
 
+import java.util.Optional;
+
 import tds.common.Response;
 import tds.common.entity.utils.ChangeListener;
 import tds.common.util.Preconditions;
@@ -42,11 +44,11 @@ public class OnPausedStatusExamChangeListener implements ChangeListener<Exam> {
         // code sets isPermeable to -1, which means false.
         // Omit CommonDLL#_OnStatus_Paused_SP, line 1489 - 1493: If the segment's getRestorePermeableCondition is set to
         // "segment" or "paused", then it is not equal to "completed" thus the update to the segment should happen.
-        Response<ExamSegment> segmentResponse = examSegmentService.findByExamIdAndSegmentPosition(newExam.getId(),
+        Optional<ExamSegment> maybeExamSegment = examSegmentService.findByExamIdAndSegmentPosition(newExam.getId(),
             newExam.getCurrentSegmentPosition());
 
-        if (segmentResponse.getData().isPresent()) {
-            ExamSegment segment = segmentResponse.getData().get();
+        if (maybeExamSegment.isPresent()) {
+            ExamSegment segment = maybeExamSegment.get();
 
             if (segment.isPermeable()
                 && (segment.getRestorePermeableCondition().equalsIgnoreCase("segment")

--- a/service/src/test/java/tds/exam/services/impl/ExamSegmentServiceImplTest.java
+++ b/service/src/test/java/tds/exam/services/impl/ExamSegmentServiceImplTest.java
@@ -659,12 +659,11 @@ public class ExamSegmentServiceImplTest {
         when(mockExamSegmentQueryRepository.findByExamIdAndSegmentPosition(any(UUID.class), any(Integer.class)))
             .thenReturn(Optional.of(mockSegment));
 
-        Response<ExamSegment> segmentResponse =
+        Optional<ExamSegment> maybeExamSegment =
             examSegmentService.findByExamIdAndSegmentPosition(mockExam.getId(), mockExam.getCurrentSegmentPosition());
 
-        assertThat(segmentResponse.getData().isPresent()).isTrue();
-        assertThat(segmentResponse.getError().isPresent()).isFalse();
-        ExamSegment result = segmentResponse.getData().get();
+        assertThat(maybeExamSegment.isPresent()).isTrue();
+        ExamSegment result = maybeExamSegment.get();
         assertThat(result).isEqualToComparingFieldByFieldRecursively(mockSegment);
     }
 

--- a/service/src/test/java/tds/exam/services/impl/ExamSegmentServiceImplTest.java
+++ b/service/src/test/java/tds/exam/services/impl/ExamSegmentServiceImplTest.java
@@ -667,7 +667,7 @@ public class ExamSegmentServiceImplTest {
     }
 
     @Test
-    public void shouldReturnOptionalWhenAnExamSegmentCannotBeFoundForExamIdAndSegmentPosition() {
+    public void shouldReturnEmptyWhenAnExamSegmentCannotBeFoundForExamIdAndSegmentPosition() {
         Exam mockExam = new ExamBuilder().build();
 
         when(mockExamSegmentQueryRepository.findByExamIdAndSegmentPosition(any(UUID.class), any(Integer.class)))

--- a/service/src/test/java/tds/exam/services/impl/ExamSegmentServiceImplTest.java
+++ b/service/src/test/java/tds/exam/services/impl/ExamSegmentServiceImplTest.java
@@ -663,12 +663,11 @@ public class ExamSegmentServiceImplTest {
             examSegmentService.findByExamIdAndSegmentPosition(mockExam.getId(), mockExam.getCurrentSegmentPosition());
 
         assertThat(maybeExamSegment.isPresent()).isTrue();
-        ExamSegment result = maybeExamSegment.get();
-        assertThat(result).isEqualToComparingFieldByFieldRecursively(mockSegment);
+        assertThat(maybeExamSegment.get()).isEqualToComparingFieldByFieldRecursively(mockSegment);
     }
 
-    @Test(expected = NotFoundException.class)
-    public void shouldThrowNotFoundExceptionWhenAnExamSegmentCannotBeFoundForExamIdAndSegmentPosition() {
+    @Test
+    public void shouldReturnOptionalWhenAnExamSegmentCannotBeFoundForExamIdAndSegmentPosition() {
         Exam mockExam = new ExamBuilder().build();
 
         when(mockExamSegmentQueryRepository.findByExamIdAndSegmentPosition(any(UUID.class), any(Integer.class)))

--- a/service/src/test/java/tds/exam/utils/listeners/OnCompletedStatusExamChangeListenerTest.java
+++ b/service/src/test/java/tds/exam/utils/listeners/OnCompletedStatusExamChangeListenerTest.java
@@ -10,6 +10,7 @@ import org.mockito.runners.MockitoJUnitRunner;
 import java.time.temporal.ChronoUnit;
 import java.util.Arrays;
 import java.util.Collections;
+import java.util.Optional;
 import java.util.UUID;
 
 import tds.common.Response;
@@ -91,7 +92,7 @@ public class OnCompletedStatusExamChangeListenerTest {
 
         when(mockExamSegmentService.findByExamIdAndSegmentPosition(newExam.getId(),
             newExam.getCurrentSegmentPosition()))
-            .thenReturn(new Response<>(mockSegment));
+            .thenReturn(Optional.of(mockSegment));
         when(mockFieldTestService.findUsageInExam(newExam.getId()))
             .thenReturn(Arrays.asList(mockFirstFtItemGroup, mockSecondFtItemGroup));
 
@@ -113,7 +114,7 @@ public class OnCompletedStatusExamChangeListenerTest {
 
         when(mockExamSegmentService.findByExamIdAndSegmentPosition(newExam.getId(),
             newExam.getCurrentSegmentPosition()))
-            .thenReturn(new Response<>(mockSegment));
+            .thenReturn(Optional.of(mockSegment));
         when(mockFieldTestService.findUsageInExam(newExam.getId()))
             .thenReturn(Collections.emptyList());
 

--- a/service/src/test/java/tds/exam/utils/listeners/OnPausedStatusExamChangeListenerTest.java
+++ b/service/src/test/java/tds/exam/utils/listeners/OnPausedStatusExamChangeListenerTest.java
@@ -7,6 +7,8 @@ import org.junit.runner.RunWith;
 import org.mockito.Mock;
 import org.mockito.runners.MockitoJUnitRunner;
 
+import java.util.Optional;
+
 import tds.common.Response;
 import tds.common.entity.utils.ChangeListener;
 import tds.common.web.exceptions.NotFoundException;
@@ -51,7 +53,7 @@ public class OnPausedStatusExamChangeListenerTest {
 
         when(mockExamSegmentService.findByExamIdAndSegmentPosition(newExam.getId(),
             newExam.getCurrentSegmentPosition()))
-            .thenReturn(new Response<>(mockSegment));
+            .thenReturn(Optional.of(mockSegment));
 
         onPausedStatusExamChangeListener.accept(oldExam, newExam);
         verify(mockExamSegmentService).findByExamIdAndSegmentPosition(newExam.getId(),
@@ -94,7 +96,7 @@ public class OnPausedStatusExamChangeListenerTest {
 
         when(mockExamSegmentService.findByExamIdAndSegmentPosition(newExam.getId(),
             newExam.getCurrentSegmentPosition()))
-            .thenReturn(new Response<>(mockSegment));
+            .thenReturn(Optional.of(mockSegment));
 
         onPausedStatusExamChangeListener.accept(oldExam, newExam);
         verify(mockExamSegmentService).findByExamIdAndSegmentPosition(newExam.getId(),
@@ -116,7 +118,7 @@ public class OnPausedStatusExamChangeListenerTest {
 
         when(mockExamSegmentService.findByExamIdAndSegmentPosition(newExam.getId(),
             newExam.getCurrentSegmentPosition()))
-            .thenReturn(new Response<>(mockSegment));
+            .thenReturn(Optional.of(mockSegment));
 
         onPausedStatusExamChangeListener.accept(oldExam, newExam);
         verify(mockExamSegmentService).findByExamIdAndSegmentPosition(newExam.getId(),
@@ -124,8 +126,8 @@ public class OnPausedStatusExamChangeListenerTest {
         verify(mockExamSegmentService, never()).update(anyVararg());
     }
 
-    @Test(expected = NotFoundException.class)
-    public void shouldThrowNotFoundExceptionWhenExamSegmentCannotBeFound() {
+    @Test
+    public void shouldReturnEmptyWhenExamSegmentCannotBeFound() {
         Exam oldExam = new ExamBuilder().build();
         Exam newExam = new ExamBuilder()
             .withStatus(new ExamStatusCode(ExamStatusCode.STATUS_PAUSED, ExamStatusStage.INACTIVE), Instant.now())
@@ -133,7 +135,7 @@ public class OnPausedStatusExamChangeListenerTest {
 
         when(mockExamSegmentService.findByExamIdAndSegmentPosition(newExam.getId(),
             newExam.getCurrentSegmentPosition()))
-            .thenThrow(new NotFoundException("Could not find exam segment"));
+            .thenReturn(Optional.empty());
 
         onPausedStatusExamChangeListener.accept(oldExam, newExam);
         verify(mockExamSegmentService, never()).update(anyVararg());


### PR DESCRIPTION
… segment not found by position

Matches the legacy logic of ignoring the DB changes in on pause status change event when not found

This will fix the error when pausing an exam currently as well as better align with the legacy logic