### PR TITLE
TDS-831: Update view for MySQL 5.6 compatibility

### DIFF
--- a/service/src/main/resources/db/migration/V1491009051__exam_update_qa_testeecomment_view.sql
+++ b/service/src/main/resources/db/migration/V1491009051__exam_update_qa_testeecomment_view.sql
@@ -1,0 +1,29 @@
+/***********************************************************************************************************************
+  File: V1491009051__exam_update_qa_testeecomment_view.sql
+
+  Desc: Update the qa_session_testeecomment view to be MySQL 5.6 compliant.  MySQL versions < 5.7 do not allow
+  subqueries in views, meaning the normal approach to getting the most recent event record will not work.  The
+  qa_session_testeecomment view has been updated to use another view that will get the most recent exam_event record.
+
+***********************************************************************************************************************/
+USE exam;
+
+CREATE OR REPLACE VIEW qa_session_testeecomment AS
+  SELECT
+    'not migrated' AS clientname,
+    'not migrated' AS _efk_testee,
+    note.exam_id AS _fk_testopportunity,
+    note.item_position AS itemposition,
+    note.note AS comment,
+    note.created_at AS `date`,
+    note.context AS context,
+    event.session_id AS _fk_session,
+    'not migrated' AS groupid
+  FROM
+    examinee_note AS note
+  JOIN
+    qa_exam_most_recent_event_per_exam AS last_event
+    ON note.exam_id = last_event.exam_id
+  JOIN
+	  exam_event AS event
+	  ON last_event.id = event.id;


### PR DESCRIPTION
[TDS-831](https://jira.fairwaytech.com/browse/TDS-831):  Updated view to be MySQL 5.6 compliant.  MySQL 5.6 does not allow views to have subqueries; another view must be used instead.  This has been changed in MySQL 5.7.

### Analysis
When flyway executed the migration against the DEV and QA environments, the TeamCity build logs reported success:

```
Current version of schema `exam`: 1490894289
outOfOrder mode is active. Migration of schema `exam` may not be reproducible.
Migrating schema `exam` to version 1490996512 - exam add session to qa testeecomment view
Successfully applied 1 migration to schema `exam` (execution time 00:00.087s).
```

However, when looking in the `schema_version` table, the `success` bit was set to 0.  Upon further investigation, the MySQL version of DEV & QA is 5.6.27 vs. my local MySQL installation of version 5.7.17.