### PR TITLE
TDS-825: Move @Transactional annotation to public methods

### DIFF
--- a/service/src/main/java/tds/exam/services/impl/ExamServiceImpl.java
+++ b/service/src/main/java/tds/exam/services/impl/ExamServiceImpl.java
@@ -218,17 +218,18 @@ class ExamServiceImpl implements ExamService {
         return createExam(currentSession.getClientName(), openExamRequest, currentSession, assessment, externalSessionConfiguration, previousExam, student);
     }
 
+    @Transactional
     @Override
     public Optional<ValidationError> updateExamStatus(final UUID examId, final ExamStatusCode newStatus) {
         return updateExamStatus(examId, newStatus, null);
     }
 
+    @Transactional
     @Override
     public Optional<ValidationError> updateExamStatus(final UUID examId, final ExamStatusCode newStatus, final String statusChangeReason) {
         return updateExamStatus(examId, newStatus, statusChangeReason, -1);
     }
 
-    @Transactional
     private Optional<ValidationError> updateExamStatus(final UUID examId, final ExamStatusCode newStatus, final String statusChangeReason,
                                                       final int waitingForSegmentPosition) {
         Exam exam = examQueryRepository.getExamById(examId)


### PR DESCRIPTION
[TDS-825](https://jira.fairwaytech.com/browse/TDS-825):  Moved the `@Transactional` annotation from the private `updateExamStatus` method to the public signatures.  According to the Spring documentation, `@Transactional` will not work on private methods or when one method calls another within the same class because they aren't handled by Spring's proxy classes:

>Note: In proxy mode (which is the default), only 'external' method calls coming in through the proxy will be intercepted. This means that 'self-invocation', i.e. a method within the target object calling some other method of the target object, won't lead to an actual transaction at runtime even if the invoked method is marked with @Transactional!