### PR TITLE
Updating ExamAccommodation approval code to use the browser key from …

### DIFF
--- a/service/src/main/java/tds/exam/services/impl/ExamServiceImpl.java
+++ b/service/src/main/java/tds/exam/services/impl/ExamServiceImpl.java
@@ -311,7 +311,7 @@ class ExamServiceImpl implements ExamService {
 
         if (!request.isGuest()) {
             /* StudentDLL line 11441 */
-            Optional<ValidationError> maybeError = examApprovalService.verifyAccess(new ExamInfo(examId, request.getSessionId(), request.getBrowserId()), exam);
+            Optional<ValidationError> maybeError = examApprovalService.verifyAccess(new ExamInfo(examId, request.getSessionId(), exam.getBrowserId()), exam);
 
             if (maybeError.isPresent()) {
                 return maybeError;


### PR DESCRIPTION
…the exam object - the browser key being sent across when proctor was approving a request was failing validation (Proctor browserKey is different than student browserKey)