### PR TITLE
Support a SATISFIED response when requesting the next ItemGroup.

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -33,7 +33,7 @@
         <tds-student-client.version>0.0.2</tds-student-client.version>
         <tds-config-client.version>0.0.2</tds-config-client.version>
         <tds-student-library.version>3.0.5</tds-student-library.version>
-        <tds-item-selection.version>3.0.1</tds-item-selection.version>
+        <tds-item-selection.version>3.0.2</tds-item-selection.version>
 
         <maven.compiler.plugin.version>3.5.1</maven.compiler.plugin.version>
         <maven.release.plugin.version>2.5.3</maven.release.plugin.version>

--- a/service/src/main/java/tds/exam/services/impl/ExamItemSelectionServiceImpl.java
+++ b/service/src/main/java/tds/exam/services/impl/ExamItemSelectionServiceImpl.java
@@ -3,16 +3,6 @@ package tds.exam.services.impl;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
-
-import java.text.SimpleDateFormat;
-import java.time.Instant;
-import java.util.ArrayList;
-import java.util.Date;
-import java.util.List;
-import java.util.Map;
-import java.util.UUID;
-import java.util.stream.Collectors;
-
 import tds.assessment.Assessment;
 import tds.assessment.Item;
 import tds.assessment.Segment;
@@ -29,6 +19,18 @@ import tds.itemselection.base.TestItem;
 import tds.itemselection.model.ItemResponse;
 import tds.itemselection.services.ItemSelectionService;
 import tds.student.sql.data.OpportunityItem;
+
+import java.text.SimpleDateFormat;
+import java.time.Instant;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.Date;
+import java.util.List;
+import java.util.Map;
+import java.util.UUID;
+import java.util.stream.Collectors;
+
+import static tds.itemselection.model.ItemResponse.Status.SATISFIED;
 
 @Service
 public class ExamItemSelectionServiceImpl implements ExamItemSelectionService {
@@ -61,7 +63,9 @@ public class ExamItemSelectionServiceImpl implements ExamItemSelectionService {
 
         ItemResponse<ItemGroup> response = itemSelectionService.getNextItemGroup(exam.getId(), assessment.isMultiStageBraille());
 
-        if (response.getErrorMessage().isPresent()) {
+        if (response.getResponseStatus() == SATISFIED) {
+            return Collections.emptyList();
+        } else if (response.getErrorMessage().isPresent()) {
             throw new RuntimeException("Failed to create item group: " + response.getErrorMessage());
         } else if (!response.getResponseData().isPresent()) {
             throw new IllegalStateException("No error nor item information was returned from selection.  Please check configuration");

--- a/service/src/main/java/tds/exam/services/item/selection/ItemCandidateServiceImpl.java
+++ b/service/src/main/java/tds/exam/services/item/selection/ItemCandidateServiceImpl.java
@@ -4,17 +4,6 @@ import TDS.Shared.Exceptions.ReturnStatusException;
 import org.apache.commons.lang.StringUtils;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Service;
-
-import java.util.ArrayList;
-import java.util.Collections;
-import java.util.HashSet;
-import java.util.List;
-import java.util.Map;
-import java.util.Optional;
-import java.util.Set;
-import java.util.UUID;
-import java.util.stream.Collectors;
-
 import tds.assessment.Assessment;
 import tds.assessment.Form;
 import tds.assessment.Segment;
@@ -40,6 +29,16 @@ import tds.itemselection.impl.ItemResponse;
 import tds.itemselection.loader.StudentHistory2013;
 import tds.itemselection.model.OffGradeResponse;
 import tds.itemselection.services.ItemCandidatesService;
+
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+import java.util.Set;
+import java.util.UUID;
+import java.util.stream.Collectors;
 
 @Service
 public class ItemCandidateServiceImpl implements ItemCandidatesService {
@@ -90,10 +89,6 @@ public class ItemCandidateServiceImpl implements ItemCandidatesService {
             .filter(fieldTestItemGroup -> !fieldTestItemGroup.isDeleted() && fieldTestItemGroup.getAdministeredAt() == null)
             .collect(Collectors.groupingBy(FieldTestItemGroup::getSegmentKey));
 
-        if (unsatisfiedSegments.isEmpty()) {
-            return Collections.singletonList(new ItemCandidatesData(examId, IItemSelectionDLL.SATISFIED));
-        }
-
         List<ExamSegment> satisfiedSegments = new ArrayList<>();
         List<ExamSegmentWrapper> nonSatisfiedSegments = new ArrayList<>();
         for (ExamSegmentWrapper examSegmentWrapper : unsatisfiedSegments) {
@@ -124,6 +119,10 @@ public class ItemCandidateServiceImpl implements ItemCandidatesService {
         //Means that a segment has been satisfied but hasn't been updated to be satisfied
         if (!satisfiedSegments.isEmpty()) {
             updateSatisfiedSegments(satisfiedSegments);
+        }
+
+        if (nonSatisfiedSegments.isEmpty()) {
+            return Collections.singletonList(new ItemCandidatesData(examId, IItemSelectionDLL.SATISFIED));
         }
 
         return nonSatisfiedSegments.stream()

--- a/service/src/test/java/tds/exam/services/impl/ExamItemSelectionServiceImplTest.java
+++ b/service/src/test/java/tds/exam/services/impl/ExamItemSelectionServiceImplTest.java
@@ -7,12 +7,6 @@ import org.junit.runner.RunWith;
 import org.mockito.ArgumentCaptor;
 import org.mockito.Mock;
 import org.mockito.runners.MockitoJUnitRunner;
-
-import java.util.Collections;
-import java.util.List;
-import java.util.Optional;
-import java.util.UUID;
-
 import tds.assessment.Assessment;
 import tds.assessment.Item;
 import tds.assessment.Segment;
@@ -34,9 +28,15 @@ import tds.itemselection.model.ItemResponse;
 import tds.itemselection.services.ItemSelectionService;
 import tds.student.sql.data.OpportunityItem;
 
+import java.util.Collections;
+import java.util.List;
+import java.util.Optional;
+import java.util.UUID;
+
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
+import static tds.itemselection.model.ItemResponse.Status.SATISFIED;
 
 @RunWith(MockitoJUnitRunner.class)
 public class ExamItemSelectionServiceImplTest {
@@ -228,5 +228,19 @@ public class ExamItemSelectionServiceImplTest {
         when(mockAssessmentService.findAssessment(exam.getClientName(), exam.getAssessmentKey())).thenReturn(Optional.of(assessment));
         when(mockItemSelectionService.getNextItemGroup(examId, false)).thenReturn(new ItemResponse<>(itemGroup));
         examItemSelectionService.createNextPageGroup(examId, 1, 2);
+    }
+
+    @Test
+    public void itShouldReturnAnEmptyListIfExamIsSatisfied() {
+        final UUID examId = UUID.randomUUID();
+        final Exam exam = new ExamBuilder().withId(examId).build();
+
+        final Assessment assessment = new AssessmentBuilder()
+            .build();
+
+        when(mockExamService.findExam(examId)).thenReturn(Optional.of(exam));
+        when(mockAssessmentService.findAssessment(exam.getClientName(), exam.getAssessmentKey())).thenReturn(Optional.of(assessment));
+        when(mockItemSelectionService.getNextItemGroup(examId, false)).thenReturn(new ItemResponse<>(SATISFIED));
+        assertThat(examItemSelectionService.createNextPageGroup(examId, 1, 2)).isEmpty();
     }
 }


### PR DESCRIPTION
This PR adds the ability to accept a SATISFIED response from ItemSelectionService#getNextItemGroup.
A SATISFIED response indicates that the exam has been completed, and there IS no next item group to retrieve.