### PR TITLE
Bugfix/set group items required

### DIFF
--- a/client/src/main/java/tds/exam/ExamPage.java
+++ b/client/src/main/java/tds/exam/ExamPage.java
@@ -151,7 +151,7 @@ public class ExamPage {
 
     /**
      * @return the number of items required for the group.  -1 means that the all the items in the
-     * group are required.
+     * group are required.  Item groups (group starts with an 'I-') seem to always have a size of 0.
      */
     public int getGroupItemsRequired() {
         return groupItemsRequired;

--- a/client/src/main/java/tds/exam/ExamPage.java
+++ b/client/src/main/java/tds/exam/ExamPage.java
@@ -15,7 +15,7 @@ public class ExamPage {
     private int pagePosition;
     private String segmentKey;
     private String itemGroupKey;
-    private boolean groupItemsRequired;
+    private int groupItemsRequired;
     private UUID examId;
     private Instant createdAt;
     private Instant deletedAt;
@@ -45,7 +45,7 @@ public class ExamPage {
         private int pagePosition;
         private String segmentKey;
         private String itemGroupKey;
-        private boolean groupItemsRequired;
+        private int groupItemsRequired;
         private UUID examId;
         private Instant createdAt;
         private Instant deletedAt;
@@ -67,7 +67,7 @@ public class ExamPage {
             return this;
         }
 
-        public Builder withGroupItemsRequired(boolean groupItemsRequired) {
+        public Builder withGroupItemsRequired(final int groupItemsRequired) {
             this.groupItemsRequired = groupItemsRequired;
             return this;
         }
@@ -112,7 +112,7 @@ public class ExamPage {
                 .withPagePosition(examPage.getPagePosition())
                 .withSegmentKey(examPage.getSegmentKey())
                 .withItemGroupKey(examPage.getItemGroupKey())
-                .withGroupItemsRequired(examPage.isGroupItemsRequired())
+                .withGroupItemsRequired(examPage.getGroupItemsRequired())
                 .withExamId(examPage.getExamId())
                 .withCreatedAt(examPage.getCreatedAt())
                 .withDeletedAt(examPage.getDeletedAt())
@@ -150,15 +150,10 @@ public class ExamPage {
     }
 
     /**
-     * @return True if all items in this page's item group are required; otherwise false
+     * @return the number of items required for the group.  -1 means that the all the items in the
+     * group are required.
      */
-    public boolean isGroupItemsRequired() {
-        // This value is only ever 0 or -1 in the database.  When the value is -1 all items are required (from comment
-        // in https://github.com/SmarterApp/TDS_TestDeliverySystemDataAccess/blob/cebc3996ab000dc604b539da51235eaf20039d0d/database%20scripts%20-%20mysql/Session/User-Defined%20Functions/iscomplete.sql#L46)
-
-        // In legacy, this value is stored in the session.testeeresponse table.  Since it pertains to an item group
-        // (which is a super-set of items), it seems appropriate to store it at the page level.  From here, it can be
-        // mapped to the legacy OpportunityItem.
+    public int getGroupItemsRequired() {
         return groupItemsRequired;
     }
 

--- a/service/src/main/java/tds/exam/repositories/impl/ExamPageCommandRepositoryImpl.java
+++ b/service/src/main/java/tds/exam/repositories/impl/ExamPageCommandRepositoryImpl.java
@@ -36,7 +36,7 @@ public class ExamPageCommandRepositoryImpl implements ExamPageCommandRepository 
                 "   page_position, \n" +
                 "   segment_key, \n" +
                 "   item_group_key, \n" +
-                "   are_group_items_required, \n" +
+                "   group_items_required, \n" +
                 "   exam_id, \n" +
                 "   created_at) \n" +
                 "VALUES (\n" +
@@ -54,7 +54,7 @@ public class ExamPageCommandRepositoryImpl implements ExamPageCommandRepository 
                 .addValue("pagePosition", examPage.getPagePosition())
                 .addValue("segmentKey", examPage.getSegmentKey())
                 .addValue("itemGroupKey", examPage.getItemGroupKey())
-                .addValue("groupItemsRequired", examPage.isGroupItemsRequired())
+                .addValue("groupItemsRequired", examPage.getGroupItemsRequired())
                 .addValue("createdAt", createdAt))
             .toArray(SqlParameterSource[]::new);
 

--- a/service/src/main/java/tds/exam/repositories/impl/ExamPageQueryRepositoryImpl.java
+++ b/service/src/main/java/tds/exam/repositories/impl/ExamPageQueryRepositoryImpl.java
@@ -30,7 +30,7 @@ public class ExamPageQueryRepositoryImpl implements ExamPageQueryRepository {
         "   P.item_group_key, \n" +
         "   P.exam_id, \n" +
         "   P.created_at, \n" +
-        "   P.are_group_items_required, \n" +
+        "   P.group_items_required, \n" +
         "   P.segment_key, \n" +
         "   PE.started_at \n" +
         "FROM \n" +

--- a/service/src/main/java/tds/exam/repositories/impl/ExamPageWrapperQueryRepositoryImpl.java
+++ b/service/src/main/java/tds/exam/repositories/impl/ExamPageWrapperQueryRepositoryImpl.java
@@ -37,7 +37,7 @@ public class ExamPageWrapperQueryRepositoryImpl implements ExamPageWrapperQueryR
         "   page.id AS page_id, \n" +
         "   page.page_position, \n" +
         "   page.item_group_key, \n" +
-        "   page.are_group_items_required, \n" +
+        "   page.group_items_required, \n" +
         "   page.exam_id, \n" +
         "   page.created_at, \n" +
         "   page.segment_key, \n" +
@@ -174,7 +174,7 @@ public class ExamPageWrapperQueryRepositoryImpl implements ExamPageWrapperQueryR
                         .withPagePosition(resultExtractor.getInt("page_position"))
                         .withSegmentKey(resultExtractor.getString("segment_key"))
                         .withItemGroupKey(resultExtractor.getString("item_group_key"))
-                        .withGroupItemsRequired(resultExtractor.getBoolean("are_group_items_required"))
+                        .withGroupItemsRequired(resultExtractor.getInt("group_items_required"))
                         .withExamId(UUID.fromString(resultExtractor.getString("exam_id")))
                         .withCreatedAt(ResultSetMapperUtility.mapTimestampToJodaInstant(resultExtractor, "created_at"))
                         .withStartedAt(ResultSetMapperUtility.mapTimestampToJodaInstant(resultExtractor, "started_at"))

--- a/service/src/main/java/tds/exam/services/impl/ExamItemSelectionServiceImpl.java
+++ b/service/src/main/java/tds/exam/services/impl/ExamItemSelectionServiceImpl.java
@@ -86,6 +86,7 @@ public class ExamItemSelectionServiceImpl implements ExamItemSelectionService {
             .withPagePosition(lastPage + 1)
             .withExamId(examId)
             .withItemGroupKey(itemGroup.getGroupID())
+            .withGroupItemsRequired(itemGroup.getNumRequired())
             .withSegmentKey(itemGroup.getSegmentKey())
             .build();
 
@@ -140,6 +141,7 @@ public class ExamItemSelectionServiceImpl implements ExamItemSelectionService {
                 oppItem.setGroupItemsRequired(segment.getMinItems());
                 oppItem.setPosition(examItem.getPosition());
                 oppItem.setDateCreated(dateCreated);
+                oppItem.setGroupItemsRequired(page.getGroupItemsRequired());
 
                 // manually set data (taken from the legacy adaptive service impl. ResponseRepository.insertItems lin 159
                 oppItem.setIsVisible(true);

--- a/service/src/main/resources/db/migration/V1494292728__exam_page_group_items_required.sql
+++ b/service/src/main/resources/db/migration/V1494292728__exam_page_group_items_required.sql
@@ -1,0 +1,10 @@
+/***********************************************************************************************************************
+  File: V1494292728__exam_page_group_items_required.sql
+
+  Desc: item group required number of items needs to be a number
+
+***********************************************************************************************************************/
+USE EXAM;
+
+ALTER TABLE exam_page DROP COLUMN are_group_items_required;
+ALTER TABLE exam_page ADD COLUMN group_items_required INT NOT NULL DEFAULT -1;

--- a/service/src/main/resources/db/migration/V1494293993__exam_qa_views_group_required_count.sql
+++ b/service/src/main/resources/db/migration/V1494293993__exam_qa_views_group_required_count.sql
@@ -1,0 +1,85 @@
+/***********************************************************************************************************************
+  File: V1494293993__exam_qa_views_group_required_count.sql
+
+  Desc: Alter view to use correct group item count value
+
+***********************************************************************************************************************/
+
+CREATE OR REPLACE VIEW qa_session_testeeresponse AS
+  SELECT
+    page.exam_id AS _fk_testopportunity,
+    item.assessment_item_key AS _efk_itsitem,
+    item.assessment_item_bank_key AS _efk_itsbank,
+    exam.session_id AS _fk_session,
+    exam.attempts AS opportunityrestart,
+    page.page_position AS page,
+    item.position AS position,
+    'not migrated' AS answer,
+    'not migrated' AS scorepoint,
+    item.item_type AS format,
+    item.is_fieldtest AS isfieldtest,
+    item.created_at AS dategenerated,
+    'not migrated' AS datesubmitted,
+    (SELECT MIN(created_at) FROM exam_item_response WHERE exam_item_id = item.id) AS datefirstresponse,
+    response.response AS response,
+    response.is_marked_for_review AS mark,
+    COALESCE(response.score, -1) AS score,
+    'not migrated' AS hostname,
+    (SELECT COUNT(id) FROM exam_item_response WHERE exam_item_id = item.id) AS numupdates,
+    'not migrated' AS datesystemaltered,
+    0 AS isinactive,
+    'not migrated' AS dateinactivated,
+    'not migrated' AS _fk_adminevent,
+    page.item_group_key AS groupid,
+    response.is_selected AS isselected,
+    item.is_required AS isrequired,
+    'not migrated' AS responsesequence,
+    LENGTH(response.response) AS responselength,
+    exam.browser_id AS _fk_browser,
+    response.is_valid AS isvalid,
+    response.score_latency AS scorelatency,
+    page.group_items_required groupitemsrequired,
+    response.scoring_status AS scorestatus,
+    response.scored_at AS scoringdate,
+    response.score_mark AS scoremark,
+    response.scoring_rationale AS scorerationale,
+    (SELECT COUNT(DISTINCT score_sent_at) FROM exam_item_response WHERE exam_item_id = item.id) AS scoreattempts,
+    item.item_key AS _efk_itemkey,
+    exam.session_id AS _fk_responsesession,
+    segment.segment_position AS segment,
+    'not migrated' AS contentlevel,
+    segment.segment_id AS segmentid,
+    'not migrated' AS groupb,
+    'not migrated' AS itemb,
+    'not migrated' AS datelastvisited,
+    'not migrated' AS visitcount,
+    'not migrated' AS geosyncid,
+    'not migrated' AS satellite,
+    response.scoring_dimensions AS scoredimensions,
+    'not migrated' AS responsedurationinsecs
+  FROM
+    exam_page AS page
+    JOIN
+    qa_exam_most_recent_event_per_exam_page AS last_page_event
+      ON page.id = last_page_event.exam_page_id
+    JOIN
+    exam_segment AS segment
+      ON segment.exam_id = page.exam_id
+         AND segment.segment_key = page.segment_key
+    JOIN
+    qa_exam_most_recent_event_per_exam AS last_exam_event
+      ON last_exam_event.exam_id = page.exam_id
+    JOIN exam.exam_event exam
+      ON last_exam_event.exam_id = exam.exam_id
+         AND last_exam_event.id = exam.id
+    JOIN
+    exam_item AS item
+      ON page.id = item.exam_page_id
+    LEFT JOIN
+    qa_exam_most_recent_response_per_exam_item AS most_recent_response
+      ON item.id = most_recent_response.exam_item_id
+    LEFT JOIN
+    exam_item_response response
+      ON most_recent_response.id = response.id
+  ORDER BY
+    item.position;

--- a/service/src/test/java/tds/exam/builder/ExamPageBuilder.java
+++ b/service/src/test/java/tds/exam/builder/ExamPageBuilder.java
@@ -16,7 +16,7 @@ public class ExamPageBuilder {
     private int pagePosition = 1;
     private String segmentKey = "segment-key-1";
     private String itemGroupKey = "item-group-key";
-    private boolean groupItemsRequired = true;
+    private int groupItemsRequired = -1;
     private UUID examId = UUID.randomUUID();
     private Instant createdAt = Instant.now();
     private Instant deletedAt;
@@ -58,7 +58,7 @@ public class ExamPageBuilder {
         return this;
     }
 
-    public ExamPageBuilder withGroupItemsRequired(boolean groupItemsRequired) {
+    public ExamPageBuilder withGroupItemsRequired(int groupItemsRequired) {
         this.groupItemsRequired = groupItemsRequired;
         return this;
     }

--- a/service/src/test/java/tds/exam/repositories/impl/ExamPageWrapperQueryRepositoryIntegrationTests.java
+++ b/service/src/test/java/tds/exam/repositories/impl/ExamPageWrapperQueryRepositoryIntegrationTests.java
@@ -101,7 +101,7 @@ public class ExamPageWrapperQueryRepositoryIntegrationTests {
         assertThat(examPage.getPagePosition()).isEqualTo(1);
         assertThat(examPage.getSegmentKey()).isEqualTo("segment-key-1");
         assertThat(examPage.getItemGroupKey()).isEqualTo("item-group-key");
-        assertThat(examPage.isGroupItemsRequired()).isTrue();
+        assertThat(examPage.getGroupItemsRequired()).isEqualTo(-1);
         assertThat(examPage.getExamId()).isEqualTo(mockExam.getId());
 
         assertThat(wrapper.getExamItems()).hasSize(2);

--- a/service/src/test/java/tds/exam/repositories/impl/ExamPrintRequestRepositoryIntegrationTests.java
+++ b/service/src/test/java/tds/exam/repositories/impl/ExamPrintRequestRepositoryIntegrationTests.java
@@ -90,8 +90,9 @@ public class ExamPrintRequestRepositoryIntegrationTests {
 
         examSegmentCommandRepository.insert(Arrays.asList(segment));
 
-        ExamPage page = new ExamPage.Builder()
+        ExamPage page = ExamPage.Builder
             .fromExamPage(random(ExamPage.class))
+            .withGroupItemsRequired(-1)
             .withExamId(exam.getId())
             .withDeletedAt(null)
             .withSegmentKey(segment.getSegmentKey())

--- a/service/src/test/java/tds/exam/services/impl/ExamItemSelectionServiceImplTest.java
+++ b/service/src/test/java/tds/exam/services/impl/ExamItemSelectionServiceImplTest.java
@@ -7,6 +7,12 @@ import org.junit.runner.RunWith;
 import org.mockito.ArgumentCaptor;
 import org.mockito.Mock;
 import org.mockito.runners.MockitoJUnitRunner;
+
+import java.util.Collections;
+import java.util.List;
+import java.util.Optional;
+import java.util.UUID;
+
 import tds.assessment.Assessment;
 import tds.assessment.Item;
 import tds.assessment.Segment;
@@ -27,11 +33,6 @@ import tds.itemselection.base.TestItem;
 import tds.itemselection.model.ItemResponse;
 import tds.itemselection.services.ItemSelectionService;
 import tds.student.sql.data.OpportunityItem;
-
-import java.util.Collections;
-import java.util.List;
-import java.util.Optional;
-import java.util.UUID;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.Mockito.verify;
@@ -101,6 +102,7 @@ public class ExamItemSelectionServiceImplTest {
         itemGroup.setSegmentKey("segmentKey");
         itemGroup.setSegmentID("segmentId");
         itemGroup.setGroupID("group");
+        itemGroup.setNumberOfItemsRequired(-1);
 
         TestItem testItem = new TestItem(
             "187-2345",
@@ -144,7 +146,6 @@ public class ExamItemSelectionServiceImplTest {
         assertThat(opportunityItem.getFormat()).isEqualTo(item.getItemType());
         assertThat(opportunityItem.getPage()).isEqualTo(examPage.getPagePosition());
         assertThat(opportunityItem.getPosition()).isEqualTo(examItem.getPosition());
-        assertThat(opportunityItem.getGroupItemsRequired()).isEqualTo(0);
         assertThat(opportunityItem.getValue()).isNull();
         assertThat(opportunityItem.isVisible()).isTrue();
         assertThat(opportunityItem.getIsSelected()).isFalse();
@@ -152,6 +153,7 @@ public class ExamItemSelectionServiceImplTest {
         assertThat(opportunityItem.isMarkForReview()).isFalse();
         assertThat(opportunityItem.getStimulusFile()).isNull();
         assertThat(opportunityItem.getItemFile()).isNull();
+        assertThat(opportunityItem.getGroupItemsRequired()).isEqualTo(-1);
 
         assertThat(examItem.getAssessmentItemBankKey()).isEqualTo(item.getBankKey());
         assertThat(examItem.getAssessmentItemKey()).isEqualTo(item.getItemKey());
@@ -163,6 +165,7 @@ public class ExamItemSelectionServiceImplTest {
 
         assertThat(examPage.getItemGroupKey()).isEqualTo(itemGroup.getGroupID());
         assertThat(examPage.getPagePosition()).isEqualTo(2);
+        assertThat(examPage.getGroupItemsRequired()).isEqualTo(-1);
     }
 
     @Test(expected = IllegalArgumentException.class)


### PR DESCRIPTION
The number of items required by item group is usually -1 which we learned means 'All items required'.  Normally the other value is 0, but there seems to be no reason that the value could be any integer.  So it could be that the item group has 20 items, but only 5 are required.  In that instance I would expect the value to be 5.

Anyhow, boolean no longer seemed appropriate after finding it out.  Thanks goes to @jeffjohnson9046 for helping tracking this down.