### PR TITLE
Fixing restart/resumption bugs and altering view

### DIFF
--- a/service/src/main/java/tds/exam/repositories/impl/ExamCommandRepositoryImpl.java
+++ b/service/src/main/java/tds/exam/repositories/impl/ExamCommandRepositoryImpl.java
@@ -116,6 +116,8 @@ class ExamCommandRepositoryImpl implements ExamCommandRepository {
                 .addValue("customAccommodations", exam.isCustomAccommodations())
                 .addValue("startedAt", mapJodaInstantToTimestamp(exam.getStartedAt()))
                 .addValue("browserUserAgent", exam.getBrowserUserAgent())
+                .addValue("restartsAndResumptions", exam.getRestartsAndResumptions())
+                .addValue("resumptions", exam.getResumptions())
                 .addValue("createdAt", now))
             .toArray(MapSqlParameterSource[]::new);
 
@@ -141,6 +143,8 @@ class ExamCommandRepositoryImpl implements ExamCommandRepository {
                 "custom_accommodations, \n" +
                 "abnormal_starts, \n" +
                 "browser_user_agent, \n" +
+                "resumptions, \n" +
+                "restarts_and_resumptions, \n" +
                 "created_at \n" +
                 ") \n" +
                 "VALUES \n" +
@@ -165,6 +169,8 @@ class ExamCommandRepositoryImpl implements ExamCommandRepository {
                 ":customAccommodations, \n" +
                 ":abnormalStarts, \n" +
                 ":browserUserAgent, \n" +
+                ":resumptions, \n" +
+                ":restartsAndResumptions, \n" +
                 ":createdAt \n" +
                 ")";
 

--- a/service/src/main/java/tds/exam/repositories/impl/ExamQueryRepositoryImpl.java
+++ b/service/src/main/java/tds/exam/repositories/impl/ExamQueryRepositoryImpl.java
@@ -74,6 +74,8 @@ public class ExamQueryRepositoryImpl implements ExamQueryRepository {
         "ee.current_segment_position, \n" +
         "ee.custom_accommodations, \n" +
         "ee.browser_user_agent, \n" +
+        "ee.resumptions, \n" +
+        "ee.restarts_and_resumptions, \n" +
         "e.created_at, \n" +
         "esc.description, \n" +
         "esc.status, \n" +
@@ -494,6 +496,8 @@ public class ExamQueryRepositoryImpl implements ExamQueryRepository {
                 .withCurrentSegmentPosition(rs.getInt("current_segment_position"))
                 .withCustomAccommodation(rs.getBoolean("custom_accommodations"))
                 .withBrowserUserAgent(rs.getString("browser_user_agent"))
+                .withRestartsAndResumptions(rs.getInt("restarts_and_resumptions"))
+                .withResumptions(rs.getInt("resumptions"))
                 .withMultiStageBraille(rs.getBoolean("msb"))
                 .build();
         }

--- a/service/src/main/resources/db/migration/V1494952652__exam_qa_view_testeeresponse_opportunityrestart.sql
+++ b/service/src/main/resources/db/migration/V1494952652__exam_qa_view_testeeresponse_opportunityrestart.sql
@@ -1,0 +1,87 @@
+/***********************************************************************************************************************
+  File: V1494952652__exam_qa_view_testeeresponse_opportunityrestart.sql
+
+  Desc: Alter view to use make opportunityrestart value to be resumptions_and_restarts instead of attempts
+
+***********************************************************************************************************************/
+
+USE exam;
+
+CREATE OR REPLACE VIEW qa_session_testeeresponse AS
+  SELECT
+    page.exam_id AS _fk_testopportunity,
+    item.assessment_item_key AS _efk_itsitem,
+    item.assessment_item_bank_key AS _efk_itsbank,
+    exam.session_id AS _fk_session,
+    exam.restarts_and_resumptions AS opportunityrestart,
+    page.page_position AS page,
+    item.position AS position,
+    'not migrated' AS answer,
+    'not migrated' AS scorepoint,
+    item.item_type AS format,
+    item.is_fieldtest AS isfieldtest,
+    item.created_at AS dategenerated,
+    'not migrated' AS datesubmitted,
+    (SELECT MIN(created_at) FROM exam_item_response WHERE exam_item_id = item.id) AS datefirstresponse,
+    response.response AS response,
+    response.is_marked_for_review AS mark,
+    COALESCE(response.score, -1) AS score,
+    'not migrated' AS hostname,
+    (SELECT COUNT(id) FROM exam_item_response WHERE exam_item_id = item.id) AS numupdates,
+    'not migrated' AS datesystemaltered,
+    0 AS isinactive,
+    'not migrated' AS dateinactivated,
+    'not migrated' AS _fk_adminevent,
+    page.item_group_key AS groupid,
+    response.is_selected AS isselected,
+    item.is_required AS isrequired,
+    'not migrated' AS responsesequence,
+    LENGTH(response.response) AS responselength,
+    exam.browser_id AS _fk_browser,
+    response.is_valid AS isvalid,
+    response.score_latency AS scorelatency,
+    page.group_items_required groupitemsrequired,
+    response.scoring_status AS scorestatus,
+    response.scored_at AS scoringdate,
+    response.score_mark AS scoremark,
+    response.scoring_rationale AS scorerationale,
+    (SELECT COUNT(DISTINCT score_sent_at) FROM exam_item_response WHERE exam_item_id = item.id AND score_sent_at IS NOT NULL) AS scoreattempts,
+    item.item_key AS _efk_itemkey,
+    exam.session_id AS _fk_responsesession,
+    segment.segment_position AS segment,
+    'not migrated' AS contentlevel,
+    segment.segment_id AS segmentid,
+    'not migrated' AS groupb,
+    'not migrated' AS itemb,
+    'not migrated' AS datelastvisited,
+    'not migrated' AS visitcount,
+    'not migrated' AS geosyncid,
+    'not migrated' AS satellite,
+    response.scoring_dimensions AS scoredimensions,
+    'not migrated' AS responsedurationinsecs
+  FROM
+    exam_page AS page
+    JOIN
+    qa_exam_most_recent_event_per_exam_page AS last_page_event
+      ON page.id = last_page_event.exam_page_id
+    JOIN
+    exam_segment AS segment
+      ON segment.exam_id = page.exam_id
+         AND segment.segment_key = page.segment_key
+    JOIN
+    qa_exam_most_recent_event_per_exam AS last_exam_event
+      ON last_exam_event.exam_id = page.exam_id
+    JOIN exam.exam_event exam
+      ON last_exam_event.exam_id = exam.exam_id
+         AND last_exam_event.id = exam.id
+    JOIN
+    exam_item AS item
+      ON page.id = item.exam_page_id
+    LEFT JOIN
+    qa_exam_most_recent_response_per_exam_item AS most_recent_response
+      ON item.id = most_recent_response.exam_item_id
+    LEFT JOIN
+    exam_item_response response
+      ON most_recent_response.id = response.id
+  ORDER BY
+    item.position;

--- a/service/src/test/java/tds/exam/repositories/impl/ExamQueryRepositoryImplIntegrationTests.java
+++ b/service/src/test/java/tds/exam/repositories/impl/ExamQueryRepositoryImplIntegrationTests.java
@@ -83,6 +83,8 @@ public class ExamQueryRepositoryImplIntegrationTests {
             .withAssessmentId("assessmentId3")
             .withStudentId(9999L)
             .withAttempts(2)
+            .withResumptions(2)
+            .withRestartsAndResumptions(3)
             .withScoredAt(Instant.now().minus(Minutes.minutes(5).toStandardDuration()))
             .build());
 
@@ -158,6 +160,8 @@ public class ExamQueryRepositoryImplIntegrationTests {
     public void shouldRetrieveExamForUniqueKey() {
         Optional<Exam> examOptional = examQueryRepository.getExamById(currentExamId);
         assertThat(examOptional.isPresent()).isTrue();
+        assertThat(examOptional.get().getRestartsAndResumptions()).isEqualTo(3);
+        assertThat(examOptional.get().getResumptions()).isEqualTo(2);
     }
 
     @Test


### PR DESCRIPTION
https://jira.fairwaytech.com/browse/TDS-975

- Updated the QA view to use the "restarts_and_resumptions" value from exam_event instead of "attempts" (which is actually legacy "opportunity")
- In testing this, I discovered that we were not actually saving/fetching the resumptions and restartsAndResumptions values from the database. Whoops!