### PR TITLE
Skip duplicate accommodation types

### DIFF
--- a/service/src/main/java/tds/exam/services/impl/ExamAccommodationServiceImpl.java
+++ b/service/src/main/java/tds/exam/services/impl/ExamAccommodationServiceImpl.java
@@ -327,6 +327,16 @@ class ExamAccommodationServiceImpl implements ExamAccommodationService {
         List<ExamAccommodation> examAccommodationsToDelete = new ArrayList<>();
 
         for (ExamAccommodation examAccommodation : accommodationsToAdd) {
+            // Check if the same accommodation type/value combination exists. If so, we can skip adding/deleting:
+            Optional<ExamAccommodation> identicalExamAccommodation = existingExamAccommodations.stream()
+                .filter(acc -> acc.equals(examAccommodation))
+                .findFirst();
+
+            if (identicalExamAccommodation.isPresent()) {
+                // No need to do anything if the exact same accommodation already exists.
+                continue;
+            }
+
             // Find an existing accommodation for the same type
             //  This might have the same code or not, so can't use contains since it checks for equality
             Optional<ExamAccommodation> existingAccommodation = existingExamAccommodations.stream()

--- a/service/src/main/java/tds/exam/services/impl/ExamAccommodationServiceImpl.java
+++ b/service/src/main/java/tds/exam/services/impl/ExamAccommodationServiceImpl.java
@@ -298,6 +298,7 @@ class ExamAccommodationServiceImpl implements ExamAccommodationService {
                     .withCreatedAt(now)
                     .build();
             })
+            .filter(examAccommodation -> !existingExamAccommodations.contains(examAccommodation))
             .distinct()
             .collect(Collectors.toSet());
 
@@ -327,16 +328,6 @@ class ExamAccommodationServiceImpl implements ExamAccommodationService {
         List<ExamAccommodation> examAccommodationsToDelete = new ArrayList<>();
 
         for (ExamAccommodation examAccommodation : accommodationsToAdd) {
-            // Check if the same accommodation type/value combination exists. If so, we can skip adding/deleting:
-            Optional<ExamAccommodation> identicalExamAccommodation = existingExamAccommodations.stream()
-                .filter(acc -> acc.equals(examAccommodation))
-                .findFirst();
-
-            if (identicalExamAccommodation.isPresent()) {
-                // No need to do anything if the exact same accommodation already exists.
-                continue;
-            }
-
             // Find an existing accommodation for the same type
             //  This might have the same code or not, so can't use contains since it checks for equality
             Optional<ExamAccommodation> existingAccommodation = existingExamAccommodations.stream()


### PR DESCRIPTION
This bugfix is for https://jira.fairwaytech.com/browse/TDS-727.

Current logic in ExamAccommodationServiceImpl does a findFirst() based on segment position, exam accommodation type, and examId. However, some exam accommodations can contain multiple values for the same type (for example, Audio Playback Controls). Before "updating" (soft deleting and re-inserting) a changed an accommodation, we need to check that the same accommodation type/value combination doesn't already exist. If it does, we should skip to avoid duplicate entries.