### PR TITLE
Returning empty list when ExamAccommodations are null in ExpandableEx…

### DIFF
--- a/client/src/main/java/tds/exam/ExpandableExam.java
+++ b/client/src/main/java/tds/exam/ExpandableExam.java
@@ -149,7 +149,7 @@ public class ExpandableExam {
      * @return The {@link tds.exam.ExamAccommodation}s of the exam
      */
     public List<ExamAccommodation> getExamAccommodations() {
-        return examAccommodations;
+        return (examAccommodations != null) ? examAccommodations : new ArrayList<ExamAccommodation>();
     }
 
     /**


### PR DESCRIPTION
…am to prevent NPE.
This PR fixes https://jira.fairwaytech.com/browse/TDS-842, which was being caused by an NPE when attempting to loop over a "null" arraylist of exam accommodations.