### PR TITLE
Add file based repositories for items and scoring files

### DIFF
--- a/service/src/main/java/tds/exam/repositories/impl/FilePathItemDataRepository.java
+++ b/service/src/main/java/tds/exam/repositories/impl/FilePathItemDataRepository.java
@@ -1,0 +1,17 @@
+package tds.exam.repositories.impl;
+
+import org.apache.commons.io.IOUtils;
+import org.springframework.stereotype.Repository;
+
+import java.io.FileInputStream;
+import java.io.IOException;
+
+import tds.score.repositories.ItemDataRepository;
+
+@Repository
+public class FilePathItemDataRepository implements ItemDataRepository {
+    @Override
+    public String findOne(final String itemPath) throws IOException {
+        return IOUtils.toString(new FileInputStream(itemPath));
+    }
+}

--- a/service/src/main/java/tds/exam/repositories/impl/FilePathRendererSpecRepository.java
+++ b/service/src/main/java/tds/exam/repositories/impl/FilePathRendererSpecRepository.java
@@ -1,0 +1,17 @@
+package tds.exam.repositories.impl;
+
+import org.apache.commons.io.IOUtils;
+import org.springframework.stereotype.Repository;
+
+import java.io.FileInputStream;
+import java.io.IOException;
+
+import tds.score.repositories.RendererSpecRepository;
+
+@Repository
+public class FilePathRendererSpecRepository implements RendererSpecRepository {
+    @Override
+    public String findOne(final String rendererSpecPath) throws IOException {
+        return IOUtils.toString(new FileInputStream(rendererSpecPath));
+    }
+}

--- a/service/src/main/java/tds/exam/repositories/impl/FilePathRubricRepository.java
+++ b/service/src/main/java/tds/exam/repositories/impl/FilePathRubricRepository.java
@@ -1,0 +1,17 @@
+package tds.exam.repositories.impl;
+
+import org.apache.commons.io.IOUtils;
+import org.springframework.stereotype.Repository;
+
+import java.io.FileInputStream;
+import java.io.IOException;
+
+import tds.score.repositories.RubricRepository;
+
+@Repository
+public class FilePathRubricRepository implements RubricRepository {
+    @Override
+    public String findOne(final String rubricPath) throws IOException {
+        return IOUtils.toString(new FileInputStream(rubricPath));
+    }
+}

--- a/service/src/main/java/tds/exam/repositories/impl/S3ItemDataRepository.java
+++ b/service/src/main/java/tds/exam/repositories/impl/S3ItemDataRepository.java
@@ -5,11 +5,13 @@ import com.amazonaws.services.s3.model.AmazonS3Exception;
 import com.amazonaws.services.s3.model.GetObjectRequest;
 import com.amazonaws.services.s3.model.S3Object;
 import org.apache.commons.io.IOUtils;
+import org.springframework.context.annotation.Primary;
 import org.springframework.stereotype.Repository;
-import tds.exam.configuration.scoring.ScoringS3Properties;
-import tds.score.repositories.ItemDataRepository;
 
 import java.io.IOException;
+
+import tds.exam.configuration.scoring.ScoringS3Properties;
+import tds.score.repositories.ItemDataRepository;
 
 import static org.apache.commons.io.Charsets.UTF_8;
 import static org.apache.commons.io.FilenameUtils.getName;
@@ -17,6 +19,7 @@ import static org.apache.commons.io.FilenameUtils.removeExtension;
 import static org.apache.commons.lang3.StringUtils.capitalize;
 
 @Repository
+@Primary
 public class S3ItemDataRepository implements ItemDataRepository {
     private final AmazonS3 s3Client;
     private final ScoringS3Properties s3Properties;

--- a/service/src/main/java/tds/exam/repositories/impl/S3RendererSpecRepository.java
+++ b/service/src/main/java/tds/exam/repositories/impl/S3RendererSpecRepository.java
@@ -5,11 +5,13 @@ import com.amazonaws.services.s3.model.AmazonS3Exception;
 import com.amazonaws.services.s3.model.GetObjectRequest;
 import com.amazonaws.services.s3.model.S3Object;
 import org.apache.commons.io.IOUtils;
+import org.springframework.context.annotation.Primary;
 import org.springframework.stereotype.Repository;
-import tds.exam.configuration.scoring.ScoringS3Properties;
-import tds.score.repositories.RendererSpecRepository;
 
 import java.io.IOException;
+
+import tds.exam.configuration.scoring.ScoringS3Properties;
+import tds.score.repositories.RendererSpecRepository;
 
 import static net.logstash.logback.encoder.org.apache.commons.lang.ArrayUtils.subarray;
 import static org.apache.commons.lang3.StringUtils.join;
@@ -18,6 +20,7 @@ import static org.apache.commons.lang3.StringUtils.join;
  * This implementation of a RendererSpecRepository reads information on S3.
  */
 @Repository
+@Primary
 public class S3RendererSpecRepository implements RendererSpecRepository {
 
     private final AmazonS3 s3Client;

--- a/service/src/main/java/tds/exam/repositories/impl/S3RubricRepository.java
+++ b/service/src/main/java/tds/exam/repositories/impl/S3RubricRepository.java
@@ -5,11 +5,13 @@ import com.amazonaws.services.s3.model.AmazonS3Exception;
 import com.amazonaws.services.s3.model.GetObjectRequest;
 import com.amazonaws.services.s3.model.S3Object;
 import org.apache.commons.io.IOUtils;
+import org.springframework.context.annotation.Primary;
 import org.springframework.stereotype.Repository;
-import tds.exam.configuration.scoring.ScoringS3Properties;
-import tds.score.repositories.RubricRepository;
 
 import java.io.IOException;
+
+import tds.exam.configuration.scoring.ScoringS3Properties;
+import tds.score.repositories.RubricRepository;
 
 import static net.logstash.logback.encoder.org.apache.commons.lang.ArrayUtils.subarray;
 import static org.apache.commons.lang3.StringUtils.join;
@@ -18,6 +20,7 @@ import static org.apache.commons.lang3.StringUtils.join;
  * This RubricRepository implementation serves rubric content from S3.
  */
 @Repository
+@Primary
 public class S3RubricRepository implements RubricRepository {
 
     private final AmazonS3 s3Client;


### PR DESCRIPTION
This is a work around while we fix the issue with S3.  The file repositories will most likely never be used in our deployment systems.

All you need to do to use the file system repositories is to make them `@Primary` with a code change.  If we decide we want to keep them around we can make it more configurable.