### PR TITLE
Fixing issue with non-embedded accommodations not being added to exam…

### DIFF
--- a/client/src/main/java/tds/exam/ExamAccommodation.java
+++ b/client/src/main/java/tds/exam/ExamAccommodation.java
@@ -33,6 +33,7 @@ public class ExamAccommodation {
     private boolean disabledOnGuestSession;
     private boolean defaultAccommodation;
     private boolean allowCombine;
+    private boolean functional;
     private int sortOrder;
     private String dependsOn;
 
@@ -63,6 +64,7 @@ public class ExamAccommodation {
         private boolean disabledOnGuestSession;
         private boolean defaultAccommodation;
         private boolean allowCombine;
+        private boolean functional;
         private int sortOrder;
         private String dependsOn;
 
@@ -175,6 +177,11 @@ public class ExamAccommodation {
             return this;
         }
 
+        public Builder withFunctional(boolean functional) {
+            this.functional = functional;
+            return this;
+        }
+
         public static Builder fromExamAccommodation(final ExamAccommodation accommodation) {
             return new Builder(accommodation.getId())
                 .withExamId(accommodation.getExamId())
@@ -188,7 +195,15 @@ public class ExamAccommodation {
                 .withSelectable(accommodation.isSelectable())
                 .withAllowChange(accommodation.isAllowChange())
                 .withValue(accommodation.getValue())
-                .withCustom(accommodation.isCustom());
+                .withCustom(accommodation.isCustom())
+                .withVisible(accommodation.isVisible())
+                .withSortOrder(accommodation.getSortOrder())
+                .withDependsOn(accommodation.getDependsOn())
+                .withStudentControlled(accommodation.isStudentControlled())
+                .withDisabledOnGuestSession(accommodation.isDisabledOnGuestSession())
+                .withDefaultAccommodation(accommodation.isDefaultAccommodation())
+                .withAllowCombine(accommodation.isAllowCombine())
+                .withFunctional(accommodation.isFunctional());
         }
 
         public ExamAccommodation build() {
@@ -219,6 +234,7 @@ public class ExamAccommodation {
         allowCombine = builder.allowCombine;
         sortOrder = builder.sortOrder;
         dependsOn = builder.dependsOn;
+        functional = builder.functional;
     }
 
     /**
@@ -384,6 +400,13 @@ public class ExamAccommodation {
      */
     public boolean isAllowCombine() {
         return allowCombine;
+    }
+
+    /**
+     * @return {@code true} if this accommodation is functional and should be displayed on the student UI
+     */
+    public boolean isFunctional() {
+        return functional;
     }
 
     @Override

--- a/service/src/main/java/tds/exam/repositories/impl/ExamAccommodationCommandRepositoryImpl.java
+++ b/service/src/main/java/tds/exam/repositories/impl/ExamAccommodationCommandRepositoryImpl.java
@@ -32,9 +32,9 @@ public class ExamAccommodationCommandRepositoryImpl implements ExamAccommodation
         String SQL =
             "INSERT INTO " +
             "   exam_accommodation(exam_id, id, segment_key, type, code, description, allow_change, value, segment_position, " +
-            "   created_at, visible, student_controlled, disabled_on_guest_session, default_accommodation, allow_combine, sort_order, depends_on) \n" +
+            "   created_at, visible, student_controlled, disabled_on_guest_session, default_accommodation, allow_combine, sort_order, depends_on, functional) \n" +
             "VALUES(:examId, :id, :segmentKey, :type, :code, :description, :allowChange, :value, :segmentPosition, :createdAt," +
-            "   :visible, :studentControlled, :disabledOnGuestSession, :defaultAccommodation, :allowCombine, :sortOrder, :dependsOn)";
+            "   :visible, :studentControlled, :disabledOnGuestSession, :defaultAccommodation, :allowCombine, :sortOrder, :dependsOn, :functional)";
 
         Timestamp createdAt = mapJodaInstantToTimestamp(Instant.now());
         List<ExamAccommodation> createdAccommodations = new ArrayList<>();
@@ -60,6 +60,7 @@ public class ExamAccommodationCommandRepositoryImpl implements ExamAccommodation
                     .addValue("value", examAccommodation.getValue())
                     .addValue("segmentPosition", examAccommodation.getSegmentPosition())
                     .addValue("description", examAccommodation.getDescription())
+                    .addValue("functional", examAccommodation.isFunctional())
                     .addValue("createdAt", createdAt);
             })
             .toArray(SqlParameterSource[]::new);

--- a/service/src/main/java/tds/exam/repositories/impl/ExamAccommodationQueryRepositoryImpl.java
+++ b/service/src/main/java/tds/exam/repositories/impl/ExamAccommodationQueryRepositoryImpl.java
@@ -55,6 +55,7 @@ public class ExamAccommodationQueryRepositoryImpl implements ExamAccommodationQu
                 "   ea.allow_combine, \n" +
                 "   ea.depends_on, \n" +
                 "   ea.sort_order, \n" +
+                "   ea.functional, \n" +
                 "   eae.selectable, \n" +
                 "   eae.total_type_count, \n" +
                 "   eae.custom \n" +
@@ -119,6 +120,7 @@ public class ExamAccommodationQueryRepositoryImpl implements ExamAccommodationQu
                 "   ea.allow_combine, \n" +
                 "   ea.depends_on, \n" +
                 "   ea.sort_order, \n" +
+                "   ea.functional, \n" +
                 "   ea.segment_position, \n" +
                 "   eae.total_type_count, \n" +
                 "   eae.selectable, \n" +
@@ -173,6 +175,7 @@ public class ExamAccommodationQueryRepositoryImpl implements ExamAccommodationQu
                 .withAllowCombine(rs.getBoolean("allow_combine"))
                 .withSortOrder(rs.getInt("sort_order"))
                 .withDependsOn(rs.getString("depends_on"))
+                .withFunctional(rs.getBoolean("functional"))
                 .build();
         }
     }

--- a/service/src/main/java/tds/exam/services/impl/ExamAccommodationServiceImpl.java
+++ b/service/src/main/java/tds/exam/services/impl/ExamAccommodationServiceImpl.java
@@ -1,5 +1,7 @@
 package tds.exam.services.impl;
 
+import com.google.common.collect.ArrayListMultimap;
+import com.google.common.collect.Multimap;
 import org.apache.commons.lang3.StringUtils;
 import org.joda.time.Instant;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -88,7 +90,7 @@ class ExamAccommodationServiceImpl implements ExamAccommodationService {
 
         // Get the list of accommodations from the student package, for the particular Exam subject
         //  Take the accommodation code, lookup the accommodation and put into a Map by type for easy lookup
-        Map<String, Accommodation> studentAccommodations = new HashMap<>();
+        Multimap<String, Accommodation> studentAccommodations = ArrayListMultimap.create();
         splitAccommodationCodes(exam.getSubject(), studentAccommodationCodes).forEach(code -> {
             if (assessmentAccommodations.containsKey(code)) {
                 Accommodation accommodation = assessmentAccommodations.get(code);
@@ -136,6 +138,7 @@ class ExamAccommodationServiceImpl implements ExamAccommodationService {
                 .withAllowCombine(accommodation.isAllowCombine())
                 .withDependsOn(accommodation.getDependsOnToolType())
                 .withSortOrder(accommodation.getToolTypeSortOrder())
+                .withFunctional(accommodation.isFunctional())
                 .withCreatedAt(now)
                 .build();
 
@@ -315,6 +318,7 @@ class ExamAccommodationServiceImpl implements ExamAccommodationService {
                     .withAllowCombine(accommodation.isAllowCombine())
                     .withDependsOn(accommodation.getDependsOnToolType())
                     .withSortOrder(accommodation.getToolTypeSortOrder())
+                    .withFunctional(accommodation.isFunctional())
                     .withDeniedAt(deniedAt)
                     .withCreatedAt(now)
                     .build();

--- a/service/src/main/resources/db/migration/V1490384492__exam_accommodations_add_functional_column.sql
+++ b/service/src/main/resources/db/migration/V1490384492__exam_accommodations_add_functional_column.sql
@@ -1,0 +1,11 @@
+/***********************************************************************************************************************
+  File: V1490384492__exam_accommodations_add_functional_column.sql
+
+  Desc: Adds the `functional` column to exam_accommodations
+
+***********************************************************************************************************************/
+
+use exam;
+
+ALTER TABLE exam_accommodation
+  ADD COLUMN functional BIT(1) NOT NULL DEFAULT 1;

--- a/service/src/test/java/tds/exam/builder/ExamAccommodationBuilder.java
+++ b/service/src/test/java/tds/exam/builder/ExamAccommodationBuilder.java
@@ -39,6 +39,7 @@ public class ExamAccommodationBuilder {
     private int segmentPosition = 1;
     private int totalTypeCount = 1;
     private boolean custom;
+    private boolean functional = false;
 
     public ExamAccommodation build() {
         return new ExamAccommodation.Builder(id)
@@ -62,6 +63,7 @@ public class ExamAccommodationBuilder {
             .withDisabledOnGuestSession(disabledOnGuestSession)
             .withStudentControlled(studentControlled)
             .withDependsOn(dependsOn)
+            .withFunctional(functional)
             .build();
     }
 
@@ -167,6 +169,11 @@ public class ExamAccommodationBuilder {
 
     public ExamAccommodationBuilder withTotalTypeCount(int totalTypeCount) {
         this.totalTypeCount = totalTypeCount;
+        return this;
+    }
+
+    public ExamAccommodationBuilder withFunctional(boolean functional) {
+        this.functional = functional;
         return this;
     }
 }

--- a/service/src/test/java/tds/exam/repositories/impl/ExamAccommodationQueryRepositoryIntegrationTests.java
+++ b/service/src/test/java/tds/exam/repositories/impl/ExamAccommodationQueryRepositoryIntegrationTests.java
@@ -59,6 +59,7 @@ public class ExamAccommodationQueryRepositoryIntegrationTests {
             .withDefaultAccommodation(true)
             .withDisabledOnGuestSession(true)
             .withStudentControlled(true)
+            .withFunctional(true)
             .withDependsOn("Language")
             .withAllowCombine(true)
             .build());
@@ -130,6 +131,7 @@ public class ExamAccommodationQueryRepositoryIntegrationTests {
         assertThat(firstExamAccommodation.getDependsOn()).isEqualTo("Language");
         assertThat(firstExamAccommodation.isVisible()).isTrue();
         assertThat(firstExamAccommodation.isStudentControlled()).isTrue();
+        assertThat(firstExamAccommodation.isFunctional()).isTrue();
 
         assertThat(secondAccommodation.getId()).isNotNull();
         assertThat(secondAccommodation.getExamId()).isEqualTo(ExamAccommodationBuilder.SampleData.DEFAULT_EXAM_ID);

--- a/service/src/test/java/tds/exam/services/impl/ExamAccommodationServiceImplTest.java
+++ b/service/src/test/java/tds/exam/services/impl/ExamAccommodationServiceImplTest.java
@@ -271,6 +271,7 @@ public class ExamAccommodationServiceImplTest {
             .withAllowCombine(true)
             .withDisableOnGuestSession(false)
             .withToolTypeSortOrder(3)
+            .withFunctional(true)
             .withTypeTotal(5)
             .build();
 
@@ -377,6 +378,7 @@ public class ExamAccommodationServiceImplTest {
         assertThat(testExamAccommodation.isAllowCombine()).isTrue();
         assertThat(testExamAccommodation.isDefaultAccommodation()).isTrue();
         assertThat(testExamAccommodation.isDisabledOnGuestSession()).isFalse();
+        assertThat(testExamAccommodation.isFunctional()).isTrue();
         assertThat(testExamAccommodation.getSortOrder()).isEqualTo(3);
     }
     


### PR DESCRIPTION
Two primary changes
- Using a guava `Multimap` in ExamAccommodationServiceImpl since exam accommodations may have multiple codes for the same type. 
- Addition of "isFunctional" flag in exam_accommodations. This flag is used by student to determine whether or not an exam accommodation needs to be displayed or added to the TDS_Student-Accs cookie.