### PR TITLE
Adding a null check in exam page wrapper repository code to prevent a…

### DIFF
--- a/service/src/main/java/tds/exam/repositories/impl/ExamPageWrapperQueryRepositoryImpl.java
+++ b/service/src/main/java/tds/exam/repositories/impl/ExamPageWrapperQueryRepositoryImpl.java
@@ -196,7 +196,9 @@ public class ExamPageWrapperQueryRepositoryImpl implements ExamPageWrapperQueryR
                         .withMarkedForReview(resultExtractor.getBoolean("is_marked_for_review"))
                         .withScore(new ExamItemResponseScore.Builder()
                             .withScore(resultExtractor.getInt("score"))
-                            .withScoringStatus(ExamScoringStatus.fromType(resultExtractor.getString("scoring_status")))
+                            .withScoringStatus(resultExtractor.getString("scoring_status") != null
+                                ? ExamScoringStatus.fromType(resultExtractor.getString("scoring_status"))
+                                : null)
                             .withScoringRationale(resultExtractor.getString("scoring_rationale"))
                             .withScoringDimensions(resultExtractor.getString("scoring_dimensions"))
                             .withScoredAt(ResultSetMapperUtility.mapTimestampToJodaInstant(resultExtractor, "scored_at"))


### PR DESCRIPTION
…n illegal argument exception in the enum fromType method

https://jira.fairwaytech.com/browse/TDS-951

Mark for review responses are unique in that they do not have a score associated with them.