### PR TITLE
Optimize accommodation queries.

### DIFF
--- a/service/src/main/java/tds/exam/repositories/impl/ExamAccommodationCommandRepositoryImpl.java
+++ b/service/src/main/java/tds/exam/repositories/impl/ExamAccommodationCommandRepositoryImpl.java
@@ -7,14 +7,13 @@ import org.springframework.jdbc.core.namedparam.MapSqlParameterSource;
 import org.springframework.jdbc.core.namedparam.NamedParameterJdbcTemplate;
 import org.springframework.jdbc.core.namedparam.SqlParameterSource;
 import org.springframework.stereotype.Repository;
+import tds.exam.ExamAccommodation;
+import tds.exam.repositories.ExamAccommodationCommandRepository;
 
 import java.sql.Timestamp;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.stream.Collectors;
-
-import tds.exam.ExamAccommodation;
-import tds.exam.repositories.ExamAccommodationCommandRepository;
 
 import static tds.common.data.mapping.ResultSetMapperUtility.mapJodaInstantToTimestamp;
 
@@ -29,16 +28,16 @@ public class ExamAccommodationCommandRepositoryImpl implements ExamAccommodation
 
     @Override
     public void insert(final List<ExamAccommodation> accommodations) {
-        String SQL =
+        final String SQL =
             "INSERT INTO " +
                 "   exam_accommodation(exam_id, id, segment_key, type, code, description, allow_change, value, segment_position, " +
                 "   created_at, visible, student_controlled, disabled_on_guest_session, default_accommodation, allow_combine, sort_order, depends_on, functional) \n" +
                 "VALUES(:examId, :id, :segmentKey, :type, :code, :description, :allowChange, :value, :segmentPosition, :createdAt," +
                 "   :visible, :studentControlled, :disabledOnGuestSession, :defaultAccommodation, :allowCombine, :sortOrder, :dependsOn, :functional)";
 
-        Timestamp createdAt = mapJodaInstantToTimestamp(Instant.now());
-        List<ExamAccommodation> createdAccommodations = new ArrayList<>();
-        SqlParameterSource[] parameters = accommodations.stream()
+        final Timestamp createdAt = mapJodaInstantToTimestamp(Instant.now());
+        final List<ExamAccommodation> createdAccommodations = new ArrayList<>();
+        final SqlParameterSource[] parameters = accommodations.stream()
             .map(examAccommodation -> {
                 createdAccommodations.add(ExamAccommodation.Builder
                     .fromExamAccommodation(examAccommodation)
@@ -76,8 +75,9 @@ public class ExamAccommodationCommandRepositoryImpl implements ExamAccommodation
     }
 
     private void updateEvent(final Timestamp createdAt, final ExamAccommodation... examAccommodations) {
-        String SQL = "INSERT INTO exam_accommodation_event(" +
+        final String SQL = "INSERT INTO exam_accommodation_event(" +
             "exam_accommodation_id, " +
+            "exam_id, " +
             "denied_at, " +
             "deleted_at, " +
             "selectable," +
@@ -86,6 +86,7 @@ public class ExamAccommodationCommandRepositoryImpl implements ExamAccommodation
             "created_at) \n" +
             "VALUES(" +
             ":examAccommodationId, " +
+            ":examId, " +
             ":deniedAt, " +
             ":deletedAt, " +
             ":selectable," +
@@ -93,11 +94,12 @@ public class ExamAccommodationCommandRepositoryImpl implements ExamAccommodation
             ":totalTypeCount," +
             ":createdAt);";
 
-        SqlParameterSource[] parameterSources = new SqlParameterSource[examAccommodations.length];
+        final SqlParameterSource[] parameterSources = new SqlParameterSource[examAccommodations.length];
 
         for (int i = 0; i < parameterSources.length; i++) {
-            ExamAccommodation examAccommodation = examAccommodations[i];
-            SqlParameterSource parameters = new MapSqlParameterSource("examAccommodationId", examAccommodation.getId().toString())
+            final ExamAccommodation examAccommodation = examAccommodations[i];
+            final SqlParameterSource parameters = new MapSqlParameterSource("examAccommodationId", examAccommodation.getId().toString())
+                .addValue("examId", examAccommodation.getExamId().toString())
                 .addValue("deniedAt", mapJodaInstantToTimestamp(examAccommodation.getDeniedAt()))
                 .addValue("selectable", examAccommodation.isSelectable())
                 .addValue("totalTypeCount", examAccommodation.getTotalTypeCount())
@@ -113,9 +115,9 @@ public class ExamAccommodationCommandRepositoryImpl implements ExamAccommodation
 
     @Override
     public void delete(final List<ExamAccommodation> accommodations) {
-        Instant deletedAt = Instant.now();
+        final Instant deletedAt = Instant.now();
 
-        List<ExamAccommodation> accommodationsToDelete = accommodations.stream()
+        final List<ExamAccommodation> accommodationsToDelete = accommodations.stream()
             .map(accommodation -> ExamAccommodation.Builder
                 .fromExamAccommodation(accommodation)
                 .withDeletedAt(deletedAt)

--- a/service/src/main/java/tds/exam/repositories/impl/ExamAccommodationQueryRepositoryImpl.java
+++ b/service/src/main/java/tds/exam/repositories/impl/ExamAccommodationQueryRepositoryImpl.java
@@ -7,6 +7,8 @@ import org.springframework.jdbc.core.namedparam.MapSqlParameterSource;
 import org.springframework.jdbc.core.namedparam.NamedParameterJdbcTemplate;
 import org.springframework.jdbc.core.namedparam.SqlParameterSource;
 import org.springframework.stereotype.Repository;
+import tds.exam.ExamAccommodation;
+import tds.exam.repositories.ExamAccommodationQueryRepository;
 
 import java.sql.ResultSet;
 import java.sql.SQLException;
@@ -14,9 +16,6 @@ import java.util.Arrays;
 import java.util.List;
 import java.util.UUID;
 import java.util.stream.Collectors;
-
-import tds.exam.ExamAccommodation;
-import tds.exam.repositories.ExamAccommodationQueryRepository;
 
 import static tds.common.data.mapping.ResultSetMapperUtility.mapTimestampToJodaInstant;
 
@@ -67,6 +66,8 @@ public class ExamAccommodationQueryRepositoryImpl implements ExamAccommodationQu
                 "       MAX(id) AS id \n" +
                 "   FROM \n" +
                 "       exam_accommodation_event \n" +
+                "   WHERE \n" +
+                "       exam_id = :examId \n" +
                 "   GROUP BY exam_accommodation_id \n" +
                 ") last_event \n" +
                 "  ON ea.id = last_event.exam_accommodation_id \n" +
@@ -133,6 +134,8 @@ public class ExamAccommodationQueryRepositoryImpl implements ExamAccommodationQu
                 "       MAX(id) AS id \n" +
                 "   FROM \n" +
                 "       exam_accommodation_event \n" +
+                "   WHERE \n" +
+                "       exam_id IN (:examIds) \n" +
                 "   GROUP BY exam_accommodation_id \n" +
                 ") last_event \n" +
                 "  ON ea.id = last_event.exam_accommodation_id \n" +
@@ -153,7 +156,7 @@ public class ExamAccommodationQueryRepositoryImpl implements ExamAccommodationQu
 
     private static class AccommodationRowMapper implements RowMapper<ExamAccommodation> {
         @Override
-        public ExamAccommodation mapRow(ResultSet rs, int rowNum) throws SQLException {
+        public ExamAccommodation mapRow(final ResultSet rs, final int rowNum) throws SQLException {
             return new ExamAccommodation.Builder(UUID.fromString(rs.getString("id")))
                 .withExamId(UUID.fromString(rs.getString("exam_id")))
                 .withSegmentKey(rs.getString("segment_key"))

--- a/service/src/main/resources/db/migration/V1495155158__exam_accommodation_event_add_exam_id.sql
+++ b/service/src/main/resources/db/migration/V1495155158__exam_accommodation_event_add_exam_id.sql
@@ -1,0 +1,28 @@
+/***********************************************************************************************************************
+  File: V1495155158__exam_accommodation_event_add_exam_id.sql
+
+  Desc: Add exam_id column to the exam_accommodation_event table
+
+***********************************************************************************************************************/
+
+USE exam;
+
+-- Add missing foreign key on exam_accommodation
+ALTER TABLE exam_accommodation
+  ADD CONSTRAINT fk_exam_accommodation_exam_id
+  FOREIGN KEY (exam_id) REFERENCES exam(id);
+
+ALTER TABLE exam_accommodation_event
+  ADD exam_id CHAR(36) NOT NULL AFTER exam_accommodation_id;
+
+-- Update the column w/data
+start transaction;
+update exam_accommodation_event
+  join exam_accommodation
+    on exam_accommodation.id = exam_accommodation_event.exam_accommodation_id
+set exam_accommodation_event.exam_id = exam_accommodation.exam_id;
+commit;
+
+ALTER TABLE exam_accommodation_event
+  ADD CONSTRAINT fk_exam_accommodation_event_exam_id
+  FOREIGN KEY (exam_id) REFERENCES exam(id);


### PR DESCRIPTION
This PR adds an "exam_id" FK column to the exam_accommodation_events table for faster lookups.

The old execution took ~65ms on my local machine, the new execution takes ~1ms on my local machine.