### PR TITLE
Submit completed exams to a messaging channel for further processing/…

### DIFF
--- a/client/src/main/java/tds/exam/ExamTopics.java
+++ b/client/src/main/java/tds/exam/ExamTopics.java
@@ -1,0 +1,19 @@
+package tds.exam;
+
+/**
+ * This class holds AMQP topics used by the ExamService.
+ * Topic names are in the general for of "{application}.{scope}.{operation}"
+ */
+public class ExamTopics {
+
+    /**
+     * This is the topic exchange for all exam topics.
+     */
+    public static final String TOPIC_EXCHANGE = "tds.exam.exchange";
+
+    /**
+     * This topic is published to when an exam is completed.
+     * The message body is a String containing the exam id.
+     */
+    public static final String TOPIC_EXAM_COMPLETED = "exam.completed";
+}

--- a/service/src/main/java/tds/exam/configuration/messaging/ExamMessagingConfiguration.java
+++ b/service/src/main/java/tds/exam/configuration/messaging/ExamMessagingConfiguration.java
@@ -1,0 +1,35 @@
+package tds.exam.configuration.messaging;
+
+import org.springframework.amqp.core.TopicExchange;
+import org.springframework.amqp.rabbit.core.RabbitTemplate;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import tds.exam.utils.LoggingAmqpConfirmationCallback;
+
+import javax.annotation.PostConstruct;
+
+import static tds.exam.ExamTopics.TOPIC_EXCHANGE;
+
+/**
+ * This configuration is responsible for initializing AMQP (RabbitMQ)
+ */
+@Configuration
+public class ExamMessagingConfiguration {
+
+    @Autowired
+    private RabbitTemplate rabbitTemplate;
+
+    @Bean
+    public TopicExchange exchange() {
+        return new TopicExchange(TOPIC_EXCHANGE, true, false);
+    }
+
+    /**
+     * Add a logging confirmation callback that will log errors if an exam could not be submitted.
+     */
+    @PostConstruct
+    public void rabbitTemplate() {
+        rabbitTemplate.setConfirmCallback(new LoggingAmqpConfirmationCallback());
+    }
+}

--- a/service/src/main/java/tds/exam/services/MessagingService.java
+++ b/service/src/main/java/tds/exam/services/MessagingService.java
@@ -1,0 +1,14 @@
+package tds.exam.services;
+
+/**
+ * Implementations of this interface are responsible for publishing messages to the ecosystem messaging framework.
+ */
+public interface MessagingService {
+
+    /**
+     * Send an exam completion message to the transmission topic.
+     *
+     * @param examId The completed exam's id
+     */
+    void sendExamCompletion(final String examId);
+}

--- a/service/src/main/java/tds/exam/services/MessagingService.java
+++ b/service/src/main/java/tds/exam/services/MessagingService.java
@@ -1,5 +1,7 @@
 package tds.exam.services;
 
+import java.util.UUID;
+
 /**
  * Implementations of this interface are responsible for publishing messages to the ecosystem messaging framework.
  */
@@ -10,5 +12,5 @@ public interface MessagingService {
      *
      * @param examId The completed exam's id
      */
-    void sendExamCompletion(final String examId);
+    void sendExamCompletion(final UUID examId);
 }

--- a/service/src/main/java/tds/exam/services/impl/MessagingServiceImpl.java
+++ b/service/src/main/java/tds/exam/services/impl/MessagingServiceImpl.java
@@ -1,0 +1,30 @@
+package tds.exam.services.impl;
+
+import org.springframework.amqp.rabbit.core.RabbitTemplate;
+import org.springframework.amqp.rabbit.support.CorrelationData;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.stereotype.Service;
+import tds.exam.services.MessagingService;
+
+import static tds.exam.ExamTopics.TOPIC_EXAM_COMPLETED;
+import static tds.exam.ExamTopics.TOPIC_EXCHANGE;
+
+/**
+ * Default implementation of a MessagingService using a RabbitTemplate.
+ */
+@Service
+public class MessagingServiceImpl implements MessagingService {
+
+    private final RabbitTemplate rabbitTemplate;
+
+    @Autowired
+    public MessagingServiceImpl(final RabbitTemplate rabbitTemplate) {
+        this.rabbitTemplate = rabbitTemplate;
+    }
+
+    @Override
+    public void sendExamCompletion(final String examId) {
+        final CorrelationData correlationData = new CorrelationData("exam.completion-" + examId);
+        this.rabbitTemplate.convertAndSend(TOPIC_EXCHANGE, TOPIC_EXAM_COMPLETED, examId, correlationData);
+    }
+}

--- a/service/src/main/java/tds/exam/services/impl/MessagingServiceImpl.java
+++ b/service/src/main/java/tds/exam/services/impl/MessagingServiceImpl.java
@@ -1,10 +1,14 @@
 package tds.exam.services.impl;
 
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 import org.springframework.amqp.rabbit.core.RabbitTemplate;
 import org.springframework.amqp.rabbit.support.CorrelationData;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Service;
 import tds.exam.services.MessagingService;
+
+import java.util.UUID;
 
 import static tds.exam.ExamTopics.TOPIC_EXAM_COMPLETED;
 import static tds.exam.ExamTopics.TOPIC_EXCHANGE;
@@ -14,6 +18,7 @@ import static tds.exam.ExamTopics.TOPIC_EXCHANGE;
  */
 @Service
 public class MessagingServiceImpl implements MessagingService {
+    private final static Logger LOG = LoggerFactory.getLogger(MessagingServiceImpl.class);
 
     private final RabbitTemplate rabbitTemplate;
 
@@ -23,8 +28,9 @@ public class MessagingServiceImpl implements MessagingService {
     }
 
     @Override
-    public void sendExamCompletion(final String examId) {
-        final CorrelationData correlationData = new CorrelationData("exam.completion-" + examId);
-        this.rabbitTemplate.convertAndSend(TOPIC_EXCHANGE, TOPIC_EXAM_COMPLETED, examId, correlationData);
+    public void sendExamCompletion(final UUID examId) {
+        final String stringId = examId.toString();
+        final CorrelationData correlationData = new CorrelationData("exam.completion-" + stringId);
+        this.rabbitTemplate.convertAndSend(TOPIC_EXCHANGE, TOPIC_EXAM_COMPLETED, stringId, correlationData);
     }
 }

--- a/service/src/main/java/tds/exam/utils/LoggingAmqpConfirmationCallback.java
+++ b/service/src/main/java/tds/exam/utils/LoggingAmqpConfirmationCallback.java
@@ -1,0 +1,25 @@
+package tds.exam.utils;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.amqp.rabbit.core.RabbitTemplate;
+import org.springframework.amqp.rabbit.support.CorrelationData;
+
+/**
+ * This confirmation callback is responsible for logging all unacknowledged
+ * RabbitTemplate message submissions.
+ */
+public class LoggingAmqpConfirmationCallback implements RabbitTemplate.ConfirmCallback {
+    private final static Logger LOG = LoggerFactory.getLogger(LoggingAmqpConfirmationCallback.class);
+
+    @Override
+    public void confirm(final CorrelationData correlationData,
+                        final boolean ack,
+                        final String cause) {
+        if (ack) {
+            LOG.debug("Message acknowledged as sent: {}", correlationData);
+        } else {
+            LOG.error("Message not acknowledged as sent: {} cause: {}", correlationData, cause);
+        }
+    }
+}

--- a/service/src/main/java/tds/exam/utils/listeners/OnCompletedStatusExamChangeListener.java
+++ b/service/src/main/java/tds/exam/utils/listeners/OnCompletedStatusExamChangeListener.java
@@ -79,7 +79,7 @@ public class OnCompletedStatusExamChangeListener implements ChangeListener<Exam>
 
         // Publish the submitted exam to the Messaging backend, allowing other services to continue processing it.
         // Submit for scoring (CommonDLL#_OnStatus_Completed_SP, line 1433 - 1434), which changes the exam's status to "submitted"
-        messagingService.sendExamCompletion(newExam.getId().toString());
+        messagingService.sendExamCompletion(newExam.getId());
 
         // CommonDLL#_OnStatus_Completed_SP, lines 1445 - 1453: Find all the field test items that were administered
         // during an exam and record their usage.

--- a/service/src/main/java/tds/exam/utils/listeners/OnCompletedStatusExamChangeListener.java
+++ b/service/src/main/java/tds/exam/utils/listeners/OnCompletedStatusExamChangeListener.java
@@ -77,17 +77,15 @@ public class OnCompletedStatusExamChangeListener implements ChangeListener<Exam>
         // tables/queries that are referenced in that method are only used by the loader stored procedures, schema
         // creation/modification scripts and/or SimDLL.java (which is related to the simulator).
 
-        // Publish the submitted exam to the Messaging backend, allowing other services to continue processing it.
-        // Submit for scoring (CommonDLL#_OnStatus_Completed_SP, line 1433 - 1434), which changes the exam's status to "submitted"
-        messagingService.sendExamCompletion(newExam.getId());
-
         // CommonDLL#_OnStatus_Completed_SP, lines 1445 - 1453: Find all the field test items that were administered
         // during an exam and record their usage.
         final List<FieldTestItemGroup> fieldTestItemGroupsToUpdate = fieldTestService.findUsageInExam(newExam.getId());
-        if (fieldTestItemGroupsToUpdate.isEmpty()) {
-            return;
+        if (!fieldTestItemGroupsToUpdate.isEmpty()) {
+            fieldTestService.update(fieldTestItemGroupsToUpdate.toArray(new FieldTestItemGroup[fieldTestItemGroupsToUpdate.size()]));
         }
 
-        fieldTestService.update(fieldTestItemGroupsToUpdate.toArray(new FieldTestItemGroup[fieldTestItemGroupsToUpdate.size()]));
+        // Publish the submitted exam to the Messaging backend, allowing other services to continue processing it.
+        // Submit for scoring (CommonDLL#_OnStatus_Completed_SP, line 1433 - 1434), which changes the exam's status to "submitted"
+        messagingService.sendExamCompletion(newExam.getId());
     }
 }

--- a/service/src/main/resources/application.yml
+++ b/service/src/main/resources/application.yml
@@ -20,6 +20,10 @@ spring:
 #Port defined in TDS_Build:docker-compose.yml
   rabbitmq:
     port: 32846
+    publisher-confirms: true
+    template:
+      retry:
+        enabled: true
 
 management:
   health:

--- a/service/src/test/java/tds/exam/services/impl/MessagingServiceImplTest.java
+++ b/service/src/test/java/tds/exam/services/impl/MessagingServiceImplTest.java
@@ -9,6 +9,8 @@ import org.mockito.runners.MockitoJUnitRunner;
 import org.springframework.amqp.rabbit.core.RabbitTemplate;
 import org.springframework.amqp.rabbit.support.CorrelationData;
 
+import java.util.UUID;
+
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.Matchers.eq;
 import static org.mockito.Mockito.verify;
@@ -19,23 +21,23 @@ import static tds.exam.ExamTopics.TOPIC_EXCHANGE;
 public class MessagingServiceImplTest {
 
     @Mock
-    private RabbitTemplate rabbitTemplate;
+    private RabbitTemplate mockRabbitTemplate;
 
     private MessagingServiceImpl messagingService;
 
     @Before
     public void setup() {
-        messagingService = new MessagingServiceImpl(rabbitTemplate);
+        messagingService = new MessagingServiceImpl(mockRabbitTemplate);
     }
 
     @Test
     public void itShouldSubmitACompletedExamToTheExpectedTopic() {
-        final String examId = "examId";
+        final UUID examId = UUID.randomUUID();
         messagingService.sendExamCompletion(examId);
 
         final ArgumentCaptor<CorrelationData> correlationDataCaptor = ArgumentCaptor.forClass(CorrelationData.class);
-        verify(rabbitTemplate).convertAndSend(eq(TOPIC_EXCHANGE), eq(TOPIC_EXAM_COMPLETED), eq(examId), correlationDataCaptor.capture());
-        assertThat(correlationDataCaptor.getValue().getId()).isEqualTo("exam.completion-" + examId);
+        verify(mockRabbitTemplate).convertAndSend(eq(TOPIC_EXCHANGE), eq(TOPIC_EXAM_COMPLETED), eq(examId.toString()), correlationDataCaptor.capture());
+        assertThat(correlationDataCaptor.getValue().getId()).isEqualTo("exam.completion-" + examId.toString());
     }
 
 }

--- a/service/src/test/java/tds/exam/services/impl/MessagingServiceImplTest.java
+++ b/service/src/test/java/tds/exam/services/impl/MessagingServiceImplTest.java
@@ -1,0 +1,41 @@
+package tds.exam.services.impl;
+
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.ArgumentCaptor;
+import org.mockito.Mock;
+import org.mockito.runners.MockitoJUnitRunner;
+import org.springframework.amqp.rabbit.core.RabbitTemplate;
+import org.springframework.amqp.rabbit.support.CorrelationData;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Matchers.eq;
+import static org.mockito.Mockito.verify;
+import static tds.exam.ExamTopics.TOPIC_EXAM_COMPLETED;
+import static tds.exam.ExamTopics.TOPIC_EXCHANGE;
+
+@RunWith(MockitoJUnitRunner.class)
+public class MessagingServiceImplTest {
+
+    @Mock
+    private RabbitTemplate rabbitTemplate;
+
+    private MessagingServiceImpl messagingService;
+
+    @Before
+    public void setup() {
+        messagingService = new MessagingServiceImpl(rabbitTemplate);
+    }
+
+    @Test
+    public void itShouldSubmitACompletedExamToTheExpectedTopic() {
+        final String examId = "examId";
+        messagingService.sendExamCompletion(examId);
+
+        final ArgumentCaptor<CorrelationData> correlationDataCaptor = ArgumentCaptor.forClass(CorrelationData.class);
+        verify(rabbitTemplate).convertAndSend(eq(TOPIC_EXCHANGE), eq(TOPIC_EXAM_COMPLETED), eq(examId), correlationDataCaptor.capture());
+        assertThat(correlationDataCaptor.getValue().getId()).isEqualTo("exam.completion-" + examId);
+    }
+
+}

--- a/service/src/test/java/tds/exam/utils/listeners/OnCompletedStatusExamChangeListenerTest.java
+++ b/service/src/test/java/tds/exam/utils/listeners/OnCompletedStatusExamChangeListenerTest.java
@@ -8,14 +8,6 @@ import org.mockito.ArgumentCaptor;
 import org.mockito.Captor;
 import org.mockito.Mock;
 import org.mockito.runners.MockitoJUnitRunner;
-
-import java.time.temporal.ChronoUnit;
-import java.util.ArrayList;
-import java.util.Arrays;
-import java.util.Collections;
-import java.util.List;
-import java.util.UUID;
-
 import tds.common.entity.utils.ChangeListener;
 import tds.exam.Exam;
 import tds.exam.ExamSegment;
@@ -27,9 +19,19 @@ import tds.exam.models.FieldTestItemGroup;
 import tds.exam.services.ExamSegmentService;
 import tds.exam.services.ExamineeService;
 import tds.exam.services.FieldTestService;
+import tds.exam.services.MessagingService;
 
+import java.time.temporal.ChronoUnit;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.List;
+import java.util.UUID;
+
+import static java.util.Collections.singletonList;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.Matchers.any;
+import static org.mockito.Matchers.eq;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.verifyZeroInteractions;
 import static org.mockito.Mockito.when;
@@ -45,6 +47,9 @@ public class OnCompletedStatusExamChangeListenerTest {
     @Mock
     private ExamineeService mockExamineeService;
 
+    @Mock
+    private MessagingService messagingService;
+
     @Captor
     private ArgumentCaptor<ExamSegment> examSegmentsArgumentCaptor;
 
@@ -54,31 +59,32 @@ public class OnCompletedStatusExamChangeListenerTest {
     public void setUp() {
         onCompletedExamStatusChangeListener = new OnCompletedStatusExamChangeListener(mockExamSegmentService,
             mockFieldTestService,
-            mockExamineeService);
+            mockExamineeService,
+            messagingService);
     }
 
     @Test
     public void shouldUpdateFieldTestItemGroupsWhenAnExamIsSetToCompleted() {
-        Exam oldExam = new ExamBuilder().build();
-        Exam newExam = new ExamBuilder()
+        final Exam oldExam = new ExamBuilder().build();
+        final Exam newExam = new ExamBuilder()
             .withStatus(new ExamStatusCode(ExamStatusCode.STATUS_COMPLETED, ExamStatusStage.IN_PROGRESS), Instant.now())
             .build();
-        ExamSegment mockSegment = new ExamSegmentBuilder()
+        final ExamSegment mockSegment = new ExamSegmentBuilder()
             .withExamId(newExam.getId())
             .withIsPermeable(true)
             .withSegmentId("segment1")
             .build();
-        ExamSegment mockSegment2 = new ExamSegmentBuilder()
+        final ExamSegment mockSegment2 = new ExamSegmentBuilder()
             .withExamId(newExam.getId())
             .withIsPermeable(false)
             .withSegmentId("segment2")
             .build();
-        ExamSegment mockSegment3 = new ExamSegmentBuilder()
+        final ExamSegment mockSegment3 = new ExamSegmentBuilder()
             .withExamId(newExam.getId())
             .withIsPermeable(true)
             .withSegmentId("segment3")
             .build();
-        FieldTestItemGroup mockFirstFtItemGroup = new FieldTestItemGroup.Builder()
+        final FieldTestItemGroup mockFirstFtItemGroup = new FieldTestItemGroup.Builder()
             .withExamId(newExam.getId())
             .withGroupId("item-group-id")
             .withGroupKey("item-group-key")
@@ -92,7 +98,7 @@ public class OnCompletedStatusExamChangeListenerTest {
             .withItemCount(1)
             .withSessionId(UUID.randomUUID())
             .build();
-        FieldTestItemGroup mockSecondFtItemGroup = new FieldTestItemGroup.Builder()
+        final FieldTestItemGroup mockSecondFtItemGroup = new FieldTestItemGroup.Builder()
             .withExamId(newExam.getId())
             .withGroupId("item-group-id-2")
             .withGroupKey("item-group-key-2")
@@ -117,7 +123,7 @@ public class OnCompletedStatusExamChangeListenerTest {
         verify(mockFieldTestService).findUsageInExam(newExam.getId());
         verify(mockExamSegmentService).update(examSegmentsArgumentCaptor.capture());
 
-        List<ExamSegment> examSegments = examSegmentsArgumentCaptor.getAllValues();
+        final List<ExamSegment> examSegments = examSegmentsArgumentCaptor.getAllValues();
 
         //ExamSegment[] examSegments = examSegmentsArgumentCaptor.getValue();
         assertThat(examSegments).hasSize(2);
@@ -129,16 +135,16 @@ public class OnCompletedStatusExamChangeListenerTest {
 
     @Test
     public void shouldNotUpdateFieldTestItemGroupsIfNoneAreAdministeredInThisExam() {
-        Exam oldExam = new ExamBuilder().build();
-        Exam newExam = new ExamBuilder()
+        final Exam oldExam = new ExamBuilder().build();
+        final Exam newExam = new ExamBuilder()
             .withStatus(new ExamStatusCode(ExamStatusCode.STATUS_COMPLETED, ExamStatusStage.IN_PROGRESS), Instant.now())
             .build();
-        ExamSegment mockSegment = new ExamSegmentBuilder()
+        final ExamSegment mockSegment = new ExamSegmentBuilder()
             .withExamId(newExam.getId())
             .build();
 
         when(mockExamSegmentService.findExamSegments(newExam.getId()))
-            .thenReturn(Arrays.asList(mockSegment));
+            .thenReturn(singletonList(mockSegment));
         when(mockFieldTestService.findUsageInExam(newExam.getId()))
             .thenReturn(Collections.emptyList());
 
@@ -149,8 +155,8 @@ public class OnCompletedStatusExamChangeListenerTest {
 
     @Test
     public void shouldDoNothingWhenOldExamAndNewExamHaveTheSameStatus() {
-        Exam oldExam = new ExamBuilder().build();
-        Exam newExam = new ExamBuilder().build();
+        final Exam oldExam = new ExamBuilder().build();
+        final Exam newExam = new ExamBuilder().build();
 
         onCompletedExamStatusChangeListener.accept(oldExam, newExam);
         verifyZeroInteractions(mockExamSegmentService);
@@ -160,10 +166,10 @@ public class OnCompletedStatusExamChangeListenerTest {
 
     @Test
     public void shouldDoNothingWhenNewExamStatusIsNotSetToCompleted() {
-        Exam oldExam = new ExamBuilder()
+        final Exam oldExam = new ExamBuilder()
             .withStatus(new ExamStatusCode(ExamStatusCode.STATUS_APPROVED, ExamStatusStage.OPEN), Instant.now())
             .build();
-        Exam newExam = new ExamBuilder()
+        final Exam newExam = new ExamBuilder()
             .withStatus(new ExamStatusCode(ExamStatusCode.STATUS_STARTED, ExamStatusStage.IN_PROGRESS), Instant.now())
             .build();
 
@@ -175,8 +181,8 @@ public class OnCompletedStatusExamChangeListenerTest {
 
     @Test
     public void shouldSucceedWhenExamSegmentsCannotBeFound() {
-        Exam oldExam = new ExamBuilder().build();
-        Exam newExam = new ExamBuilder()
+        final Exam oldExam = new ExamBuilder().build();
+        final Exam newExam = new ExamBuilder()
             .withStatus(new ExamStatusCode(ExamStatusCode.STATUS_COMPLETED, ExamStatusStage.IN_PROGRESS), Instant.now())
             .build();
 
@@ -185,5 +191,17 @@ public class OnCompletedStatusExamChangeListenerTest {
 
         onCompletedExamStatusChangeListener.accept(oldExam, newExam);
         verify(mockExamSegmentService).findExamSegments(any(UUID.class));
+    }
+
+    @Test
+    public void shouldSubmitACompletedExamToTheMessagingService() {
+        final Exam oldExam = new ExamBuilder().withId(UUID.randomUUID()).build();
+        final Exam newExam = new ExamBuilder()
+            .withId(oldExam.getId())
+            .withStatus(new ExamStatusCode(ExamStatusCode.STATUS_COMPLETED, ExamStatusStage.IN_PROGRESS), Instant.now())
+            .build();
+
+        onCompletedExamStatusChangeListener.accept(oldExam, newExam);
+        verify(messagingService).sendExamCompletion(eq(oldExam.getId().toString()));
     }
 }

--- a/service/src/test/java/tds/exam/utils/listeners/OnCompletedStatusExamChangeListenerTest.java
+++ b/service/src/test/java/tds/exam/utils/listeners/OnCompletedStatusExamChangeListenerTest.java
@@ -48,7 +48,7 @@ public class OnCompletedStatusExamChangeListenerTest {
     private ExamineeService mockExamineeService;
 
     @Mock
-    private MessagingService messagingService;
+    private MessagingService mockMessagingService;
 
     @Captor
     private ArgumentCaptor<ExamSegment> examSegmentsArgumentCaptor;
@@ -60,7 +60,7 @@ public class OnCompletedStatusExamChangeListenerTest {
         onCompletedExamStatusChangeListener = new OnCompletedStatusExamChangeListener(mockExamSegmentService,
             mockFieldTestService,
             mockExamineeService,
-            messagingService);
+            mockMessagingService);
     }
 
     @Test
@@ -202,6 +202,6 @@ public class OnCompletedStatusExamChangeListenerTest {
             .build();
 
         onCompletedExamStatusChangeListener.accept(oldExam, newExam);
-        verify(messagingService).sendExamCompletion(eq(oldExam.getId().toString()));
+        verify(mockMessagingService).sendExamCompletion(eq(oldExam.getId()));
     }
 }


### PR DESCRIPTION
…reporting.

This PR includes a logging submission acknowledgement handler.  If an exam cannot be submitted, the failure will be logged using the standard SLF4J logging framework.
@mtrupkin @trapnine How do we get the logs into the long-term logging framework?  Because if an exam cannot be submitted, it requires action to re-submit it.