### PR TITLE
TDS-765: Add exam/item comments

### DIFF
--- a/client/src/main/java/tds/exam/ExamineeNote.java
+++ b/client/src/main/java/tds/exam/ExamineeNote.java
@@ -74,13 +74,13 @@ public class ExamineeNote {
             return new ExamineeNote(this);
         }
 
-        public Builder fromExamineeNote(ExamineeNote examineeNote) {
-            id = examineeNote.id;
-            examId = examineeNote.examId;
-            context = examineeNote.context;
-            itemPosition = examineeNote.itemPosition;
-            note = examineeNote.note;
-            return this;
+        public static Builder fromExamineeNote(ExamineeNote examineeNote) {
+            return new ExamineeNote.Builder()
+                .withId(examineeNote.id)
+                .withExamId(examineeNote.examId)
+                .withContext(examineeNote.context)
+                .withItemPosition(examineeNote.itemPosition)
+                .withNote(examineeNote.note);
         }
     }
 

--- a/client/src/main/java/tds/exam/ExamineeNote.java
+++ b/client/src/main/java/tds/exam/ExamineeNote.java
@@ -1,0 +1,126 @@
+package tds.exam;
+
+import java.util.UUID;
+
+import tds.common.util.Preconditions;
+
+
+/**
+ * Represents a comment/note made via the Notepad tool in the Student user interface
+ */
+public class ExamineeNote {
+    private long id;
+    private UUID examId;
+    private ExamineeNoteContext context;
+    private int itemPosition;
+    private String note;
+
+    /**
+     * Private constructor for frameworks
+     */
+    private ExamineeNote() {
+    }
+
+    private ExamineeNote(Builder builder) {
+        this.id = builder.id;
+        this.examId = builder.examId;
+        this.context = builder.context;
+        this.itemPosition = builder.itemPosition;
+        this.note = builder.note;
+    }
+
+    public static class Builder {
+        private long id;
+        private UUID examId;
+        private ExamineeNoteContext context;
+        private int itemPosition;
+        private String note;
+
+        public Builder withId(final long id) {
+            this.id = id;
+            return this;
+        }
+
+        public Builder withExamId(final UUID examId) {
+            Preconditions.checkNotNull(examId, "examId cannot be null");
+            this.examId = examId;
+            return this;
+        }
+
+        public Builder withContext(final ExamineeNoteContext context) {
+            Preconditions.checkNotNull(context, "context cannot be null");
+            this.context = context;
+            return this;
+        }
+
+        public Builder withItemPosition(final int itemPosition) {
+            this.itemPosition = itemPosition;
+            return this;
+        }
+
+        public Builder withNote(final String note) {
+            Preconditions.checkNotNull(note, "note cannot be null");
+            this.note = note;
+            return this;
+        }
+
+        public ExamineeNote build() {
+            // RULE:  If the note is in the context of an exam, the position should be set to 0.  Item position is not
+            // relevant to Exam-level notes
+            if (this.context.equals(ExamineeNoteContext.EXAM) && this.itemPosition > 0) {
+                throw new IllegalStateException("itemPosition must be 0 for an ExamineeNote within an EXAM-level context");
+            }
+
+            return new ExamineeNote(this);
+        }
+
+        public Builder fromExamineeNote(ExamineeNote examineeNote) {
+            id = examineeNote.id;
+            examId = examineeNote.examId;
+            context = examineeNote.context;
+            itemPosition = examineeNote.itemPosition;
+            note = examineeNote.note;
+            return this;
+        }
+    }
+
+    /**
+     * @return The unique identifier of this {@link ExamineeNote}
+     */
+    public long getId() {
+        return id;
+    }
+
+    /**
+     * @return The unique identifier of the {@link tds.exam.Exam} to which this {@link ExamineeNote} belongs
+     */
+    public UUID getExamId() {
+        return examId;
+    }
+
+    /**
+     * @return The {@link ExamineeNoteContext} describing what this {@link tds.exam.ExamineeNote} is associated
+     * to
+     */
+    public ExamineeNoteContext getContext() {
+        return context;
+    }
+
+    /**
+     * @return The position of the {@link tds.exam.ExamItem} for which this {@link ExamineeNote} was created
+     * <p>
+     * This property is only relevant for an item-scoped {@link tds.exam.ExamineeNote}.  An exam-scoped
+     * {@link tds.exam.ExamineeNote} will always have an item position of 0.
+     * </p>
+     */
+    public int getItemPosition() {
+        return itemPosition;
+    }
+
+    /**
+     * @return The text for this {@link ExamineeNote}
+     */
+    public String getNote() {
+        return note;
+    }
+}

--- a/client/src/main/java/tds/exam/ExamineeNoteContext.java
+++ b/client/src/main/java/tds/exam/ExamineeNoteContext.java
@@ -1,0 +1,51 @@
+package tds.exam;
+
+/**
+ * Describe the possible contexts for an {@link tds.exam.ExamineeNote}:
+ * <ul>
+ * <li>{@link #EXAM}</li>
+ * <li>{@link #ITEM}</li>
+ * </ul>
+ */
+public enum ExamineeNoteContext {
+    /**
+     * The {@link tds.exam.ExamineeNote} was created using the Notepad tool for the {@link tds.exam.Exam}.
+     */
+    EXAM("GlobalNotes"),
+
+    /**
+     * The {@link tds.exam.ExamineeNote} was created using the Notepad tool at a specific {@link tds.exam.ExamItem}
+     */
+    ITEM("TESTITEM");
+
+    private final String type;
+
+    ExamineeNoteContext(final String type) {
+        this.type = type;
+    }
+
+    String getType() {
+        return type;
+    }
+
+    /**
+     * Get an {@link ExamineeNoteContext} from its string representation
+     *
+     * @param type The string that describes the type of {@link ExamineeNoteContext} to get
+     * @return The equivalent {@link ExamineeNoteContext}
+     */
+    public static ExamineeNoteContext fromType(final String type) {
+        for (ExamineeNoteContext context : ExamineeNoteContext.values()) {
+            if (context.getType().equals(type)) {
+                return context;
+            }
+        }
+
+        throw new IllegalArgumentException(String.format("Could not find ExamineeNoteContext for %s", type));
+    }
+
+    @Override
+    public String toString() {
+        return type;
+    }
+}

--- a/client/src/test/java/tds/exam/ExamineeNoteTest.java
+++ b/client/src/test/java/tds/exam/ExamineeNoteTest.java
@@ -1,0 +1,38 @@
+package tds.exam;
+
+import org.junit.Test;
+
+import java.util.UUID;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+public class ExamineeNoteTest {
+    @Test
+    public void shouldCreateAnExamineeNote() {
+        UUID mockExamId = UUID.randomUUID();
+        ExamineeNote note = new ExamineeNote.Builder()
+            .withId(42L)
+            .withExamId(mockExamId)
+            .withContext(ExamineeNoteContext.ITEM)
+            .withItemPosition(5)
+            .withNote("exam item note")
+            .build();
+
+        assertThat(note.getId()).isEqualTo(42L);
+        assertThat(note.getExamId()).isEqualTo(mockExamId);
+        assertThat(note.getContext()).isEqualTo(ExamineeNoteContext.ITEM);
+        assertThat(note.getItemPosition()).isEqualTo(5);
+        assertThat(note.getNote()).isEqualTo("exam item note");
+    }
+
+    @Test(expected = IllegalStateException.class)
+    public void shouldNotCreateAnExamineeNoteWithExamContextAndItemPositionGreaterThanZero() {
+        ExamineeNote note = new ExamineeNote.Builder()
+            .withId(42L)
+            .withExamId(UUID.randomUUID())
+            .withContext(ExamineeNoteContext.EXAM)
+            .withItemPosition(5)
+            .withNote("exam item note")
+            .build();
+    }
+}

--- a/service/src/main/java/tds/exam/repositories/ExamineeNoteCommandRepository.java
+++ b/service/src/main/java/tds/exam/repositories/ExamineeNoteCommandRepository.java
@@ -1,0 +1,15 @@
+package tds.exam.repositories;
+
+import tds.exam.ExamineeNote;
+
+/**
+ * Handles data modification for the examinee_note table
+ */
+public interface ExamineeNoteCommandRepository {
+    /**
+     * Persist an {@link tds.exam.ExamineeNote} to the database
+     *
+     * @param examineeNote The {@link tds.exam.ExamineeNote} to persist
+     */
+    void insert(final ExamineeNote examineeNote);
+}

--- a/service/src/main/java/tds/exam/repositories/ExamineeNoteQueryRepository.java
+++ b/service/src/main/java/tds/exam/repositories/ExamineeNoteQueryRepository.java
@@ -1,0 +1,19 @@
+package tds.exam.repositories;
+
+import java.util.Optional;
+import java.util.UUID;
+
+import tds.exam.ExamineeNote;
+
+/**
+ * Handles data reads from the examinee_note table
+ */
+public interface ExamineeNoteQueryRepository {
+    /**
+     * Get the most recent {@link tds.exam.ExamineeNote} for the specified {@link tds.exam.Exam}
+     *
+     * @param examId The unique identifier of the {@link tds.exam.Exam}
+     * @return The {@link tds.exam.ExamineeNote} with an {@link tds.exam.ExamineeNoteContext} of "exam"
+     */
+    Optional<ExamineeNote> findNoteInExamContext(final UUID examId);
+}

--- a/service/src/main/java/tds/exam/repositories/impl/ExamineeNoteCommandRepositoryImpl.java
+++ b/service/src/main/java/tds/exam/repositories/impl/ExamineeNoteCommandRepositoryImpl.java
@@ -1,0 +1,49 @@
+package tds.exam.repositories.impl;
+
+import org.joda.time.Instant;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.beans.factory.annotation.Qualifier;
+import org.springframework.jdbc.core.namedparam.MapSqlParameterSource;
+import org.springframework.jdbc.core.namedparam.NamedParameterJdbcTemplate;
+import org.springframework.jdbc.core.namedparam.SqlParameterSource;
+import org.springframework.stereotype.Repository;
+
+import tds.exam.ExamineeNote;
+import tds.exam.repositories.ExamineeNoteCommandRepository;
+
+import static tds.common.data.mapping.ResultSetMapperUtility.mapJodaInstantToTimestamp;
+
+@Repository
+public class ExamineeNoteCommandRepositoryImpl implements ExamineeNoteCommandRepository {
+    private final NamedParameterJdbcTemplate jdbcTemplate;
+
+    @Autowired
+    public ExamineeNoteCommandRepositoryImpl(@Qualifier("commandJdbcTemplate") final NamedParameterJdbcTemplate jdbcTemplate) {
+        this.jdbcTemplate = jdbcTemplate;
+    }
+
+    @Override
+    public void insert(final ExamineeNote examineeNote) {
+        final SqlParameterSource parameters = new MapSqlParameterSource("examId", examineeNote.getExamId().toString())
+            .addValue("context", examineeNote.getContext().toString())
+            .addValue("itemPosition", examineeNote.getItemPosition())
+            .addValue("note", examineeNote.getNote())
+            .addValue("createdAt", mapJodaInstantToTimestamp(Instant.now()));
+
+        final String SQL =
+            "INSERT INTO examinee_note( \n" +
+                "   exam_id, \n" +
+                "   context, \n" +
+                "   item_position, \n" +
+                "   note, \n" +
+                "   created_at) \n" +
+                "VALUES( \n" +
+                "   :examId, \n" +
+                "   :context, \n" +
+                "   :itemPosition, \n" +
+                "   :note, \n" +
+                "   :createdAt)";
+
+        jdbcTemplate.update(SQL, parameters);
+    }
+}

--- a/service/src/main/java/tds/exam/repositories/impl/ExamineeNoteQueryRepositoryImpl.java
+++ b/service/src/main/java/tds/exam/repositories/impl/ExamineeNoteQueryRepositoryImpl.java
@@ -1,0 +1,63 @@
+package tds.exam.repositories.impl;
+
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.beans.factory.annotation.Qualifier;
+import org.springframework.dao.EmptyResultDataAccessException;
+import org.springframework.jdbc.core.namedparam.MapSqlParameterSource;
+import org.springframework.jdbc.core.namedparam.NamedParameterJdbcTemplate;
+import org.springframework.jdbc.core.namedparam.SqlParameterSource;
+import org.springframework.stereotype.Repository;
+
+import java.util.Optional;
+import java.util.UUID;
+
+import tds.exam.ExamineeNote;
+import tds.exam.ExamineeNoteContext;
+import tds.exam.repositories.ExamineeNoteQueryRepository;
+
+@Repository
+public class ExamineeNoteQueryRepositoryImpl implements ExamineeNoteQueryRepository {
+    private final NamedParameterJdbcTemplate jdbcTemplate;
+
+    @Autowired
+    public ExamineeNoteQueryRepositoryImpl(@Qualifier("queryJdbcTemplate") final NamedParameterJdbcTemplate jdbcTemplate) {
+        this.jdbcTemplate = jdbcTemplate;
+    }
+
+    @Override
+    public Optional<ExamineeNote> findNoteInExamContext(final UUID examId) {
+        final SqlParameterSource parameters = new MapSqlParameterSource("examId", examId.toString())
+            .addValue("context", ExamineeNoteContext.EXAM.toString());
+        final String SQL =
+            "SELECT \n" +
+                "   id, \n" +
+                "   exam_id, \n" +
+                "   context, \n" +
+                "   item_position, \n" +
+                "   note \n" +
+                "FROM \n" +
+                "   examinee_note \n" +
+                "WHERE \n" +
+                "   exam_id = :examId \n" +
+                "   AND context = :context \n" +
+                "ORDER BY \n" +
+                "   id DESC \n" +
+                "LIMIT 1";
+
+        Optional<ExamineeNote> maybeExamineeNote;
+        try {
+            maybeExamineeNote = Optional.of(jdbcTemplate.queryForObject(SQL, parameters, (rs, r) ->
+                new ExamineeNote.Builder()
+                    .withId(rs.getLong("id"))
+                    .withExamId(UUID.fromString(rs.getString("exam_id")))
+                    .withContext(ExamineeNoteContext.fromType(rs.getString("context")))
+                    .withItemPosition(rs.getInt("item_position"))
+                    .withNote(rs.getString("note"))
+                    .build()));
+        } catch (EmptyResultDataAccessException e) {
+            maybeExamineeNote = Optional.empty();
+        }
+
+        return maybeExamineeNote;
+    }
+}

--- a/service/src/main/java/tds/exam/services/ExamineeNoteService.java
+++ b/service/src/main/java/tds/exam/services/ExamineeNoteService.java
@@ -1,0 +1,27 @@
+package tds.exam.services;
+
+import java.util.Optional;
+import java.util.UUID;
+
+import tds.exam.ExamineeNote;
+
+/**
+ * A service for interacting with {@link tds.exam.ExamineeNote}s.
+ */
+public interface ExamineeNoteService {
+    /**
+     * Find the most recent {@link tds.exam.ExamineeNote} for the specified {@link tds.exam.Exam}.
+     *
+     * @param examId The unique identifier of the {@link tds.exam.Exam}
+     * @return An Optional of the {@link tds.exam.ExamineeNote}.  If no {@link tds.exam.ExamineeNote} is found,
+     * an empty {@link java.util.Optional} is returned instead.
+     */
+    Optional<ExamineeNote> findNoteInExamContext(final UUID examId);
+
+    /**
+     * Persist a {@link tds.exam.ExamineeNote}.
+     *
+     * @param examineeNote The {@link tds.exam.ExamineeNote} to persist
+     */
+    void insert(final ExamineeNote examineeNote);
+}

--- a/service/src/main/java/tds/exam/services/impl/ExamineeNoteServiceImpl.java
+++ b/service/src/main/java/tds/exam/services/impl/ExamineeNoteServiceImpl.java
@@ -1,0 +1,35 @@
+package tds.exam.services.impl;
+
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.stereotype.Service;
+
+import java.util.Optional;
+import java.util.UUID;
+
+import tds.exam.ExamineeNote;
+import tds.exam.repositories.ExamineeNoteCommandRepository;
+import tds.exam.repositories.ExamineeNoteQueryRepository;
+import tds.exam.services.ExamineeNoteService;
+
+@Service
+public class ExamineeNoteServiceImpl implements ExamineeNoteService {
+    private final ExamineeNoteCommandRepository examineeNoteCommandRepository;
+    private final ExamineeNoteQueryRepository examineeNoteQueryRepository;
+
+    @Autowired
+    public ExamineeNoteServiceImpl(final ExamineeNoteCommandRepository examineeNoteCommandRepository,
+                                   final ExamineeNoteQueryRepository examineeNoteQueryRepository) {
+        this.examineeNoteCommandRepository = examineeNoteCommandRepository;
+        this.examineeNoteQueryRepository = examineeNoteQueryRepository;
+    }
+
+    @Override
+    public Optional<ExamineeNote> findNoteInExamContext(final UUID examId) {
+        return examineeNoteQueryRepository.findNoteInExamContext(examId);
+    }
+
+    @Override
+    public void insert(final ExamineeNote examineeNote) {
+        examineeNoteCommandRepository.insert(examineeNote);
+    }
+}

--- a/service/src/main/java/tds/exam/web/endpoints/ExamineeNoteController.java
+++ b/service/src/main/java/tds/exam/web/endpoints/ExamineeNoteController.java
@@ -34,20 +34,19 @@ public class ExamineeNoteController {
     ResponseEntity<ExamineeNote> getNoteInExamContext(@PathVariable final UUID id) {
         Optional<ExamineeNote> maybeExamineeNote = examineeNoteService.findNoteInExamContext(id);
 
-        // It is possible that there is no note for an exam.  When that is the case, return a NO CONTENT response,
-        // indicating the call was successful but there was nothing to get.
+        // It is possible that there is no note for an exam.  When that is the case, return a NOT FOUND response - the
+        // caller can decide if that's an error condition
         return maybeExamineeNote.isPresent()
             ? ResponseEntity.ok(maybeExamineeNote.get())
-            : new ResponseEntity<>(HttpStatus.NO_CONTENT);
+            : new ResponseEntity<>(HttpStatus.NOT_FOUND);
     }
 
-    @RequestMapping(value = "/{id}/note", method = RequestMethod.PUT, produces = MediaType.APPLICATION_JSON_VALUE)
+    @RequestMapping(value = "/{id}/note", method = RequestMethod.POST, produces = MediaType.APPLICATION_JSON_VALUE)
     @VerifyAccess
     @ResponseStatus(HttpStatus.NO_CONTENT)
     void insert(@PathVariable final UUID id,
                 @RequestBody final ExamineeNote note) {
-        final ExamineeNote examineeNote = new ExamineeNote.Builder()
-            .fromExamineeNote(note)
+        final ExamineeNote examineeNote = ExamineeNote.Builder.fromExamineeNote(note)
             .withExamId(id)
             .withNote(HtmlUtils.htmlEscape(note.getNote()))
             .build();

--- a/service/src/main/java/tds/exam/web/endpoints/ExamineeNoteController.java
+++ b/service/src/main/java/tds/exam/web/endpoints/ExamineeNoteController.java
@@ -1,0 +1,57 @@
+package tds.exam.web.endpoints;
+
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.MediaType;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestMethod;
+import org.springframework.web.bind.annotation.ResponseStatus;
+import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.util.HtmlUtils;
+
+import java.util.Optional;
+import java.util.UUID;
+
+import tds.exam.ExamineeNote;
+import tds.exam.services.ExamineeNoteService;
+import tds.exam.web.annotations.VerifyAccess;
+
+@RestController
+@RequestMapping("/exam")
+public class ExamineeNoteController {
+    private final ExamineeNoteService examineeNoteService;
+
+    @Autowired
+    public ExamineeNoteController(final ExamineeNoteService examineeNoteService) {
+        this.examineeNoteService = examineeNoteService;
+    }
+
+    @RequestMapping(value = "/{id}/note", method = RequestMethod.GET, produces = MediaType.APPLICATION_JSON_VALUE)
+    @VerifyAccess
+    ResponseEntity<ExamineeNote> getNoteInExamContext(@PathVariable final UUID id) {
+        Optional<ExamineeNote> maybeExamineeNote = examineeNoteService.findNoteInExamContext(id);
+
+        // It is possible that there is no note for an exam.  When that is the case, return a NO CONTENT response,
+        // indicating the call was successful but there was nothing to get.
+        return maybeExamineeNote.isPresent()
+            ? ResponseEntity.ok(maybeExamineeNote.get())
+            : new ResponseEntity<>(HttpStatus.NO_CONTENT);
+    }
+
+    @RequestMapping(value = "/{id}/note", method = RequestMethod.PUT, produces = MediaType.APPLICATION_JSON_VALUE)
+    @VerifyAccess
+    @ResponseStatus(HttpStatus.NO_CONTENT)
+    void insert(@PathVariable final UUID id,
+                @RequestBody final ExamineeNote note) {
+        final ExamineeNote examineeNote = new ExamineeNote.Builder()
+            .fromExamineeNote(note)
+            .withExamId(id)
+            .withNote(HtmlUtils.htmlEscape(note.getNote()))
+            .build();
+
+        examineeNoteService.insert(examineeNote);
+    }
+}

--- a/service/src/main/resources/db/migration/V1489696880__exam_create_examinee_note_table.sql
+++ b/service/src/main/resources/db/migration/V1489696880__exam_create_examinee_note_table.sql
@@ -1,0 +1,37 @@
+/***********************************************************************************************************************
+  File: V1489696880__exam_create_examinee_note_table.sql
+
+  Desc: Create the examinee_note table for storing exam-related and item-related notes from the notepad tool
+
+***********************************************************************************************************************/
+
+USE exam;
+
+DROP TABLE IF EXISTS examinee_note;
+
+CREATE TABLE examinee_note(
+  id BIGINT NOT NULL AUTO_INCREMENT,
+  exam_id CHAR(36) NOT NULL,
+  context VARCHAR(11) NOT NULL,
+  item_position INT NOT NULL DEFAULT 0,
+  note TEXT NOT NULL,
+  created_at TIMESTAMP(3) NOT NULL,
+  CONSTRAINT pk_examinee_notes_id PRIMARY KEY (id),
+  CONSTRAINT fk_examinee_notes_exam_id FOREIGN KEY (exam_id) REFERENCES exam(id)
+);
+
+CREATE INDEX ix_examinee_note_exam_id_context ON examinee_note(exam_id, context);
+
+CREATE OR REPLACE VIEW qa_session_testeecomment AS
+  SELECT
+    'not migrated' AS clientname,
+    'not migrated' AS _efk_testee,
+    exam_id AS _fk_testopportunity,
+    item_position AS itemposition,
+    note AS comment,
+    created_at AS `date`,
+    context AS context,
+    'not migrated' AS _fk_session,
+    'not migrated' AS groupid
+  FROM
+    examinee_note;

--- a/service/src/test/java/tds/exam/qa/views/QaViewsIntegrationTests.java
+++ b/service/src/test/java/tds/exam/qa/views/QaViewsIntegrationTests.java
@@ -71,6 +71,10 @@ public class QaViewsIntegrationTests {
         queryView("qa_session_testopportunitysegment");
     }
 
+    @Test
+    public void shouldQuerySessionTesteeComment() {
+        queryView("qa_session_testeecomment");
+    }
 
     private void queryView(final String viewName) {
         jdbcTemplate.query("select * from " + viewName + " limit 0, 1", resultSet -> "success");

--- a/service/src/test/java/tds/exam/repositories/impl/ExamineeNoteCommandRepositoryImplIntegrationTests.java
+++ b/service/src/test/java/tds/exam/repositories/impl/ExamineeNoteCommandRepositoryImplIntegrationTests.java
@@ -1,0 +1,67 @@
+package tds.exam.repositories.impl;
+
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.beans.factory.annotation.Qualifier;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.dao.DataIntegrityViolationException;
+import org.springframework.jdbc.core.namedparam.NamedParameterJdbcTemplate;
+import org.springframework.test.context.junit4.SpringJUnit4ClassRunner;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.UUID;
+
+import tds.exam.Exam;
+import tds.exam.ExamineeNote;
+import tds.exam.ExamineeNoteContext;
+import tds.exam.builder.ExamBuilder;
+import tds.exam.repositories.ExamCommandRepository;
+import tds.exam.repositories.ExamineeNoteCommandRepository;
+
+@RunWith(SpringJUnit4ClassRunner.class)
+@SpringBootTest
+@Transactional
+public class ExamineeNoteCommandRepositoryImplIntegrationTests {
+    @Autowired
+    @Qualifier("commandJdbcTemplate")
+    private NamedParameterJdbcTemplate jdbcTemplate;
+
+    private ExamCommandRepository examCommandRepository;
+    private ExamineeNoteCommandRepository examineeNoteCommandRepository;
+
+    private final Exam mockExam = new ExamBuilder().build();
+
+    @Before
+    public void setup() {
+        examCommandRepository = new ExamCommandRepositoryImpl(jdbcTemplate);
+        examineeNoteCommandRepository = new ExamineeNoteCommandRepositoryImpl(jdbcTemplate);
+    }
+
+    @Test
+    public void shouldInsertAnExamineeNote() {
+        ExamineeNote note = new ExamineeNote.Builder()
+            .withExamId(mockExam.getId())
+            .withContext(ExamineeNoteContext.ITEM)
+            .withItemPosition(5)
+            .withNote("exam item note")
+            .build();
+
+        examCommandRepository.insert(mockExam);
+
+        examineeNoteCommandRepository.insert(note);
+    }
+
+    @Test(expected = DataIntegrityViolationException.class)
+    public void shouldNotInsertAnExamineeNoteWhenTheExamIsNotPresent() {
+        ExamineeNote note = new ExamineeNote.Builder()
+            .withExamId(UUID.randomUUID())
+            .withContext(ExamineeNoteContext.ITEM)
+            .withItemPosition(5)
+            .withNote("exam item note")
+            .build();
+
+        examineeNoteCommandRepository.insert(note);
+    }
+}

--- a/service/src/test/java/tds/exam/repositories/impl/ExamineeNoteQueryRepositoryImplIntegrationTests.java
+++ b/service/src/test/java/tds/exam/repositories/impl/ExamineeNoteQueryRepositoryImplIntegrationTests.java
@@ -1,0 +1,124 @@
+package tds.exam.repositories.impl;
+
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.beans.factory.annotation.Qualifier;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.jdbc.core.namedparam.NamedParameterJdbcTemplate;
+import org.springframework.test.context.junit4.SpringJUnit4ClassRunner;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.Optional;
+import java.util.UUID;
+
+import tds.exam.Exam;
+import tds.exam.ExamineeNote;
+import tds.exam.ExamineeNoteContext;
+import tds.exam.builder.ExamBuilder;
+import tds.exam.repositories.ExamCommandRepository;
+import tds.exam.repositories.ExamineeNoteCommandRepository;
+import tds.exam.repositories.ExamineeNoteQueryRepository;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+@RunWith(SpringJUnit4ClassRunner.class)
+@SpringBootTest
+@Transactional
+public class ExamineeNoteQueryRepositoryImplIntegrationTests {
+    @Autowired
+    @Qualifier("commandJdbcTemplate")
+    private NamedParameterJdbcTemplate jdbcTemplate;
+
+    private ExamineeNoteCommandRepository examineeNoteCommandRepository;
+    private ExamineeNoteQueryRepository examineeNoteQueryRepository;
+
+    private final Exam mockExam = new ExamBuilder().build();
+
+    @Before
+    public void setup() {
+        ExamCommandRepository examCommandRepository = new ExamCommandRepositoryImpl(jdbcTemplate);
+        examineeNoteCommandRepository = new ExamineeNoteCommandRepositoryImpl(jdbcTemplate);
+        examineeNoteQueryRepository = new ExamineeNoteQueryRepositoryImpl(jdbcTemplate);
+
+        examCommandRepository.insert(mockExam);
+    }
+
+    @Test
+    public void shouldFindAnExamineeNoteForAnExam() {
+        ExamineeNote note = new ExamineeNote.Builder()
+            .withExamId(mockExam.getId())
+            .withContext(ExamineeNoteContext.EXAM)
+            .withNote("exam note")
+            .build();
+
+        examineeNoteCommandRepository.insert(note);
+
+        Optional<ExamineeNote> maybeResult = examineeNoteQueryRepository.findNoteInExamContext(mockExam.getId());
+
+        assertThat(maybeResult).isPresent();
+
+        ExamineeNote result = maybeResult.get();
+        assertThat(result.getId()).isGreaterThan(0L);
+        assertThat(result).isEqualToComparingOnlyGivenFields(note,
+            "examId",
+            "context",
+            "itemPosition",
+            "note");
+    }
+
+    @Test
+    public void shouldOnlyReturnExamScopedNoteWhenExamHasMultipleNotes() {
+        ExamineeNote examNote = new ExamineeNote.Builder()
+            .withExamId(mockExam.getId())
+            .withContext(ExamineeNoteContext.EXAM)
+            .withNote("exam note")
+            .build();
+
+        ExamineeNote itemNote = new ExamineeNote.Builder()
+            .withExamId(mockExam.getId())
+            .withContext(ExamineeNoteContext.ITEM)
+            .withItemPosition(5)
+            .withNote("exam item note")
+            .build();
+
+        examineeNoteCommandRepository.insert(examNote);
+        examineeNoteCommandRepository.insert(itemNote);
+
+        Optional<ExamineeNote> maybeResult = examineeNoteQueryRepository.findNoteInExamContext(mockExam.getId());
+
+        assertThat(maybeResult).isPresent();
+
+        ExamineeNote examNoteResult = maybeResult.get();
+        assertThat(examNoteResult.getId()).isGreaterThan(0L);
+        assertThat(examNoteResult).isEqualToComparingOnlyGivenFields(examNote,
+            "examId",
+            "context",
+            "itemPosition",
+            "note");
+    }
+
+    @Test
+    public void shouldReturnOptionalEmptyWhenExamOnlyHasItemScopedNotes() {
+        ExamineeNote note = new ExamineeNote.Builder()
+            .withExamId(mockExam.getId())
+            .withContext(ExamineeNoteContext.ITEM)
+            .withItemPosition(5)
+            .withNote("exam item note")
+            .build();
+
+        examineeNoteCommandRepository.insert(note);
+
+        Optional<ExamineeNote> maybeResult = examineeNoteQueryRepository.findNoteInExamContext(mockExam.getId());
+
+        assertThat(maybeResult).isNotPresent();
+    }
+
+    @Test
+    public void shouldReturnOptionalEmptyWhenExamDoesNotHaveAnyNotes() {
+        Optional<ExamineeNote> maybeResult = examineeNoteQueryRepository.findNoteInExamContext(UUID.randomUUID());
+
+        assertThat(maybeResult).isNotPresent();
+    }
+}

--- a/service/src/test/java/tds/exam/services/impl/ExamineeNoteServiceImplTest.java
+++ b/service/src/test/java/tds/exam/services/impl/ExamineeNoteServiceImplTest.java
@@ -1,0 +1,83 @@
+package tds.exam.services.impl;
+
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.Mock;
+import org.mockito.runners.MockitoJUnitRunner;
+
+import java.util.Optional;
+import java.util.UUID;
+
+import tds.exam.ExamineeNote;
+import tds.exam.ExamineeNoteContext;
+import tds.exam.repositories.ExamineeNoteCommandRepository;
+import tds.exam.repositories.ExamineeNoteQueryRepository;
+import tds.exam.services.ExamineeNoteService;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Matchers.any;
+import static org.mockito.Mockito.doNothing;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+@RunWith(MockitoJUnitRunner.class)
+public class ExamineeNoteServiceImplTest {
+    @Mock
+    private ExamineeNoteQueryRepository mockExamineeNoteQueryRepository;
+
+    @Mock
+    private ExamineeNoteCommandRepository mockExamineeNoteCommandRepository;
+
+    private ExamineeNoteService examineeNoteService;
+
+    @Before
+    public void setup() {
+        examineeNoteService = new ExamineeNoteServiceImpl(mockExamineeNoteCommandRepository,
+            mockExamineeNoteQueryRepository);
+    }
+
+    @Test
+    public void shouldGetAnExamineeNote() {
+        ExamineeNote note = new ExamineeNote.Builder()
+            .withId(42L)
+            .withExamId(UUID.randomUUID())
+            .withContext(ExamineeNoteContext.EXAM)
+            .withNote("exam note")
+            .build();
+
+        when(mockExamineeNoteQueryRepository.findNoteInExamContext(any(UUID.class)))
+            .thenReturn(Optional.of(note));
+
+        Optional<ExamineeNote> result = examineeNoteService.findNoteInExamContext(UUID.randomUUID());
+        verify(mockExamineeNoteQueryRepository).findNoteInExamContext(any(UUID.class));
+
+        assertThat(result).isPresent();
+    }
+
+    @Test
+    public void shouldGetOptionalEmptyForAnExamThatHasNoExamineeNoteWithExamScope() {
+        when(mockExamineeNoteQueryRepository.findNoteInExamContext(any(UUID.class)))
+            .thenReturn(Optional.empty());
+
+        Optional<ExamineeNote> result = examineeNoteService.findNoteInExamContext(UUID.randomUUID());
+        verify(mockExamineeNoteQueryRepository).findNoteInExamContext(any(UUID.class));
+
+        assertThat(result).isNotPresent();
+    }
+
+    @Test
+    public void shouldInsertANewExamineeNote() {
+        ExamineeNote note = new ExamineeNote.Builder()
+            .withExamId(UUID.randomUUID())
+            .withContext(ExamineeNoteContext.ITEM)
+            .withItemPosition(5)
+            .withNote("exam note")
+            .build();
+
+        doNothing().when(mockExamineeNoteCommandRepository).insert(any(ExamineeNote.class));
+
+        examineeNoteService.insert(note);
+        verify(mockExamineeNoteCommandRepository).insert(any(ExamineeNote.class));
+    }
+}

--- a/service/src/test/java/tds/exam/web/endpoints/ExamineeNoteControllerIntegrationTests.java
+++ b/service/src/test/java/tds/exam/web/endpoints/ExamineeNoteControllerIntegrationTests.java
@@ -24,6 +24,7 @@ import static org.mockito.Mockito.doNothing;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.put;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
@@ -65,7 +66,7 @@ public class ExamineeNoteControllerIntegrationTests {
     }
 
     @Test
-    public void shouldReturnNoContentSuccessForExamWithNoExamineeNote() throws Exception {
+    public void shouldReturnNotFoundForExamWithNoExamineeNote() throws Exception {
         ExamInfo examInfo = new ExamInfo(UUID.randomUUID(),
             UUID.randomUUID(),
             UUID.randomUUID());
@@ -77,7 +78,7 @@ public class ExamineeNoteControllerIntegrationTests {
             .contentType(MediaType.APPLICATION_JSON)
             .param("sessionid", examInfo.getSessionId().toString())
             .param("browserid", examInfo.getBrowserId().toString()))
-            .andExpect(status().isNoContent());
+            .andExpect(status().isNotFound());
         verify(mockExamineeNoteService).findNoteInExamContext(any(UUID.class));
     }
 
@@ -97,7 +98,7 @@ public class ExamineeNoteControllerIntegrationTests {
 
         doNothing().when(mockExamineeNoteService).insert(examineeNote);
 
-        http.perform(put("/exam/{id}/note", examInfo.getExamId())
+        http.perform(post("/exam/{id}/note", examInfo.getExamId())
             .contentType(MediaType.APPLICATION_JSON)
             .content(examineeNoteJson)
             .param("sessionid", examInfo.getSessionId().toString())

--- a/service/src/test/java/tds/exam/web/endpoints/ExamineeNoteControllerIntegrationTests.java
+++ b/service/src/test/java/tds/exam/web/endpoints/ExamineeNoteControllerIntegrationTests.java
@@ -1,0 +1,108 @@
+package tds.exam.web.endpoints;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.http.MediaType;
+import org.springframework.test.context.junit4.SpringRunner;
+import org.springframework.test.web.servlet.MockMvc;
+
+import java.util.Optional;
+import java.util.UUID;
+
+import tds.exam.ExamInfo;
+import tds.exam.ExamineeNote;
+import tds.exam.ExamineeNoteContext;
+import tds.exam.WebMvcControllerIntegrationTest;
+import tds.exam.services.ExamineeNoteService;
+
+import static org.hamcrest.CoreMatchers.is;
+import static org.mockito.Matchers.any;
+import static org.mockito.Mockito.doNothing;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.put;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+@RunWith(SpringRunner.class)
+@WebMvcControllerIntegrationTest(controllers = ExamineeNoteController.class)
+public class ExamineeNoteControllerIntegrationTests {
+    @Autowired
+    private MockMvc http;
+
+    @MockBean
+    private ExamineeNoteService mockExamineeNoteService;
+
+    @Test
+    public void shouldGetAnExamineeNote() throws Exception {
+        ExamInfo examInfo = new ExamInfo(UUID.randomUUID(),
+            UUID.randomUUID(),
+            UUID.randomUUID());
+        ExamineeNote examineeNote = new ExamineeNote.Builder()
+            .withId(42L)
+            .withExamId(examInfo.getExamId())
+            .withContext(ExamineeNoteContext.EXAM)
+            .withNote("Exam note")
+            .build();
+
+        when(mockExamineeNoteService.findNoteInExamContext(any(UUID.class)))
+            .thenReturn(Optional.of(examineeNote));
+
+        http.perform(get("/exam/{id}/note", examInfo.getExamId().toString())
+            .contentType(MediaType.APPLICATION_JSON)
+            .param("sessionid", examInfo.getSessionId().toString())
+            .param("browserid", examInfo.getBrowserId().toString()))
+            .andExpect(status().isOk())
+            .andExpect(jsonPath("id", is(42)))
+            .andExpect(jsonPath("examId", is(examInfo.getExamId().toString())))
+            .andExpect(jsonPath("itemPosition", is(0)))
+            .andExpect(jsonPath("note", is("Exam note")));
+        verify(mockExamineeNoteService).findNoteInExamContext(any(UUID.class));
+    }
+
+    @Test
+    public void shouldReturnNoContentSuccessForExamWithNoExamineeNote() throws Exception {
+        ExamInfo examInfo = new ExamInfo(UUID.randomUUID(),
+            UUID.randomUUID(),
+            UUID.randomUUID());
+
+        when(mockExamineeNoteService.findNoteInExamContext(any(UUID.class)))
+            .thenReturn(Optional.empty());
+
+        http.perform(get("/exam/{id}/note", examInfo.getExamId().toString())
+            .contentType(MediaType.APPLICATION_JSON)
+            .param("sessionid", examInfo.getSessionId().toString())
+            .param("browserid", examInfo.getBrowserId().toString()))
+            .andExpect(status().isNoContent());
+        verify(mockExamineeNoteService).findNoteInExamContext(any(UUID.class));
+    }
+
+    @Test
+    public void shouldInsertAnExamineeNote() throws Exception {
+        ExamInfo examInfo = new ExamInfo(UUID.randomUUID(),
+            UUID.randomUUID(),
+            UUID.randomUUID());
+        ExamineeNote examineeNote = new ExamineeNote.Builder()
+            .withId(42L)
+            .withExamId(examInfo.getExamId())
+            .withContext(ExamineeNoteContext.ITEM)
+            .withItemPosition(5)
+            .withNote("Exam note")
+            .build();
+        String examineeNoteJson = new ObjectMapper().writeValueAsString(examineeNote);
+
+        doNothing().when(mockExamineeNoteService).insert(examineeNote);
+
+        http.perform(put("/exam/{id}/note", examInfo.getExamId())
+            .contentType(MediaType.APPLICATION_JSON)
+            .content(examineeNoteJson)
+            .param("sessionid", examInfo.getSessionId().toString())
+            .param("browserid", examInfo.getBrowserId().toString()))
+            .andExpect(status().isNoContent());
+        verify(mockExamineeNoteService).insert(any(ExamineeNote.class));
+    }
+}

--- a/service/src/test/java/tds/exam/web/endpoints/ExamineeNoteControllerTest.java
+++ b/service/src/test/java/tds/exam/web/endpoints/ExamineeNoteControllerTest.java
@@ -63,14 +63,14 @@ public class ExamineeNoteControllerTest {
     }
 
     @Test
-    public void shouldReturnNoContentSuccessWhenExamHasNoExamineeNote() {
+    public void shouldReturnNotFoundWhenExamHasNoExamineeNote() {
         when(mockExamineeNoteService.findNoteInExamContext(any(UUID.class)))
             .thenReturn(Optional.empty());
 
         ResponseEntity<ExamineeNote> result = controller.getNoteInExamContext(UUID.randomUUID());
         verify(mockExamineeNoteService).findNoteInExamContext(any(UUID.class));
 
-        assertThat(result.getStatusCode()).isEqualTo(HttpStatus.NO_CONTENT);
+        assertThat(result.getStatusCode()).isEqualTo(HttpStatus.NOT_FOUND);
     }
 
     @Test

--- a/service/src/test/java/tds/exam/web/endpoints/ExamineeNoteControllerTest.java
+++ b/service/src/test/java/tds/exam/web/endpoints/ExamineeNoteControllerTest.java
@@ -1,0 +1,89 @@
+package tds.exam.web.endpoints;
+
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.Mock;
+import org.mockito.runners.MockitoJUnitRunner;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.mock.web.MockHttpServletRequest;
+import org.springframework.web.context.request.RequestContextHolder;
+import org.springframework.web.context.request.ServletRequestAttributes;
+
+import javax.servlet.http.HttpServletRequest;
+import java.util.Optional;
+import java.util.UUID;
+
+import tds.exam.ExamineeNote;
+import tds.exam.ExamineeNoteContext;
+import tds.exam.services.ExamineeNoteService;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Matchers.any;
+import static org.mockito.Mockito.doNothing;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+@RunWith(MockitoJUnitRunner.class)
+public class ExamineeNoteControllerTest {
+    private ExamineeNoteController controller;
+
+    @Mock
+    private ExamineeNoteService mockExamineeNoteService;
+
+    @Before
+    public void setUp() {
+        HttpServletRequest request = new MockHttpServletRequest();
+        ServletRequestAttributes requestAttributes = new ServletRequestAttributes(request);
+        RequestContextHolder.setRequestAttributes(requestAttributes);
+
+        controller = new ExamineeNoteController(mockExamineeNoteService);
+    }
+
+    @Test
+    public void shouldReturnAnExamineeNote() {
+        ExamineeNote examineeNote = new ExamineeNote.Builder()
+            .withId(42L)
+            .withExamId(UUID.randomUUID())
+            .withContext(ExamineeNoteContext.EXAM)
+            .withNote("Exam note")
+            .build();
+        when(mockExamineeNoteService.findNoteInExamContext(any(UUID.class)))
+            .thenReturn(Optional.of(examineeNote));
+
+        ResponseEntity<ExamineeNote> result = controller.getNoteInExamContext(UUID.randomUUID());
+        verify(mockExamineeNoteService).findNoteInExamContext(any(UUID.class));
+
+        assertThat(result.getBody().getId()).isEqualTo(examineeNote.getId());
+        assertThat(result.getBody().getExamId()).isEqualTo(examineeNote.getExamId());
+        assertThat(result.getBody().getContext()).isEqualTo(examineeNote.getContext());
+        assertThat(result.getBody().getItemPosition()).isEqualTo(examineeNote.getItemPosition());
+        assertThat(result.getBody().getNote()).isEqualTo(examineeNote.getNote());
+    }
+
+    @Test
+    public void shouldReturnNoContentSuccessWhenExamHasNoExamineeNote() {
+        when(mockExamineeNoteService.findNoteInExamContext(any(UUID.class)))
+            .thenReturn(Optional.empty());
+
+        ResponseEntity<ExamineeNote> result = controller.getNoteInExamContext(UUID.randomUUID());
+        verify(mockExamineeNoteService).findNoteInExamContext(any(UUID.class));
+
+        assertThat(result.getStatusCode()).isEqualTo(HttpStatus.NO_CONTENT);
+    }
+
+    @Test
+    public void shouldInsertANewExamineeNote() {
+        ExamineeNote examineeNote = new ExamineeNote.Builder()
+            .withId(42L)
+            .withExamId(UUID.randomUUID())
+            .withContext(ExamineeNoteContext.EXAM)
+            .withNote("Exam note")
+            .build();
+        doNothing().when(mockExamineeNoteService).insert(any(ExamineeNote.class));
+
+        controller.insert(UUID.randomUUID(), examineeNote);
+        verify(mockExamineeNoteService).insert(any(ExamineeNote.class));
+    }
+}


### PR DESCRIPTION
[TDS-765](https://jira.fairwaytech.com/browse/TDS-765):  Allow for persisting/fetching comments for `Exam`s or `ExamItem`s via the notepad tool in the student UI.

### Notes
* Referred to as "comments" in legacy code
* In the legacy Student application, Item-level notes are not retrievable.
  * If a user creates a comment on an item then refreshes the page, the item comment will no longer be available
  * The item comment will be available if the user uses the provided navigation controls to switch between pages
  * This PR will also store item-level notes, but does not provide an endpoint to retrieve them
* Item-level and Exam-level notes are an optional element within the TRT
* There can only be one Exam-level note
  * In the event there are multiple records for an exam-level note on a single exam, the most recent record is returned
* The TRT spec says that comments are a data element that Smarter Balanced isn't interested in ([TRT spec](http://www.smarterapp.org/documents/TestResults-DataModel.pdf), appendix B, p. 21), but there are `<comment>` elements in their [sample TRT output](http://www.smarterapp.org/documents/TestResultsTransmissionFormat_Sample.xml)
* Legacy `session.testeecomment` acts like our `_event` tables; records in `session.testeecomment` are never updated; new records are inserted when a user changes a note
* QA view included for comparing `exam.examinee_note` to `session.testeecomment`