### PR TITLE
Refactoring approve accommodations. Adding check/exam update for cust…

### DIFF
--- a/service/src/main/java/tds/exam/services/ExamAccommodationService.java
+++ b/service/src/main/java/tds/exam/services/ExamAccommodationService.java
@@ -3,14 +3,13 @@ package tds.exam.services;
 import org.joda.time.Instant;
 
 import java.util.List;
-import java.util.Optional;
 import java.util.UUID;
 
 import tds.assessment.Assessment;
-import tds.common.ValidationError;
 import tds.exam.ApproveAccommodationsRequest;
 import tds.exam.Exam;
 import tds.exam.ExamAccommodation;
+import tds.session.Session;
 
 /**
  * Handles interaction with {@link tds.exam.ExamAccommodation}s associated to an {@link tds.exam.Exam}
@@ -37,7 +36,7 @@ public interface ExamAccommodationService {
     /**
      * Initializes and inserts exam accommodations for the exam;
      *
-     * @param exam exam to use to initialize the {@link tds.exam.ExamAccommodation}
+     * @param exam                      exam to use to initialize the {@link tds.exam.ExamAccommodation}
      * @param studentAccommodationCodes the separated list of accommodations from the student package retrieved from ART
      */
     List<ExamAccommodation> initializeExamAccommodations(Exam exam, String studentAccommodationCodes);
@@ -53,29 +52,29 @@ public interface ExamAccommodationService {
     /**
      * Initializes accommodations on a previous exam
      *
-     * @param exam                {@link tds.exam.Exam}
-     * @param assessment          {@link tds.assessment.Assessment}
-     * @param segmentPosition     the segment position for the accommodations
-     * @param restoreRts          {@code true} if the restore rts
+     * @param exam                      {@link tds.exam.Exam}
+     * @param assessment                {@link tds.assessment.Assessment}
+     * @param segmentPosition           the segment position for the accommodations
+     * @param restoreRts                {@code true} if the restore rts
      * @param studentAccommodationCodes the student accommodations String
-     *
      * @return list of {@link tds.exam.ExamAccommodation}
      */
     List<ExamAccommodation> initializeAccommodationsOnPreviousExam(Exam exam, Assessment assessment, int segmentPosition, boolean restoreRts, String studentAccommodationCodes);
-    
+
     /**
      * Approves {@link tds.exam.ExamAccommodation}s for an exam and set of accommodation codes.
      *
-     * @param examId  the id of the {@link tds.exam.Exam} to approve accommodations for
+     * @param exam    the {@link tds.exam.Exam} to approve accommodations for
+     * @param session the {@link tds.session.Session} the exam belongs to
      * @param request the {@link tds.exam.ApproveAccommodationsRequest} containing request datazz
-     * @return an optional {@link tds.common.ValidationError}
+     * @return the updated {@link List<tds.exam.ExamAccommodation>}s
      */
-    Optional<ValidationError> approveAccommodations(UUID examId, ApproveAccommodationsRequest request);
+    List<ExamAccommodation> approveAccommodations(final Exam exam, final Session session, final ApproveAccommodationsRequest request);
 
     /**
      * Denies all {@link tds.exam.ExamAccommodation}s for an exam
      *
-     * @param examId The id of the exam for which to deny accommodations
+     * @param examId   The id of the exam for which to deny accommodations
      * @param deniedAt
      */
     void denyAccommodations(final UUID examId, final Instant deniedAt);

--- a/service/src/main/java/tds/exam/services/ExamService.java
+++ b/service/src/main/java/tds/exam/services/ExamService.java
@@ -5,6 +5,7 @@ import java.util.UUID;
 
 import tds.common.Response;
 import tds.common.ValidationError;
+import tds.exam.ApproveAccommodationsRequest;
 import tds.exam.Exam;
 import tds.exam.ExamConfiguration;
 import tds.exam.ExamStatusCode;
@@ -35,7 +36,7 @@ public interface ExamService {
     /**
      * Starts a new or existing exam.
      *
-     * @param examId The exam to start
+     * @param examId           The exam to start
      * @param browserUserAgent The browser user agent string for the {@link tds.exam.Exam}
      * @return {@link tds.common.Response<tds.exam.Exam>} containing the exam's configuration or errors.
      */
@@ -72,10 +73,20 @@ public interface ExamService {
     /**
      * Performs exam access validation and updates the {@link Exam} status to wait for segment approval.
      *
-     * @param examId The id of the exam seeking segment approval
+     * @param examId  The id of the exam seeking segment approval
      * @param request A request object containing data related to the segment approval request
      * @return {@code Optional<ValidationError>} if the {@link tds.exam.Exam} cannot be updated from its current status
      * to the new status of if the approval request fails.
      */
     Optional<ValidationError> waitForSegmentApproval(UUID examId, SegmentApprovalRequest request);
+
+    /**
+     * Updates the exam accommodations defined in the given {@link tds.exam.ApproveAccommodationsRequest} request and
+     * also updated the Exam if custom accommodations are added or removed
+     *
+     * @param examId  The id of the exam with accommodations to approve
+     * @param request A {@link tds.exam.ApproveAccommodationsRequest} containing request data
+     * @return {@code Optional<ValidationError>}, if one occurs while processing the approval request
+     */
+    Optional<ValidationError> updateExamAccommodationsAndExam(UUID examId, ApproveAccommodationsRequest request);
 }

--- a/service/src/main/java/tds/exam/services/impl/ExamServiceImpl.java
+++ b/service/src/main/java/tds/exam/services/impl/ExamServiceImpl.java
@@ -310,7 +310,7 @@ class ExamServiceImpl implements ExamService {
         Exam exam = maybeExam.get();
 
         if (!request.isGuest()) {
-            /* line 11441 */
+            /* StudentDLL line 11441 */
             Optional<ValidationError> maybeError = examApprovalService.verifyAccess(new ExamInfo(examId, request.getSessionId(), request.getBrowserId()), exam);
 
             if (maybeError.isPresent()) {
@@ -318,7 +318,7 @@ class ExamServiceImpl implements ExamService {
             }
         }
 
-        /* lines 11465-11473 */
+        /* StudentDLL lines 11465-11473 */
         Optional<Session> maybeSession = sessionService.findSessionById(exam.getSessionId());
 
         if (!maybeSession.isPresent()) {

--- a/service/src/main/java/tds/exam/services/impl/ExamServiceImpl.java
+++ b/service/src/main/java/tds/exam/services/impl/ExamServiceImpl.java
@@ -27,6 +27,7 @@ import tds.common.entity.utils.ChangeListener;
 import tds.common.web.exceptions.NotFoundException;
 import tds.config.ClientSystemFlag;
 import tds.config.TimeLimitConfiguration;
+import tds.exam.ApproveAccommodationsRequest;
 import tds.exam.Exam;
 import tds.exam.ExamAccommodation;
 import tds.exam.ExamApproval;
@@ -273,7 +274,6 @@ class ExamServiceImpl implements ExamService {
         }
     }
 
-
     @Override
     public Optional<ValidationError> waitForSegmentApproval(final UUID examId, final SegmentApprovalRequest request) {
         Response<ExamApproval> approvalResponse = examApprovalService.getApproval(new ExamInfo(examId, request.getSessionId(), request.getBrowserId()));
@@ -294,6 +294,44 @@ class ExamServiceImpl implements ExamService {
         }
 
         return maybeError;
+    }
+
+    @Override
+    public Optional<ValidationError> updateExamAccommodationsAndExam(final UUID examId, final ApproveAccommodationsRequest request) {
+        /* This method is a port of StudentDLL.T_ApproveAccommodations_SP, starting at line 11429 */
+        Optional<Exam> maybeExam = examQueryRepository.getExamById(examId);
+
+        if (!maybeExam.isPresent()) {
+            return Optional.of(new ValidationError(
+                ExamStatusCode.STATUS_FAILED, String.format("No exam found for id %s", examId)
+            ));
+        }
+
+        Exam exam = maybeExam.get();
+
+        if (!request.isGuest()) {
+            /* line 11441 */
+            Optional<ValidationError> maybeError = examApprovalService.verifyAccess(new ExamInfo(examId, request.getSessionId(), request.getBrowserId()), exam);
+
+            if (maybeError.isPresent()) {
+                return maybeError;
+            }
+        }
+
+        /* lines 11465-11473 */
+        Optional<Session> maybeSession = sessionService.findSessionById(exam.getSessionId());
+
+        if (!maybeSession.isPresent()) {
+            return Optional.of(new ValidationError(ValidationErrorCode.EXAM_NOT_ENROLLED_IN_SESSION, "The test opportunity is not enrolled in this session"));
+        } else if (maybeSession.isPresent() && !maybeSession.get().isProctorless() && request.isGuest()) {
+            return Optional.of(new ValidationError(ValidationErrorCode.STUDENT_SELF_APPROVE_UNPROCTORED_SESSION, "Student can only self-approve unproctored sessions"));
+        }
+
+        List<ExamAccommodation> updatedAccommodations = examAccommodationService.approveAccommodations(exam, maybeSession.get(), request);
+        // Update the "custom" exam flag is a custom exam accommodation is approved
+        updateExamWithCustomAccommodations(exam, updatedAccommodations);
+
+        return Optional.empty();
     }
 
     @Transactional
@@ -708,14 +746,14 @@ class ExamServiceImpl implements ExamService {
     private Exam updateExamWithCustomAccommodations(final Exam exam,
                                                     final List<ExamAccommodation> examAccommodations) {
         //Pulled from CommonDLL lines 2669 - 2670.  If any of the exam accommodations are custom then we need to flag the exam
-        Optional<ExamAccommodation> maybeExamAccommodation = examAccommodations.stream()
+        Optional<ExamAccommodation> maybeCustomExamAccommodation = examAccommodations.stream()
             .filter(ExamAccommodation::isCustom)
             .findFirst();
 
-        if (maybeExamAccommodation.isPresent() != exam.isCustomAccommodations()) {
+        if (maybeCustomExamAccommodation.isPresent() != exam.isCustomAccommodations()) {
             Exam updatedExam = new Exam.Builder()
                 .fromExam(exam)
-                .withCustomAccommodation(maybeExamAccommodation.isPresent())
+                .withCustomAccommodation(maybeCustomExamAccommodation.isPresent())
                 .build();
 
             updateExam(exam, updatedExam);

--- a/service/src/main/java/tds/exam/web/endpoints/ExamAccommodationController.java
+++ b/service/src/main/java/tds/exam/web/endpoints/ExamAccommodationController.java
@@ -52,20 +52,4 @@ public class ExamAccommodationController {
     ResponseEntity<List<ExamAccommodation>> findApprovedAccommodations(@PathVariable final UUID examId) {
         return ResponseEntity.ok(examAccommodationService.findApprovedAccommodations(examId));
     }
-    
-    @RequestMapping(value = "/{examId}/accommodations", method = RequestMethod.POST, produces = MediaType.APPLICATION_JSON_VALUE)
-    ResponseEntity<NoContentResponseResource> approveAccommodations(@PathVariable final UUID examId, @RequestBody ApproveAccommodationsRequest request) {
-        Optional<ValidationError> maybeError = examAccommodationService.approveAccommodations(examId, request);
-        
-        if (maybeError.isPresent()) {
-            NoContentResponseResource response = new NoContentResponseResource(maybeError.get());
-            return new ResponseEntity<>(response, HttpStatus.UNPROCESSABLE_ENTITY);
-        }
-        
-        Link link = linkTo(methodOn(ExamAccommodationController.class).findAccommodations(examId)).withSelfRel();
-        final HttpHeaders headers = new HttpHeaders();
-        headers.add("Location", link.getHref());
-        
-        return new ResponseEntity<>(headers, HttpStatus.NO_CONTENT);
-    }
 }

--- a/service/src/main/java/tds/exam/web/endpoints/ExamController.java
+++ b/service/src/main/java/tds/exam/web/endpoints/ExamController.java
@@ -22,6 +22,7 @@ import tds.common.Response;
 import tds.common.ValidationError;
 import tds.common.web.exceptions.NotFoundException;
 import tds.common.web.resources.NoContentResponseResource;
+import tds.exam.ApproveAccommodationsRequest;
 import tds.exam.Exam;
 import tds.exam.ExamConfiguration;
 import tds.exam.ExamStatusCode;
@@ -136,6 +137,22 @@ public class ExamController {
         }
 
         Link link = linkTo(methodOn(ExamController.class).getExamById(examId)).withSelfRel();
+        final HttpHeaders headers = new HttpHeaders();
+        headers.add("Location", link.getHref());
+
+        return new ResponseEntity<>(headers, HttpStatus.NO_CONTENT);
+    }
+
+    @RequestMapping(value = "/{examId}/accommodations", method = RequestMethod.POST, produces = MediaType.APPLICATION_JSON_VALUE)
+    ResponseEntity<NoContentResponseResource> approveAccommodations(@PathVariable final UUID examId, @RequestBody ApproveAccommodationsRequest request) {
+        Optional<ValidationError> maybeError = examService.updateExamAccommodationsAndExam(examId, request);
+
+        if (maybeError.isPresent()) {
+            NoContentResponseResource response = new NoContentResponseResource(maybeError.get());
+            return new ResponseEntity<>(response, HttpStatus.UNPROCESSABLE_ENTITY);
+        }
+
+        Link link = linkTo(methodOn(ExamAccommodationController.class).findAccommodations(examId)).withSelfRel();
         final HttpHeaders headers = new HttpHeaders();
         headers.add("Location", link.getHref());
 

--- a/service/src/test/java/tds/exam/web/endpoints/ExamAccommodationControllerIntegrationTests.java
+++ b/service/src/test/java/tds/exam/web/endpoints/ExamAccommodationControllerIntegrationTests.java
@@ -110,63 +110,23 @@ public class ExamAccommodationControllerIntegrationTests {
         
         verify(mockExamAccommodationService).findAllAccommodations(examId);
     }
-    
-    @Test
-    public void shouldApproveAccommodationsAndReturnNoContentWithNoErrors() throws Exception {
-        final UUID examId = UUID.randomUUID();
-        final UUID sessionId = UUID.randomUUID();
-        final UUID browserId = UUID.randomUUID();
-        ApproveAccommodationsRequest request = new ApproveAccommodationsRequest(sessionId, browserId, new HashMap<>());
-        
-        when(mockExamAccommodationService.approveAccommodations(examId, request)).thenReturn(Optional.empty());
-        JSONObject requestJson = new JSONObject(request);
-        
-        http.perform(post(new URI(String.format("/exam/%s/accommodations", examId)))
-            .content(requestJson.toString())
-            .contentType(MediaType.APPLICATION_JSON))
-            .andExpect(status().isNoContent());
-        
-        verify(mockExamAccommodationService).approveAccommodations(examId, request);
-    }
-    
-    @Test
-    public void shouldReturnUnprocessableEntityWithError() throws Exception {
-        final UUID examId = UUID.randomUUID();
-        final UUID sessionId = UUID.randomUUID();
-        final UUID browserId = UUID.randomUUID();
-        final String errorCode = "ErrorCode";
-        final String errorMsg = "Error!";
-        ApproveAccommodationsRequest request = new ApproveAccommodationsRequest(sessionId, browserId, new HashMap<>());
-        
-        when(mockExamAccommodationService.approveAccommodations(examId, request)).thenReturn(Optional.of(new ValidationError(errorCode, errorMsg)));
-        JSONObject requestJson = new JSONObject(request);
-        
-        http.perform(post(new URI(String.format("/exam/%s/accommodations", examId)))
-            .content(requestJson.toString())
-            .contentType(MediaType.APPLICATION_JSON))
-            .andExpect(jsonPath("errors[0].code", is(errorCode)))
-            .andExpect(jsonPath("errors[0].message", is(errorMsg)))
-            .andExpect(status().isUnprocessableEntity());
-        
-        verify(mockExamAccommodationService).approveAccommodations(examId, request);
-    }
-    
+
     @Test
     public void shouldReturnApprovedExamAccommodations() throws Exception {
         UUID examId = UUID.randomUUID();
         ExamAccommodation examAccommodation = new ExamAccommodationBuilder()
             .withExamId(examId)
             .build();
-        
+
         when(mockExamAccommodationService.findApprovedAccommodations(examId)).thenReturn(Collections.singletonList(examAccommodation));
-        
+
         http.perform(get(new URI(String.format("/exam/%s/accommodations/approved", examId)))
             .contentType(MediaType.APPLICATION_JSON))
             .andExpect(status().isOk())
             .andExpect(jsonPath("$", hasSize(1)))
             .andExpect(jsonPath("[0].examId", is(examAccommodation.getExamId().toString())))
             .andExpect(jsonPath("[0].type", is(examAccommodation.getType())));
-        
+
         verify(mockExamAccommodationService).findApprovedAccommodations(examId);
     }
 }

--- a/service/src/test/java/tds/exam/web/endpoints/ExamAccommodationControllerTest.java
+++ b/service/src/test/java/tds/exam/web/endpoints/ExamAccommodationControllerTest.java
@@ -183,41 +183,4 @@ public class ExamAccommodationControllerTest {
         assertThat(response.getStatusCode()).isEqualTo(HttpStatus.OK);
         assertThat(response.getBody()).containsExactly(examAccommodation);
     }
-    
-    @Test
-    public void shouldApproveAccommodationsAndReturnNoErrors() {
-        final UUID examId = UUID.randomUUID();
-        final UUID sessionId = UUID.randomUUID();
-        final UUID browserId = UUID.randomUUID();
-        ApproveAccommodationsRequest request = new ApproveAccommodationsRequest(sessionId, browserId, new HashMap<>());
-        
-        when(mockExamAccommodationService.approveAccommodations(examId, request)).thenReturn(Optional.empty());
-        
-        ResponseEntity<NoContentResponseResource> response = controller.approveAccommodations(examId, request);
-        
-        verify(mockExamAccommodationService).approveAccommodations(examId, request);
-        verifyNoMoreInteractions(mockExamAccommodationService);
-        
-        assertThat(response.getStatusCode()).isEqualTo(HttpStatus.NO_CONTENT);
-    }
-    
-    @Test
-    public void shouldReturnValidationError() {
-        final UUID examId = UUID.randomUUID();
-        final UUID sessionId = UUID.randomUUID();
-        final UUID browserId = UUID.randomUUID();
-        final String errCode = "Error code";
-        final String errMsg = "Error message";
-        ApproveAccommodationsRequest request = new ApproveAccommodationsRequest(sessionId, browserId, new HashMap<>());
-        
-        when(mockExamAccommodationService.approveAccommodations(examId, request)).thenReturn(Optional.of(new ValidationError(errCode, errMsg)));
-        
-        ResponseEntity<NoContentResponseResource> response = controller.approveAccommodations(examId, request);
-        
-        verify(mockExamAccommodationService).approveAccommodations(examId, request);
-        verifyNoMoreInteractions(mockExamAccommodationService);
-        
-        assertThat(response.getStatusCode()).isEqualTo(HttpStatus.UNPROCESSABLE_ENTITY);
-        assertThat(response.getBody().getErrors()).isNotEmpty();
-    }
 }


### PR DESCRIPTION
…om accommodations

This PR is in regards to TDS-836. This bug is caused because the "custom_accommodations" flag is not being set on the Exam after exam_accommodation changes are approved (neither by the guest student changing them from default, or a proctor approving non-default accommodations). 

Unfortunately, it wasn't as simple as simply adding ExamService (which contains a method already to update the exam flag if a custom accommodation exists) dependency to ExamAccommodation. This would have caused a circular dependency. ExamServiceImpl is already fairly large and I was hoping to not have to add to it, but I think this is the cleanest solution as ExamServiceImpl is already dependent on many of the services that are utilized in the approval flow.  The benefit of this refactor is that ExamAccommodationService now has three less dependencies (including ExamQueryRepository). 