### PR TITLE
Deny exam accommodations when exam status is set to “denied”

### DIFF
--- a/service/src/main/java/tds/exam/repositories/ExamAccommodationCommandRepository.java
+++ b/service/src/main/java/tds/exam/repositories/ExamAccommodationCommandRepository.java
@@ -1,6 +1,7 @@
 package tds.exam.repositories;
 
 import java.util.List;
+import java.util.UUID;
 
 import tds.exam.ExamAccommodation;
 

--- a/service/src/main/java/tds/exam/repositories/impl/ExamAccommodationCommandRepositoryImpl.java
+++ b/service/src/main/java/tds/exam/repositories/impl/ExamAccommodationCommandRepositoryImpl.java
@@ -11,7 +11,6 @@ import org.springframework.stereotype.Repository;
 import java.sql.Timestamp;
 import java.util.ArrayList;
 import java.util.List;
-import java.util.UUID;
 import java.util.stream.Collectors;
 
 import tds.exam.ExamAccommodation;

--- a/service/src/main/java/tds/exam/repositories/impl/ExamAccommodationCommandRepositoryImpl.java
+++ b/service/src/main/java/tds/exam/repositories/impl/ExamAccommodationCommandRepositoryImpl.java
@@ -11,6 +11,7 @@ import org.springframework.stereotype.Repository;
 import java.sql.Timestamp;
 import java.util.ArrayList;
 import java.util.List;
+import java.util.UUID;
 import java.util.stream.Collectors;
 
 import tds.exam.ExamAccommodation;
@@ -31,10 +32,10 @@ public class ExamAccommodationCommandRepositoryImpl implements ExamAccommodation
     public void insert(final List<ExamAccommodation> accommodations) {
         String SQL =
             "INSERT INTO " +
-            "   exam_accommodation(exam_id, id, segment_key, type, code, description, allow_change, value, segment_position, " +
-            "   created_at, visible, student_controlled, disabled_on_guest_session, default_accommodation, allow_combine, sort_order, depends_on, functional) \n" +
-            "VALUES(:examId, :id, :segmentKey, :type, :code, :description, :allowChange, :value, :segmentPosition, :createdAt," +
-            "   :visible, :studentControlled, :disabledOnGuestSession, :defaultAccommodation, :allowCombine, :sortOrder, :dependsOn, :functional)";
+                "   exam_accommodation(exam_id, id, segment_key, type, code, description, allow_change, value, segment_position, " +
+                "   created_at, visible, student_controlled, disabled_on_guest_session, default_accommodation, allow_combine, sort_order, depends_on, functional) \n" +
+                "VALUES(:examId, :id, :segmentKey, :type, :code, :description, :allowChange, :value, :segmentPosition, :createdAt," +
+                "   :visible, :studentControlled, :disabledOnGuestSession, :defaultAccommodation, :allowCombine, :sortOrder, :dependsOn, :functional)";
 
         Timestamp createdAt = mapJodaInstantToTimestamp(Instant.now());
         List<ExamAccommodation> createdAccommodations = new ArrayList<>();
@@ -75,7 +76,7 @@ public class ExamAccommodationCommandRepositoryImpl implements ExamAccommodation
         updateEvent(mapJodaInstantToTimestamp(Instant.now()), examAccommodation);
     }
 
-    private void updateEvent( final Timestamp createdAt, final ExamAccommodation... examAccommodations) {
+    private void updateEvent(final Timestamp createdAt, final ExamAccommodation... examAccommodations) {
         String SQL = "INSERT INTO exam_accommodation_event(" +
             "exam_accommodation_id, " +
             "denied_at, " +

--- a/service/src/main/java/tds/exam/services/ExamAccommodationService.java
+++ b/service/src/main/java/tds/exam/services/ExamAccommodationService.java
@@ -69,4 +69,11 @@ public interface ExamAccommodationService {
      * @return an optional {@link tds.common.ValidationError}
      */
     Optional<ValidationError> approveAccommodations(UUID examId, ApproveAccommodationsRequest request);
+
+    /**
+     * Denies all {@link tds.exam.ExamAccommodation}s for an exam
+     *
+     * @param examId The id of the exam for which to deny accommodations
+     */
+    void denyAccommodations(UUID examId);
 }

--- a/service/src/main/java/tds/exam/services/ExamAccommodationService.java
+++ b/service/src/main/java/tds/exam/services/ExamAccommodationService.java
@@ -1,5 +1,7 @@
 package tds.exam.services;
 
+import org.joda.time.Instant;
+
 import java.util.List;
 import java.util.Optional;
 import java.util.UUID;
@@ -74,6 +76,7 @@ public interface ExamAccommodationService {
      * Denies all {@link tds.exam.ExamAccommodation}s for an exam
      *
      * @param examId The id of the exam for which to deny accommodations
+     * @param deniedAt
      */
-    void denyAccommodations(UUID examId);
+    void denyAccommodations(final UUID examId, final Instant deniedAt);
 }

--- a/service/src/main/java/tds/exam/services/impl/ExamAccommodationServiceImpl.java
+++ b/service/src/main/java/tds/exam/services/impl/ExamAccommodationServiceImpl.java
@@ -9,7 +9,6 @@ import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
 import java.util.ArrayList;
-import java.util.HashMap;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
@@ -230,13 +229,14 @@ class ExamAccommodationServiceImpl implements ExamAccommodationService {
     }
 
     @Override
-    public void denyAccommodations(final UUID examId) {
+    @Transactional
+    public void denyAccommodations(final UUID examId, final Instant deniedAt) {
         final List<ExamAccommodation> pendingAccommodations = examAccommodationQueryRepository.findAccommodations(examId);
         final ExamAccommodation[] deniedAccommodations = pendingAccommodations.stream()
             .map(accommodation ->
                 new ExamAccommodation.Builder(accommodation.getId())
                     .fromExamAccommodation(accommodation)
-                    .withDeniedAt(Instant.now())
+                    .withDeniedAt(deniedAt)
                     .build())
             .collect(Collectors.toList()).toArray(new ExamAccommodation[pendingAccommodations.size()]);
 

--- a/service/src/main/java/tds/exam/services/impl/ExamAccommodationServiceImpl.java
+++ b/service/src/main/java/tds/exam/services/impl/ExamAccommodationServiceImpl.java
@@ -229,6 +229,20 @@ class ExamAccommodationServiceImpl implements ExamAccommodationService {
         return Optional.empty();
     }
 
+    @Override
+    public void denyAccommodations(final UUID examId) {
+        final List<ExamAccommodation> pendingAccommodations = examAccommodationQueryRepository.findAccommodations(examId);
+        final ExamAccommodation[] deniedAccommodations = pendingAccommodations.stream()
+            .map(accommodation ->
+                new ExamAccommodation.Builder(accommodation.getId())
+                    .fromExamAccommodation(accommodation)
+                    .withDeniedAt(Instant.now())
+                    .build())
+            .collect(Collectors.toList()).toArray(new ExamAccommodation[pendingAccommodations.size()]);
+
+        examAccommodationCommandRepository.update(deniedAccommodations);
+    }
+
     private static String getOtherAccommodationValue(String formattedValue) {
         return formattedValue.substring("TDS_Other#".length());
     }

--- a/service/src/main/java/tds/exam/utils/listeners/OnDeniedStatusExamChangeListener.java
+++ b/service/src/main/java/tds/exam/utils/listeners/OnDeniedStatusExamChangeListener.java
@@ -1,0 +1,38 @@
+package tds.exam.utils.listeners;
+
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.stereotype.Component;
+
+import tds.common.entity.utils.ChangeListener;
+import tds.common.util.Preconditions;
+import tds.exam.Exam;
+import tds.exam.ExamStatusCode;
+import tds.exam.services.ExamAccommodationService;
+
+/**
+ * Listener to apply business rules when an {@link tds.exam.Exam}'s status is set to "denied"
+ */
+@Component
+public class OnDeniedStatusExamChangeListener implements ChangeListener<Exam> {
+    private final ExamAccommodationService examAccommodationService;
+
+    @Autowired
+    public OnDeniedStatusExamChangeListener(final ExamAccommodationService examAccommodationService) {
+        this.examAccommodationService = examAccommodationService;
+    }
+
+    @Override
+    public void accept(final Exam oldExam, final Exam newExam) {
+        Preconditions.checkNotNull(oldExam, "oldExam cannot be null");
+        Preconditions.checkNotNull(newExam, "newExam cannot be null");
+
+        // If the status has not changed between exam instances or the status has not already been set to "denied" on
+        // the new version of the exam, exit
+        if (oldExam.getStatus().equals(newExam.getStatus())
+            || !newExam.getStatus().getCode().equals(ExamStatusCode.STATUS_DENIED)) {
+            return;
+        }
+
+        examAccommodationService.denyAccommodations(newExam.getId());
+    }
+}

--- a/service/src/main/java/tds/exam/utils/listeners/OnDeniedStatusExamChangeListener.java
+++ b/service/src/main/java/tds/exam/utils/listeners/OnDeniedStatusExamChangeListener.java
@@ -33,6 +33,6 @@ public class OnDeniedStatusExamChangeListener implements ChangeListener<Exam> {
             return;
         }
 
-        examAccommodationService.denyAccommodations(newExam.getId());
+        examAccommodationService.denyAccommodations(newExam.getId(), newExam.getChangedAt());
     }
 }

--- a/service/src/test/java/tds/exam/services/impl/ExamAccommodationServiceImplTest.java
+++ b/service/src/test/java/tds/exam/services/impl/ExamAccommodationServiceImplTest.java
@@ -40,6 +40,7 @@ import tds.exam.services.ExamApprovalService;
 import tds.exam.services.SessionService;
 import tds.session.Session;
 
+import static io.github.benas.randombeans.api.EnhancedRandom.random;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.fail;
 import static org.mockito.Matchers.any;
@@ -71,6 +72,9 @@ public class ExamAccommodationServiceImplTest {
 
     @Captor
     private ArgumentCaptor<List<ExamAccommodation>> examAccommodationInsertCaptor;
+
+    @Captor
+    private ArgumentCaptor<ExamAccommodation> examAccommodationUpdateCaptor;
 
     @Before
     public void setUp() {
@@ -651,6 +655,34 @@ public class ExamAccommodationServiceImplTest {
         assertThat(otherExamAccomm.isAllowChange()).isFalse();
         assertThat(otherExamAccomm.isSelectable()).isFalse();
 
+    }
+
+    @Test
+    public void shouldDenyAccommodations() {
+        final UUID examId = UUID.randomUUID();
+
+        ExamAccommodation examAcc1 = new ExamAccommodation.Builder(UUID.randomUUID())
+            .fromExamAccommodation(random(ExamAccommodation.class))
+            .withDeletedAt(null)
+            .withDeniedAt(null)
+            .build();
+        ExamAccommodation examAcc2 = new ExamAccommodation.Builder(UUID.randomUUID())
+            .fromExamAccommodation(random(ExamAccommodation.class))
+            .withDeletedAt(null)
+            .withDeniedAt(null)
+            .build();
+
+        when(mockExamAccommodationQueryRepository.findAccommodations(examId)).thenReturn(Arrays.asList(examAcc1, examAcc2));
+        examAccommodationService.denyAccommodations(examId);
+        verify(mockExamAccommodationQueryRepository).findAccommodations(examId);
+        verify(mockExamAccommodationCommandRepository).update(examAccommodationUpdateCaptor.capture());
+
+        List<ExamAccommodation> examAccommodations = examAccommodationUpdateCaptor.getAllValues();
+        assertThat(examAccommodations).hasSize(2);
+
+        for (ExamAccommodation updatedAccomm : examAccommodations) {
+            assertThat(updatedAccomm.getDeniedAt()).isNotNull();
+        }
     }
     
     @Test

--- a/service/src/test/java/tds/exam/services/impl/ExamAccommodationServiceImplTest.java
+++ b/service/src/test/java/tds/exam/services/impl/ExamAccommodationServiceImplTest.java
@@ -671,9 +671,10 @@ public class ExamAccommodationServiceImplTest {
             .withDeletedAt(null)
             .withDeniedAt(null)
             .build();
+        final Instant deniedAt = Instant.now();
 
         when(mockExamAccommodationQueryRepository.findAccommodations(examId)).thenReturn(Arrays.asList(examAcc1, examAcc2));
-        examAccommodationService.denyAccommodations(examId);
+        examAccommodationService.denyAccommodations(examId, deniedAt);
         verify(mockExamAccommodationQueryRepository).findAccommodations(examId);
         verify(mockExamAccommodationCommandRepository).update(examAccommodationUpdateCaptor.capture());
 
@@ -681,7 +682,7 @@ public class ExamAccommodationServiceImplTest {
         assertThat(examAccommodations).hasSize(2);
 
         for (ExamAccommodation updatedAccomm : examAccommodations) {
-            assertThat(updatedAccomm.getDeniedAt()).isNotNull();
+            assertThat(updatedAccomm.getDeniedAt()).isEqualTo(deniedAt);
         }
     }
     

--- a/service/src/test/java/tds/exam/utils/listeners/OnDeniedStatusExamChangeListenerTest.java
+++ b/service/src/test/java/tds/exam/utils/listeners/OnDeniedStatusExamChangeListenerTest.java
@@ -37,7 +37,7 @@ public class OnDeniedStatusExamChangeListenerTest {
             .build();
 
         onDeniedStatusExamChangeListener.accept(exam, deniedExam);
-        verify(mockExamAccommodationService).denyAccommodations(exam.getId());
+        verify(mockExamAccommodationService).denyAccommodations(exam.getId(), deniedExam.getChangedAt());
     }
 
     @Test
@@ -49,6 +49,6 @@ public class OnDeniedStatusExamChangeListenerTest {
             .build();
 
         onDeniedStatusExamChangeListener.accept(exam, deniedExam);
-        verify(mockExamAccommodationService, never()).denyAccommodations(exam.getId());
+        verify(mockExamAccommodationService, never()).denyAccommodations(exam.getId(), deniedExam.getChangedAt());
     }
 }

--- a/service/src/test/java/tds/exam/utils/listeners/OnDeniedStatusExamChangeListenerTest.java
+++ b/service/src/test/java/tds/exam/utils/listeners/OnDeniedStatusExamChangeListenerTest.java
@@ -1,0 +1,54 @@
+package tds.exam.utils.listeners;
+
+import org.joda.time.Instant;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.Mock;
+import org.mockito.runners.MockitoJUnitRunner;
+
+import tds.common.entity.utils.ChangeListener;
+import tds.exam.Exam;
+import tds.exam.ExamStatusCode;
+import tds.exam.builder.ExamBuilder;
+import tds.exam.services.ExamAccommodationService;
+
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+
+@RunWith(MockitoJUnitRunner.class)
+public class OnDeniedStatusExamChangeListenerTest {
+    private ChangeListener<Exam> onDeniedStatusExamChangeListener;
+
+    @Mock
+    private ExamAccommodationService mockExamAccommodationService;
+
+    @Before
+    public void setup() {
+        onDeniedStatusExamChangeListener = new OnDeniedStatusExamChangeListener(mockExamAccommodationService);
+    }
+
+    @Test
+    public void shouldCallDenyAccommodationsIfExamHasBeenUpdatedToDenied() {
+        Exam exam = new ExamBuilder().build();
+        Exam deniedExam = new Exam.Builder()
+            .fromExam(exam)
+            .withStatus(new ExamStatusCode(ExamStatusCode.STATUS_DENIED), Instant.now())
+            .build();
+
+        onDeniedStatusExamChangeListener.accept(exam, deniedExam);
+        verify(mockExamAccommodationService).denyAccommodations(exam.getId());
+    }
+
+    @Test
+    public void shouldNotCallDenyIfExamIsNotDenied() {
+        Exam exam = new ExamBuilder().build();
+        Exam deniedExam = new Exam.Builder()
+            .fromExam(exam)
+            .withStatus(new ExamStatusCode(ExamStatusCode.STATUS_APPROVED), Instant.now())
+            .build();
+
+        onDeniedStatusExamChangeListener.accept(exam, deniedExam);
+        verify(mockExamAccommodationService, never()).denyAccommodations(exam.getId());
+    }
+}


### PR DESCRIPTION
Previously, exam accommodations were not set to denied when the entire exam was denied by a proctor (only when individual accommodations were denied). This fixes that.