### PR TITLE
Resolving bug where multiple print requests were created for an item …

### DIFF
--- a/service/src/main/java/tds/exam/repositories/ExamPrintRequestQueryRepository.java
+++ b/service/src/main/java/tds/exam/repositories/ExamPrintRequestQueryRepository.java
@@ -45,4 +45,14 @@ public interface ExamPrintRequestQueryRepository {
      * @return A {@link List<tds.exam.ExamPrintRequest>} that have been approved
      */
     List<ExamPrintRequest> findApprovedRequests(final UUID sessionId);
+
+    /**
+     * Retrieves a count of unfulfilled requests for a given exam and item position
+     *
+     * @param examId       The id of the exam for the {@link tds.exam.ExamPrintRequest}s
+     * @param itemPosition The item position of the request to check for
+     * @param pagePosition The page position of the request to check for
+     * @return
+     */
+    int findCountOfUnfulfilledRequestsForExamAndItemPosition(final UUID examId, final int itemPosition, final int pagePosition);
 }

--- a/service/src/test/java/tds/exam/repositories/impl/ExamPrintRequestRepositoryIntegrationTests.java
+++ b/service/src/test/java/tds/exam/repositories/impl/ExamPrintRequestRepositoryIntegrationTests.java
@@ -399,4 +399,39 @@ public class ExamPrintRequestRepositoryIntegrationTests {
         assertThat(requestCounts.containsKey(diffSessionExam.getId())).isFalse();
     }
 
+    @Test
+    public void shouldGetCountOfUnfulfilledRequests() {
+        UUID sessionId = UUID.randomUUID();
+        Exam exam = new ExamBuilder().withSessionId(sessionId).build();
+        examCommandRepository.insert(exam);
+
+        ExamPrintRequest unfulfilledRequest = new ExamPrintRequest.Builder(UUID.randomUUID())
+            .fromExamPrintRequest(random(ExamPrintRequest.class))
+            .withSessionId(sessionId)
+            .withExamId(exam.getId())
+            .withCreatedAt(null)
+            .withChangedAt(null)
+            .withStatus(ExamPrintRequestStatus.SUBMITTED)
+            .withType(ExamPrintRequest.REQUEST_TYPE_EMBOSS_ITEM)
+            .withItemPosition(1)
+            .withPagePosition(3)
+            .build();
+
+        ExamPrintRequest fulfilledPrintRequest = new ExamPrintRequest.Builder(UUID.randomUUID())
+            .fromExamPrintRequest(random(ExamPrintRequest.class))
+            .withSessionId(sessionId)
+            .withExamId(exam.getId())
+            .withCreatedAt(null)
+            .withChangedAt(null)
+            .withStatus(ExamPrintRequestStatus.APPROVED)
+            .withType(ExamPrintRequest.REQUEST_TYPE_PRINT_ITEM)
+            .withItemPosition(1)
+            .withPagePosition(3)
+            .build();
+
+
+        examPrintRequestCommandRepository.insert(unfulfilledRequest);
+        examPrintRequestCommandRepository.insert(fulfilledPrintRequest);
+        assertThat(examPrintRequestQueryRepository.findCountOfUnfulfilledRequestsForExamAndItemPosition(exam.getId(), 1, 3)).isEqualTo(1);
+    }
 }

--- a/service/src/test/java/tds/exam/services/impl/ExamPrintRequestServiceImplTest.java
+++ b/service/src/test/java/tds/exam/services/impl/ExamPrintRequestServiceImplTest.java
@@ -1,6 +1,5 @@
 package tds.exam.services.impl;
 
-import com.google.common.collect.ImmutableSet;
 import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
@@ -21,7 +20,6 @@ import tds.exam.ExpandableExamPrintRequest;
 import tds.exam.repositories.ExamPrintRequestCommandRepository;
 import tds.exam.repositories.ExamPrintRequestQueryRepository;
 import tds.exam.services.ExamPrintRequestService;
-import tds.exam.services.ExpandableExamMapper;
 import tds.exam.services.ExpandableExamPrintRequestMapper;
 
 import static io.github.benas.randombeans.api.EnhancedRandom.random;
@@ -58,8 +56,23 @@ public class ExamPrintRequestServiceImplTest {
     @Test
     public void shouldCreateExamPrintRequest() {
         ExamPrintRequest examPrintRequest = random(ExamPrintRequest.class);
+        when(mockExamPrintRequestQueryRepository
+            .findCountOfUnfulfilledRequestsForExamAndItemPosition(examPrintRequest.getExamId(), examPrintRequest.getItemPosition(), examPrintRequest.getPagePosition())).thenReturn(0);
         examPrintRequestService.insert(examPrintRequest);
         verify(mockExamPrintRequestCommandRepository).insert(examPrintRequest);
+        verify(mockExamPrintRequestQueryRepository).findCountOfUnfulfilledRequestsForExamAndItemPosition(examPrintRequest.getExamId(),
+            examPrintRequest.getItemPosition(), examPrintRequest.getPagePosition());
+    }
+
+    @Test
+    public void shouldNotCreateExamPrintRequestDueToExistingRequest() {
+        ExamPrintRequest examPrintRequest = random(ExamPrintRequest.class);
+        when(mockExamPrintRequestQueryRepository
+            .findCountOfUnfulfilledRequestsForExamAndItemPosition(examPrintRequest.getExamId(), examPrintRequest.getItemPosition(), examPrintRequest.getPagePosition())).thenReturn(1);
+        examPrintRequestService.insert(examPrintRequest);
+        verify(mockExamPrintRequestCommandRepository, never()).insert(examPrintRequest);
+        verify(mockExamPrintRequestQueryRepository).findCountOfUnfulfilledRequestsForExamAndItemPosition(examPrintRequest.getExamId(),
+            examPrintRequest.getItemPosition(), examPrintRequest.getPagePosition());
     }
 
     @Test


### PR DESCRIPTION
…or passage that already had an active unfulfilled print request.

- Note that page position is included in the check because for passages, itemPosition = 0. Not including pagePosition would result in a bug where only one passage can have a print request at any given time.

- The legacy app does not have any indication on the UI that a request has been sent for an item already requested, therefore no change to the controller is necessary.