### PR TITLE
Insert “default” student “TDS_Other” exam accommodations

### DIFF
--- a/service/src/main/java/tds/exam/services/impl/ExamAccommodationServiceImpl.java
+++ b/service/src/main/java/tds/exam/services/impl/ExamAccommodationServiceImpl.java
@@ -93,6 +93,13 @@ class ExamAccommodationServiceImpl implements ExamAccommodationService {
             if (assessmentAccommodations.containsKey(code)) {
                 Accommodation accommodation = assessmentAccommodations.get(code);
                 studentAccommodations.put(accommodation.getType(), accommodation);
+            } else if (code.startsWith(OTHER_ACCOMMODATION_VALUE)) {
+                Accommodation otherAccommodation = new Accommodation.Builder()
+                    .withAccommodationType(OTHER_ACCOMMODATION_NAME)
+                    .withAccommodationCode(OTHER_ACCOMMODATION_CODE)
+                    .withAccommodationValue(StringUtils.substringAfter(code, OTHER_ACCOMMODATION_VALUE))
+                    .build();
+                studentAccommodations.put(OTHER_ACCOMMODATION_NAME, otherAccommodation);
             }
         });
 

--- a/service/src/test/java/tds/exam/services/impl/ExamAccommodationServiceImplTest.java
+++ b/service/src/test/java/tds/exam/services/impl/ExamAccommodationServiceImplTest.java
@@ -616,6 +616,31 @@ public class ExamAccommodationServiceImplTest {
         assertThat(seg2Acc.getSegmentPosition()).isEqualTo(2);
         assertThat(seg2Acc.getDeletedAt()).isNull();
     }
+
+    @Test
+    public void shouldCreateOtherExamAccommodations() {
+        final Exam exam = new ExamBuilder().build();
+        final String studentCodes = "ELA;ELA:ESN;Language:ESN;ELA:TDS_APC_SCRUBBER;ELA:TDS_APC_PSP;ELA:TDS_Other#test;";
+
+        when(mockAssessmentService.findAssessmentAccommodationsByAssessmentKey(any(), any())).thenReturn(new ArrayList<>());
+        examAccommodationService.initializeExamAccommodations(exam, studentCodes);
+        verify(mockExamAccommodationCommandRepository).insert(examAccommodationInsertCaptor.capture());
+        List<ExamAccommodation> insertedAccomms = examAccommodationInsertCaptor.getValue();
+        assertThat(insertedAccomms).hasSize(1);
+        ExamAccommodation otherExamAccomm = insertedAccomms.get(0);
+
+        assertThat(otherExamAccomm.getCode()).isEqualTo("TDS_Other");
+        assertThat(otherExamAccomm.getValue()).isEqualTo("test");
+        assertThat(otherExamAccomm.getType()).isEqualTo("Other");
+        assertThat(otherExamAccomm.getSegmentPosition()).isEqualTo(0);
+        assertThat(otherExamAccomm.getSegmentKey()).isEqualTo(exam.getAssessmentKey());
+        assertThat(otherExamAccomm.getDeletedAt()).isNull();
+        assertThat(otherExamAccomm.getExamId()).isEqualTo(exam.getId());
+        assertThat(otherExamAccomm.getDescription()).isEqualTo("test");
+        assertThat(otherExamAccomm.isAllowChange()).isFalse();
+        assertThat(otherExamAccomm.isSelectable()).isFalse();
+
+    }
     
     @Test
     public void shouldFindApprovedExamAccommodations() {


### PR DESCRIPTION
Default "Other" accommodations (as configured in ART) were not being added to exam_accommodations table as they did not match up with any default Assessment accommodation.

This is part of TDS-807. However, this bug will not be closed out until TDS-777 is complete. Once TDS-777 is complete, Proctor should have exam accommodation metadata included, and TDS_Other should not be filtered out like it currently is.