### PR TITLE
Adding additional properties to ExamAccommodation to get rid of the n…

### DIFF
--- a/client/src/main/java/tds/exam/ExamAccommodation.java
+++ b/client/src/main/java/tds/exam/ExamAccommodation.java
@@ -55,7 +55,7 @@ public class ExamAccommodation {
         private boolean selectable;
         private boolean allowChange;
         private String value;
-        private int segmentPosition = 1;
+        private int segmentPosition;
         private int totalTypeCount;
         private boolean custom;
         private boolean visible;
@@ -174,7 +174,6 @@ public class ExamAccommodation {
             this.allowCombine = allowCombine;
             return this;
         }
-
 
         public static Builder fromExamAccommodation(final ExamAccommodation accommodation) {
             return new Builder(accommodation.getId())

--- a/client/src/main/java/tds/exam/ExamAccommodation.java
+++ b/client/src/main/java/tds/exam/ExamAccommodation.java
@@ -28,6 +28,13 @@ public class ExamAccommodation {
     private Instant deletedAt;
     private int totalTypeCount;
     private boolean custom;
+    private boolean visible;
+    private boolean studentControlled;
+    private boolean disabledOnGuestSession;
+    private boolean defaultAccommodation;
+    private boolean allowCombine;
+    private int sortOrder;
+    private String dependsOn;
 
     /**
      * Private constructor for frameworks
@@ -51,6 +58,13 @@ public class ExamAccommodation {
         private int segmentPosition = 1;
         private int totalTypeCount;
         private boolean custom;
+        private boolean visible;
+        private boolean studentControlled;
+        private boolean disabledOnGuestSession;
+        private boolean defaultAccommodation;
+        private boolean allowCombine;
+        private int sortOrder;
+        private String dependsOn;
 
         public Builder(UUID id) {
             this.id = id;
@@ -126,6 +140,42 @@ public class ExamAccommodation {
             return this;
         }
 
+        public Builder withVisible(boolean visible) {
+            this.visible = visible;
+            return this;
+        }
+
+        public Builder withSortOrder(int sortOrder) {
+            this.sortOrder = sortOrder;
+            return this;
+        }
+
+        public Builder withDependsOn(String dependsOn) {
+            this.dependsOn = dependsOn;
+            return this;
+        }
+
+        public Builder withStudentControlled(boolean studentControlled) {
+            this.studentControlled = studentControlled;
+            return this;
+        }
+
+        public Builder withDisabledOnGuestSession(boolean disabledOnGuestSession) {
+            this.disabledOnGuestSession = disabledOnGuestSession;
+            return this;
+        }
+
+        public Builder withDefaultAccommodation(boolean defaultAccommodation) {
+            this.defaultAccommodation = defaultAccommodation;
+            return this;
+        }
+
+        public Builder withAllowCombine(boolean allowCombine) {
+            this.allowCombine = allowCombine;
+            return this;
+        }
+
+
         public static Builder fromExamAccommodation(final ExamAccommodation accommodation) {
             return new Builder(accommodation.getId())
                 .withExamId(accommodation.getExamId())
@@ -163,6 +213,13 @@ public class ExamAccommodation {
         segmentPosition = builder.segmentPosition;
         totalTypeCount = builder.totalTypeCount;
         custom = builder.custom;
+        visible = builder.visible;
+        studentControlled = builder.studentControlled;
+        disabledOnGuestSession = builder.disabledOnGuestSession;
+        defaultAccommodation = builder.defaultAccommodation;
+        allowCombine = builder.allowCombine;
+        sortOrder = builder.sortOrder;
+        dependsOn = builder.dependsOn;
     }
 
     /**
@@ -279,6 +336,55 @@ public class ExamAccommodation {
      */
     public boolean isCustom() {
         return custom;
+    }
+
+    /**
+     * @return {@code true} if the accommodation should be visible
+     */
+    public boolean isVisible() {
+        return visible;
+    }
+
+    /**
+     * @return The order position of the tool in the UI
+     */
+    public int getSortOrder() {
+        return sortOrder;
+    }
+
+    /**
+     * @return The toolname the {@link tds.exam.ExamAccommodation} depends on
+     */
+    public String getDependsOn() {
+        return dependsOn;
+    }
+
+    /**
+     * @return {@code true} if this accommodation is controlled by a student
+     */
+    public boolean isStudentControlled() {
+        return studentControlled;
+    }
+
+    /**
+     * @return {@code true} if this accommodation is disabled for guest sessions
+     */
+    public boolean isDisabledOnGuestSession() {
+        return disabledOnGuestSession;
+    }
+
+    /**
+     * @return {@code true} if this accommodation is enabled by default
+     */
+    public boolean isDefaultAccommodation() {
+        return defaultAccommodation;
+    }
+
+    /**
+     * @return {@code true} if this accommodation is allowed to be combined with other accommodations of this type
+     */
+    public boolean isAllowCombine() {
+        return allowCombine;
     }
 
     @Override

--- a/service/src/main/java/tds/exam/repositories/impl/ExamAccommodationCommandRepositoryImpl.java
+++ b/service/src/main/java/tds/exam/repositories/impl/ExamAccommodationCommandRepositoryImpl.java
@@ -29,8 +29,12 @@ public class ExamAccommodationCommandRepositoryImpl implements ExamAccommodation
 
     @Override
     public void insert(final List<ExamAccommodation> accommodations) {
-        String SQL = "INSERT INTO exam_accommodation(exam_id, id, segment_key, type, code, description, allow_change, value, segment_position, created_at) \n" +
-            "VALUES(:examId, :id, :segmentKey, :type, :code, :description, :allowChange, :value, :segmentPosition, :createdAt)";
+        String SQL =
+            "INSERT INTO " +
+            "   exam_accommodation(exam_id, id, segment_key, type, code, description, allow_change, value, segment_position, " +
+            "   created_at, visible, student_controlled, disabled_on_guest_session, default_accommodation, allow_combine, sort_order, depends_on) \n" +
+            "VALUES(:examId, :id, :segmentKey, :type, :code, :description, :allowChange, :value, :segmentPosition, :createdAt," +
+            "   :visible, :studentControlled, :disabledOnGuestSession, :defaultAccommodation, :allowCombine, :sortOrder, :dependsOn)";
 
         Timestamp createdAt = mapJodaInstantToTimestamp(Instant.now());
         List<ExamAccommodation> createdAccommodations = new ArrayList<>();
@@ -44,6 +48,13 @@ public class ExamAccommodationCommandRepositoryImpl implements ExamAccommodation
                     .addValue("id", examAccommodation.getId().toString())
                     .addValue("segmentKey", examAccommodation.getSegmentKey())
                     .addValue("type", examAccommodation.getType())
+                    .addValue("visible", examAccommodation.isVisible())
+                    .addValue("studentControlled", examAccommodation.isStudentControlled())
+                    .addValue("disabledOnGuestSession", examAccommodation.isDisabledOnGuestSession())
+                    .addValue("defaultAccommodation", examAccommodation.isDefaultAccommodation())
+                    .addValue("allowCombine", examAccommodation.isAllowCombine())
+                    .addValue("dependsOn", examAccommodation.getDependsOn())
+                    .addValue("sortOrder", examAccommodation.getSortOrder())
                     .addValue("code", examAccommodation.getCode())
                     .addValue("allowChange", examAccommodation.isAllowChange())
                     .addValue("value", examAccommodation.getValue())

--- a/service/src/main/java/tds/exam/repositories/impl/ExamAccommodationQueryRepositoryImpl.java
+++ b/service/src/main/java/tds/exam/repositories/impl/ExamAccommodationQueryRepositoryImpl.java
@@ -48,6 +48,13 @@ public class ExamAccommodationQueryRepositoryImpl implements ExamAccommodationQu
                 "   ea.allow_change, \n" +
                 "   ea.value, \n" +
                 "   ea.segment_position, \n" +
+                "   ea.visible, \n" +
+                "   ea.student_controlled, \n" +
+                "   ea.disabled_on_guest_session, \n" +
+                "   ea.default_accommodation, \n" +
+                "   ea.allow_combine, \n" +
+                "   ea.depends_on, \n" +
+                "   ea.sort_order, \n" +
                 "   eae.selectable, \n" +
                 "   eae.total_type_count, \n" +
                 "   eae.custom \n" +
@@ -105,6 +112,13 @@ public class ExamAccommodationQueryRepositoryImpl implements ExamAccommodationQu
                 "   ea.created_at, \n" +
                 "   ea.allow_change, \n" +
                 "   ea.value, \n" +
+                "   ea.visible, \n" +
+                "   ea.student_controlled, \n" +
+                "   ea.disabled_on_guest_session, \n" +
+                "   ea.default_accommodation, \n" +
+                "   ea.allow_combine, \n" +
+                "   ea.depends_on, \n" +
+                "   ea.sort_order, \n" +
                 "   ea.segment_position, \n" +
                 "   eae.total_type_count, \n" +
                 "   eae.selectable, \n" +
@@ -152,6 +166,9 @@ public class ExamAccommodationQueryRepositoryImpl implements ExamAccommodationQu
                 .withSegmentPosition(rs.getInt("segment_position"))
                 .withTotalTypeCount(rs.getInt("total_type_count"))
                 .withCustom(rs.getBoolean("custom"))
+                .withVisible(rs.getBoolean("visible"))
+                .withSortOrder(rs.getInt("sort_order"))
+                .withDependsOn(rs.getString("depends_on"))
                 .build();
         }
     }

--- a/service/src/main/java/tds/exam/repositories/impl/ExamAccommodationQueryRepositoryImpl.java
+++ b/service/src/main/java/tds/exam/repositories/impl/ExamAccommodationQueryRepositoryImpl.java
@@ -167,6 +167,10 @@ public class ExamAccommodationQueryRepositoryImpl implements ExamAccommodationQu
                 .withTotalTypeCount(rs.getInt("total_type_count"))
                 .withCustom(rs.getBoolean("custom"))
                 .withVisible(rs.getBoolean("visible"))
+                .withStudentControlled(rs.getBoolean("student_controlled"))
+                .withDisabledOnGuestSession(rs.getBoolean("disabled_on_guest_session"))
+                .withDefaultAccommodation(rs.getBoolean("default_accommodation"))
+                .withAllowCombine(rs.getBoolean("allow_combine"))
                 .withSortOrder(rs.getInt("sort_order"))
                 .withDependsOn(rs.getString("depends_on"))
                 .build();

--- a/service/src/main/java/tds/exam/services/impl/ExamAccommodationServiceImpl.java
+++ b/service/src/main/java/tds/exam/services/impl/ExamAccommodationServiceImpl.java
@@ -129,6 +129,13 @@ class ExamAccommodationServiceImpl implements ExamAccommodationService {
                 .withCustom(!accommodation.isDefaultAccommodation())
                 .withAllowChange(accommodation.isAllowChange())
                 .withSelectable(accommodation.isSelectable())
+                .withVisible(accommodation.isVisible())
+                .withStudentControlled(accommodation.isStudentControl())
+                .withDisabledOnGuestSession(accommodation.isDisableOnGuestSession())
+                .withDefaultAccommodation(accommodation.isDefaultAccommodation())
+                .withAllowCombine(accommodation.isAllowCombine())
+                .withDependsOn(accommodation.getDependsOnToolType())
+                .withSortOrder(accommodation.getToolTypeSortOrder())
                 .withCreatedAt(now)
                 .build();
 
@@ -301,6 +308,13 @@ class ExamAccommodationServiceImpl implements ExamAccommodationService {
                     .withSegmentPosition(segmentPosition)
                     .withTotalTypeCount(accommodation.getTypeTotal())
                     .withCustom(!accommodation.isDefaultAccommodation())
+                    .withVisible(accommodation.isVisible())
+                    .withStudentControlled(accommodation.isStudentControl())
+                    .withDisabledOnGuestSession(accommodation.isDisableOnGuestSession())
+                    .withDefaultAccommodation(accommodation.isDefaultAccommodation())
+                    .withAllowCombine(accommodation.isAllowCombine())
+                    .withDependsOn(accommodation.getDependsOnToolType())
+                    .withSortOrder(accommodation.getToolTypeSortOrder())
                     .withDeniedAt(deniedAt)
                     .withCreatedAt(now)
                     .build();

--- a/service/src/main/resources/db/migration/V1490229600__exam__add_columns_exam_accommodations.sql
+++ b/service/src/main/resources/db/migration/V1490229600__exam__add_columns_exam_accommodations.sql
@@ -1,0 +1,29 @@
+/***********************************************************************************************************************
+  File: V1490229600__exam__add_columns_exam_accommodations.sql
+
+  Desc: Adds additional columns to the exam_accommodation table
+
+***********************************************************************************************************************/
+
+use exam;
+
+ALTER TABLE exam_accommodation
+  ADD COLUMN visible BIT(1) NOT NULL DEFAULT 1;
+
+ALTER TABLE exam_accommodation
+  ADD COLUMN student_controlled BIT(1) NOT NULL DEFAULT 1;
+
+ALTER TABLE exam_accommodation
+  ADD COLUMN disabled_on_guest_session BIT(1) NOT NULL DEFAULT 0;
+
+ALTER TABLE exam_accommodation
+  ADD COLUMN default_accommodation BIT(1) NOT NULL;
+
+ALTER TABLE exam_accommodation
+  ADD COLUMN allow_combine BIT(1) NOT NULL;
+
+ALTER TABLE exam_accommodation
+  ADD COLUMN depends_on VARCHAR(50) DEFAULT NULL;
+
+ALTER TABLE exam_accommodation
+  ADD COLUMN sort_order INT(11) NOT NULL;

--- a/service/src/test/java/tds/exam/builder/ExamAccommodationBuilder.java
+++ b/service/src/test/java/tds/exam/builder/ExamAccommodationBuilder.java
@@ -29,6 +29,12 @@ public class ExamAccommodationBuilder {
     private Instant deletedAt = null;
     private boolean selectable = false;
     private boolean allowChange = false;
+    private boolean allowCombine = false;
+    private boolean visible = true;
+    private boolean disabledOnGuestSession = false;
+    private boolean studentControlled = false;
+    private boolean defaultAccommodation = true;
+    private String dependsOn = null;
     private String value = SampleData.DEFAULT_ACCOMMODATION_VALUE;
     private int segmentPosition = 1;
     private int totalTypeCount = 1;
@@ -50,6 +56,12 @@ public class ExamAccommodationBuilder {
             .withSegmentPosition(segmentPosition)
             .withTotalTypeCount(totalTypeCount)
             .withCustom(custom)
+            .withAllowCombine(allowCombine)
+            .withDefaultAccommodation(defaultAccommodation)
+            .withVisible(visible)
+            .withDisabledOnGuestSession(disabledOnGuestSession)
+            .withStudentControlled(studentControlled)
+            .withDependsOn(dependsOn)
             .build();
     }
 
@@ -115,6 +127,36 @@ public class ExamAccommodationBuilder {
 
     public ExamAccommodationBuilder withValue(String value) {
         this.value = value;
+        return this;
+    }
+
+    public ExamAccommodationBuilder withVisible(boolean visible) {
+        this.visible = visible;
+        return this;
+    }
+
+    public ExamAccommodationBuilder withDependsOn(String dependsOn) {
+        this.dependsOn = dependsOn;
+        return this;
+    }
+
+    public ExamAccommodationBuilder withStudentControlled(boolean studentControlled) {
+        this.studentControlled = studentControlled;
+        return this;
+    }
+
+    public ExamAccommodationBuilder withDisabledOnGuestSession(boolean disabledOnGuestSession) {
+        this.disabledOnGuestSession = disabledOnGuestSession;
+        return this;
+    }
+
+    public ExamAccommodationBuilder withDefaultAccommodation(boolean defaultAccommodation) {
+        this.defaultAccommodation = defaultAccommodation;
+        return this;
+    }
+
+    public ExamAccommodationBuilder withAllowCombine(boolean allowCombine) {
+        this.allowCombine = allowCombine;
         return this;
     }
 

--- a/service/src/test/java/tds/exam/repositories/impl/ExamAccommodationCommandRepositoryIntegrationTests.java
+++ b/service/src/test/java/tds/exam/repositories/impl/ExamAccommodationCommandRepositoryIntegrationTests.java
@@ -1,5 +1,7 @@
 package tds.exam.repositories.impl;
 
+import io.github.benas.randombeans.EnhancedRandomBuilder;
+import io.github.benas.randombeans.api.EnhancedRandom;
 import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
@@ -16,7 +18,6 @@ import java.util.List;
 import java.util.UUID;
 
 import tds.exam.ExamAccommodation;
-import tds.exam.builder.ExamAccommodationBuilder;
 import tds.exam.repositories.ExamAccommodationCommandRepository;
 import tds.exam.repositories.ExamAccommodationQueryRepository;
 
@@ -70,18 +71,27 @@ public class ExamAccommodationCommandRepositoryIntegrationTests {
     }
 
     private List<ExamAccommodation> insertExamAccommodations(UUID examId) {
+        EnhancedRandom rand = EnhancedRandomBuilder.aNewEnhancedRandomBuilder().stringLengthRange(3, 10).build();
         List<ExamAccommodation> mockExamAccommodations = new ArrayList<>();
         // Two accommodations for the first Exam ID
-        mockExamAccommodations.add(new ExamAccommodationBuilder()
+        mockExamAccommodations.add(new ExamAccommodation.Builder(UUID.randomUUID())
+            .fromExamAccommodation(rand.nextObject(ExamAccommodation.class))
             .withExamId(examId)
             .withSegmentKey("segment")
+            .withType("language")
+            .withValue("ENU")
+            .withDeniedAt(null)
+            .withDeletedAt(null)
             .build());
-        mockExamAccommodations.add(new ExamAccommodationBuilder()
+        mockExamAccommodations.add(new ExamAccommodation.Builder(UUID.randomUUID())
+            .fromExamAccommodation(rand.nextObject(ExamAccommodation.class))
             .withExamId(examId)
             .withSegmentKey("segment")
             .withType("closed captioning")
             .withCode("TDS_ClosedCap0")
             .withTotalTypeCount(5)
+            .withDeniedAt(null)
+            .withDeletedAt(null)
             .build());
 
         examAccommodationCommandRepository.insert(mockExamAccommodations);

--- a/service/src/test/java/tds/exam/repositories/impl/ExamAccommodationQueryRepositoryIntegrationTests.java
+++ b/service/src/test/java/tds/exam/repositories/impl/ExamAccommodationQueryRepositoryIntegrationTests.java
@@ -55,6 +55,12 @@ public class ExamAccommodationQueryRepositoryIntegrationTests {
             .withSegmentPosition(5)
             .withTotalTypeCount(5)
             .withCustom(true)
+            .withVisible(true)
+            .withDefaultAccommodation(true)
+            .withDisabledOnGuestSession(true)
+            .withStudentControlled(true)
+            .withDependsOn("Language")
+            .withAllowCombine(true)
             .build());
 
         // Accommodation in second segment that is denied
@@ -118,6 +124,12 @@ public class ExamAccommodationQueryRepositoryIntegrationTests {
         assertThat(firstExamAccommodation.getCreatedAt()).isLessThan(Instant.now());
         assertThat(firstExamAccommodation.isApproved()).isTrue();
         assertThat(firstExamAccommodation.isCustom()).isTrue();
+        assertThat(firstExamAccommodation.isAllowCombine()).isTrue();
+        assertThat(firstExamAccommodation.isDefaultAccommodation()).isTrue();
+        assertThat(firstExamAccommodation.isDisabledOnGuestSession()).isTrue();
+        assertThat(firstExamAccommodation.getDependsOn()).isEqualTo("Language");
+        assertThat(firstExamAccommodation.isVisible()).isTrue();
+        assertThat(firstExamAccommodation.isStudentControlled()).isTrue();
 
         assertThat(secondAccommodation.getId()).isNotNull();
         assertThat(secondAccommodation.getExamId()).isEqualTo(ExamAccommodationBuilder.SampleData.DEFAULT_EXAM_ID);

--- a/service/src/test/java/tds/exam/services/impl/ExamAccommodationServiceImplTest.java
+++ b/service/src/test/java/tds/exam/services/impl/ExamAccommodationServiceImplTest.java
@@ -267,6 +267,10 @@ public class ExamAccommodationServiceImplTest {
             .withAllowChange(true)
             .withSelectable(true)
             .withDefaultAccommodation(true)
+            .withDependsOnToolType("Language")
+            .withAllowCombine(true)
+            .withDisableOnGuestSession(false)
+            .withToolTypeSortOrder(3)
             .withTypeTotal(5)
             .build();
 
@@ -369,6 +373,11 @@ public class ExamAccommodationServiceImplTest {
         assertThat(testExamAccommodation.isSelectable()).isTrue();
         assertThat(testExamAccommodation.isApproved()).isFalse();
         assertThat(testExamAccommodation.isCustom()).isFalse();
+        assertThat(testExamAccommodation.getDependsOn()).isEqualTo("Language");
+        assertThat(testExamAccommodation.isAllowCombine()).isTrue();
+        assertThat(testExamAccommodation.isDefaultAccommodation()).isTrue();
+        assertThat(testExamAccommodation.isDisabledOnGuestSession()).isFalse();
+        assertThat(testExamAccommodation.getSortOrder()).isEqualTo(3);
     }
     
     @Test


### PR DESCRIPTION
…eed to fetch Assessment Accommodations on student/proctor

We will no longer need to fetch/match assessment accommodations in Student/Proctor as the exam accommodations will contain all the data we need.