### PR TITLE
Fixing issues with exam resumes before and after grace period

### DIFF
--- a/client/src/main/java/tds/exam/ExamPage.java
+++ b/client/src/main/java/tds/exam/ExamPage.java
@@ -203,9 +203,7 @@ public class ExamPage {
     }
 
     /**
-     * The restart number of the exam when the exam page was created
-     *
-     * @return
+     * @return The restart number of the exam when the exam page was created
      */
     public int getExamRestartsAndResumptions() {
         return examRestartsAndResumptions;

--- a/client/src/main/java/tds/exam/ExamPage.java
+++ b/client/src/main/java/tds/exam/ExamPage.java
@@ -21,6 +21,7 @@ public class ExamPage {
     private Instant deletedAt;
     private Instant startedAt;
     private long duration;
+    private int examRestartsAndResumptions;
 
     /**
      * Private constructor for frameworks
@@ -38,6 +39,8 @@ public class ExamPage {
         createdAt = builder.createdAt;
         deletedAt = builder.deletedAt;
         startedAt = builder.startedAt;
+        duration = builder.duration;
+        examRestartsAndResumptions = builder.examRestartsAndResumptions;
     }
 
     public static final class Builder {
@@ -51,6 +54,7 @@ public class ExamPage {
         private Instant deletedAt;
         private Instant startedAt;
         private long duration;
+        private int examRestartsAndResumptions;
 
         public Builder withPagePosition(int pagePosition) {
             this.pagePosition = pagePosition;
@@ -102,6 +106,11 @@ public class ExamPage {
             return this;
         }
 
+        public Builder withExamRestartsAndResumptions(int examRestartsAndResumptions) {
+            this.examRestartsAndResumptions = examRestartsAndResumptions;
+            return this;
+        }
+
         public ExamPage build() {
             return new ExamPage(this);
         }
@@ -117,7 +126,8 @@ public class ExamPage {
                 .withCreatedAt(examPage.getCreatedAt())
                 .withDeletedAt(examPage.getDeletedAt())
                 .withStartedAt(examPage.getStartedAt())
-                .withDuration(examPage.getDuration());
+                .withDuration(examPage.getDuration())
+                .withExamRestartsAndResumptions(examPage.getExamRestartsAndResumptions());
         }
     }
 
@@ -190,5 +200,14 @@ public class ExamPage {
      */
     public long getDuration() {
         return duration;
+    }
+
+    /**
+     * The restart number of the exam when the exam page was created
+     *
+     * @return
+     */
+    public int getExamRestartsAndResumptions() {
+        return examRestartsAndResumptions;
     }
 }

--- a/client/src/main/java/tds/exam/wrapper/ExamPageWrapper.java
+++ b/client/src/main/java/tds/exam/wrapper/ExamPageWrapper.java
@@ -12,10 +12,12 @@ import tds.exam.ExamPage;
 public class ExamPageWrapper {
     private ExamPage examPage;
     private List<ExamItem> examItems = new ArrayList<>();
+    private boolean visible;
 
-    public ExamPageWrapper(final ExamPage examPage, final List<ExamItem> examItems) {
+    public ExamPageWrapper(final ExamPage examPage, final List<ExamItem> examItems, final boolean visible) {
         this.examPage = examPage;
         this.examItems = examItems;
+        this.visible = visible;
     }
 
     //For frameworks
@@ -34,5 +36,9 @@ public class ExamPageWrapper {
      */
     public List<ExamItem> getExamItems() {
         return examItems;
+    }
+
+    public boolean isVisible() {
+        return visible;
     }
 }

--- a/client/src/main/java/tds/exam/wrapper/ExamPageWrapper.java
+++ b/client/src/main/java/tds/exam/wrapper/ExamPageWrapper.java
@@ -38,6 +38,9 @@ public class ExamPageWrapper {
         return examItems;
     }
 
+    /**
+     * @return {@code true} if this exam page should be visible in student upon a resume, false otherwise
+     */
     public boolean isVisible() {
         return visible;
     }

--- a/service/src/main/java/tds/exam/repositories/impl/ExamPageCommandRepositoryImpl.java
+++ b/service/src/main/java/tds/exam/repositories/impl/ExamPageCommandRepositoryImpl.java
@@ -70,11 +70,15 @@ public class ExamPageCommandRepositoryImpl implements ExamPageCommandRepository 
             "INSERT INTO \n" +
                 "exam_page_event (\n" +
                 "   exam_page_id, \n" +
+                "   exam_restarts_and_resumptions, \n" +
+                "   page_duration, \n" +
                 "   deleted_at, \n" +
                 "   started_at, \n" +
                 "   created_at) \n" +
                 "SELECT \n" +
                 "   exam_page_id, \n" +
+                "   exam_restarts_and_resumptions, \n" +
+                "   page_duration, \n" +
                 "   UTC_TIMESTAMP(), \n" +
                 "   started_at, \n " +
                 "   UTC_TIMESTAMP() \n" +
@@ -94,11 +98,13 @@ public class ExamPageCommandRepositoryImpl implements ExamPageCommandRepository 
     public void update(final ExamPage... examPages) {
         final Timestamp createdAt = mapJodaInstantToTimestamp(Instant.now());
         final String updatePageSQL =
-            "INSERT INTO exam_page_event (exam_page_id, deleted_at, started_at, created_at) \n" +
-                "VALUES (:examPageId, :deletedAt, :startedAt, :createdAt)";
+            "INSERT INTO exam_page_event (exam_page_id, exam_restarts_and_resumptions, page_duration, deleted_at, started_at, created_at) \n" +
+                "VALUES (:examPageId, :examRestartsAndResumptions, :pageDuration, :deletedAt, :startedAt, :createdAt)";
 
         SqlParameterSource[] parameters = Stream.of(examPages).map(examPage ->
             new MapSqlParameterSource("examPageId", examPage.getId().toString())
+                .addValue("examRestartsAndResumptions", examPage.getExamRestartsAndResumptions())
+                .addValue("pageDuration", examPage.getDuration())
                 .addValue("startedAt", mapJodaInstantToTimestamp(examPage.getStartedAt()))
                 .addValue("deletedAt", mapJodaInstantToTimestamp(examPage.getDeletedAt()))
                 .addValue("createdAt", createdAt))

--- a/service/src/main/java/tds/exam/repositories/impl/ExamPageQueryRepositoryImpl.java
+++ b/service/src/main/java/tds/exam/repositories/impl/ExamPageQueryRepositoryImpl.java
@@ -32,7 +32,9 @@ public class ExamPageQueryRepositoryImpl implements ExamPageQueryRepository {
         "   P.created_at, \n" +
         "   P.group_items_required, \n" +
         "   P.segment_key, \n" +
-        "   PE.started_at \n" +
+        "   PE.started_at, \n" +
+        "   PE.page_duration, \n" +
+        "   PE.exam_restarts_and_resumptions \n" +
         "FROM \n" +
         "   exam_page P\n" +
         "JOIN ( \n" +
@@ -116,8 +118,10 @@ public class ExamPageQueryRepositoryImpl implements ExamPageQueryRepository {
                 .withSegmentKey(rs.getString("segment_key"))
                 .withItemGroupKey(rs.getString("item_group_key"))
                 .withExamId(UUID.fromString(rs.getString("exam_id")))
+                .withDuration(rs.getLong("page_duration"))
                 .withCreatedAt(ResultSetMapperUtility.mapTimestampToJodaInstant(rs, "created_at"))
                 .withStartedAt(ResultSetMapperUtility.mapTimestampToJodaInstant(rs, "started_at"))
+                .withExamRestartsAndResumptions(rs.getInt("exam_restarts_and_resumptions"))
                 .build();
         }
     }

--- a/service/src/main/java/tds/exam/services/impl/ExamItemSelectionServiceImpl.java
+++ b/service/src/main/java/tds/exam/services/impl/ExamItemSelectionServiceImpl.java
@@ -94,6 +94,7 @@ public class ExamItemSelectionServiceImpl implements ExamItemSelectionService {
             .withItemGroupKey(itemGroup.getGroupID())
             .withGroupItemsRequired(itemGroup.getNumRequired())
             .withSegmentKey(itemGroup.getSegmentKey())
+            .withExamRestartsAndResumptions(exam.getRestartsAndResumptions())
             .build();
 
         int examItemPosition = lastPosition;

--- a/service/src/main/resources/db/migration/V1495225295__exam_page_event_add_exam_restarts_and_resumptions.sql
+++ b/service/src/main/resources/db/migration/V1495225295__exam_page_event_add_exam_restarts_and_resumptions.sql
@@ -1,0 +1,10 @@
+/***********************************************************************************************************************
+  File: V1495225295__exam_page_event_add_exam_restarts_and_resumptions.sql
+
+  Desc: Schema modification to add the exam_restarts_and_resumptions column to exam_page_event
+
+***********************************************************************************************************************/
+
+USE exam;
+
+ALTER TABLE exam_page_event ADD COLUMN exam_restarts_and_resumptions INT(11) NOT NULL DEFAULT 0;

--- a/service/src/test/java/tds/exam/builder/ExamPageBuilder.java
+++ b/service/src/test/java/tds/exam/builder/ExamPageBuilder.java
@@ -22,6 +22,7 @@ public class ExamPageBuilder {
     private Instant deletedAt;
     private Instant startedAt;
     private long duration = 100;
+    private int examRestartAndResumption;
 
     public ExamPage build() {
         return new ExamPage.Builder()
@@ -35,6 +36,7 @@ public class ExamPageBuilder {
             .withDeletedAt(deletedAt)
             .withStartedAt(startedAt)
             .withDuration(duration)
+            .withExamRestartsAndResumptions(examRestartAndResumption)
             .build();
     }
 
@@ -85,6 +87,11 @@ public class ExamPageBuilder {
 
     public ExamPageBuilder withDuration(long duration) {
         this.duration = duration;
+        return this;
+    }
+
+    public ExamPageBuilder withExamRestartsAndResumptions(int examRestartAndResumption) {
+        this.examRestartAndResumption = examRestartAndResumption;
         return this;
     }
 }

--- a/service/src/test/java/tds/exam/repositories/impl/ExamPageWrapperQueryRepositoryIntegrationTests.java
+++ b/service/src/test/java/tds/exam/repositories/impl/ExamPageWrapperQueryRepositoryIntegrationTests.java
@@ -45,12 +45,14 @@ public class ExamPageWrapperQueryRepositoryIntegrationTests {
     private ExamPageCommandRepository examPageCommandRepository;
     private ExamPageWrapperQueryRepository examPageQueryRepository;
 
-    private final Exam mockExam = new ExamBuilder().build();
+    private final Exam mockExam = new ExamBuilder().withRestartsAndResumptions(0).build();
     private final ExamSegment mockExamSegment = new ExamSegmentBuilder()
         .withExamId(mockExam.getId())
         .build();
     private final ExamPage mockExamPage = new ExamPageBuilder()
+        .withId(UUID.randomUUID())
         .withExamId(mockExam.getId())
+        .withExamRestartsAndResumptions(0)
         .withSegmentKey(mockExamSegment.getSegmentKey())
         .build();
     private final ExamItem mockFirstExamItem = new ExamItemBuilder()
@@ -208,6 +210,7 @@ public class ExamPageWrapperQueryRepositoryIntegrationTests {
             .withId(UUID.randomUUID())
             .withExamId(mockExamPage.getExamId())
             .withPagePosition(mockExamPage.getPagePosition() + 1)
+            .withExamRestartsAndResumptions(2)
             .build();
 
         ExamItem otherExamItem = new ExamItemBuilder()
@@ -226,10 +229,12 @@ public class ExamPageWrapperQueryRepositoryIntegrationTests {
         assertThat(examPageWrappers.get(0).getExamItems()).hasSize(2);
         assertThat(examPageWrappers.get(0).getExamItems().get(0).getId()).isEqualTo(mockFirstExamItem.getId());
         assertThat(examPageWrappers.get(0).getExamItems().get(1).getId()).isEqualTo(mockSecondExamItem.getId());
+        assertThat(examPageWrappers.get(0).isVisible()).isTrue();
 
         assertThat(examPageWrappers.get(1).getExamPage().getId()).isEqualTo(otherExamPage.getId());
         assertThat(examPageWrappers.get(1).getExamItems()).hasSize(1);
         assertThat(examPageWrappers.get(1).getExamItems().get(0).getId()).isEqualTo(otherExamItem.getId());
+        assertThat(examPageWrappers.get(1).isVisible()).isFalse();
     }
 
     @Test

--- a/service/src/test/java/tds/exam/services/impl/ExamSegmentWrapperServiceImplTest.java
+++ b/service/src/test/java/tds/exam/services/impl/ExamSegmentWrapperServiceImplTest.java
@@ -60,21 +60,24 @@ public class ExamSegmentWrapperServiceImplTest {
             .withSegmentKey("segmentKey")
             .withPagePosition(1)
             .build(),
-            Collections.emptyList());
+            Collections.emptyList(),
+            true);
 
         ExamPageWrapper examPageWrapper2 = new ExamPageWrapper(new ExamPageBuilder()
             .withExamId(examId)
             .withSegmentKey("segmentKey")
             .withPagePosition(2)
             .build(),
-            Collections.emptyList());
+            Collections.emptyList(),
+            true);
 
         ExamPageWrapper examPageWrapper3 = new ExamPageWrapper(new ExamPageBuilder()
             .withExamId(examId)
             .withSegmentKey("segmentKey2")
             .withPagePosition(3)
             .build(),
-            Collections.emptyList());
+            Collections.emptyList(),
+            true);
 
 
         when(mockExamSegmentService.findExamSegments(examId)).thenReturn(Arrays.asList(examSegment, examSegment2));
@@ -117,7 +120,8 @@ public class ExamSegmentWrapperServiceImplTest {
             .withSegmentKey("segmentKey")
             .withPagePosition(1)
             .build(),
-            Collections.emptyList());
+            Collections.emptyList(),
+            true);
 
         when(mockExamSegmentService.findByExamIdAndSegmentPosition(examId, 1)).thenReturn(Optional.of(examSegment));
         when(mockExamPageWrapperService.findPagesForExamSegment(examId, examSegment.getSegmentKey())).thenReturn(Collections.singletonList(examPageWrapper));
@@ -172,7 +176,7 @@ public class ExamSegmentWrapperServiceImplTest {
     @Test
     public void shouldReturnExamSegmentWrapperByExamIdAndPageNumber() {
         UUID examId = UUID.randomUUID();
-        ExamPageWrapper examPageWrapper = new ExamPageWrapper(new ExamPageBuilder().withSegmentKey("segmentKey").build(), Collections.emptyList());
+        ExamPageWrapper examPageWrapper = new ExamPageWrapper(new ExamPageBuilder().withSegmentKey("segmentKey").build(), Collections.emptyList(), true);
         ExamSegment examSegment = new ExamSegmentBuilder().withSegmentKey("segmentKey").build();
 
         when(mockExamPageWrapperService.findPageWithItems(examId, 2)).thenReturn(Optional.of(examPageWrapper));
@@ -196,7 +200,7 @@ public class ExamSegmentWrapperServiceImplTest {
     @Test(expected = IllegalStateException.class)
     public void shouldThrowWhenExamSegmentCannotBeFoundForExamPage() {
         UUID examId = UUID.randomUUID();
-        ExamPageWrapper examPageWrapper = new ExamPageWrapper(new ExamPageBuilder().withSegmentKey("segmentKey").build(), Collections.emptyList());
+        ExamPageWrapper examPageWrapper = new ExamPageWrapper(new ExamPageBuilder().withSegmentKey("segmentKey").build(), Collections.emptyList(), true);
         ExamSegment examSegment = new ExamSegmentBuilder().withSegmentKey("bogusKey").build();
 
         when(mockExamPageWrapperService.findPageWithItems(examId, 2)).thenReturn(Optional.of(examPageWrapper));

--- a/service/src/test/java/tds/exam/services/impl/ExamServiceImplTest.java
+++ b/service/src/test/java/tds/exam/services/impl/ExamServiceImplTest.java
@@ -40,6 +40,10 @@ import tds.exam.ExamApproval;
 import tds.exam.ExamAssessmentMetadata;
 import tds.exam.ExamConfiguration;
 import tds.exam.ExamInfo;
+import tds.exam.ExamItem;
+import tds.exam.ExamItemResponse;
+import tds.exam.ExamPage;
+import tds.exam.ExamSegment;
 import tds.exam.ExamStatusCode;
 import tds.exam.ExamStatusStage;
 import tds.exam.ExamineeContext;
@@ -48,6 +52,8 @@ import tds.exam.SegmentApprovalRequest;
 import tds.exam.builder.AssessmentBuilder;
 import tds.exam.builder.ExamAccommodationBuilder;
 import tds.exam.builder.ExamBuilder;
+import tds.exam.builder.ExamItemBuilder;
+import tds.exam.builder.ExamItemResponseBuilder;
 import tds.exam.builder.ExternalSessionConfigurationBuilder;
 import tds.exam.builder.OpenExamRequestBuilder;
 import tds.exam.builder.SessionBuilder;
@@ -63,12 +69,15 @@ import tds.exam.services.ExamApprovalService;
 import tds.exam.services.ExamItemService;
 import tds.exam.services.ExamPageService;
 import tds.exam.services.ExamSegmentService;
+import tds.exam.services.ExamSegmentWrapperService;
 import tds.exam.services.ExamService;
 import tds.exam.services.ExamineeService;
 import tds.exam.services.SessionService;
 import tds.exam.services.StudentService;
 import tds.exam.services.TimeLimitConfigurationService;
 import tds.exam.utils.ExamStatusChangeValidator;
+import tds.exam.wrapper.ExamPageWrapper;
+import tds.exam.wrapper.ExamSegmentWrapper;
 import tds.session.ExternalSessionConfiguration;
 import tds.session.Session;
 import tds.session.SessionAssessment;
@@ -154,6 +163,9 @@ public class ExamServiceImplTest {
     @Mock
     private ExamStatusChangeValidator mockReviewExamStatusChangeValidator;
 
+    @Mock
+    private ExamSegmentWrapperService mockExamSegmentWrapperService;
+
     @Captor
     private ArgumentCaptor<Exam> examArgumentCaptor;
 
@@ -166,6 +178,7 @@ public class ExamServiceImplTest {
             mockSessionService,
             mockStudentService,
             mockExamSegmentService,
+            mockExamSegmentWrapperService,
             mockAssessmentService,
             mockTimeLimitConfigurationService,
             mockConfigService,
@@ -1036,7 +1049,7 @@ public class ExamServiceImplTest {
     }
 
     @Test
-    public void shouldRestartExistingExamOutsideGracePeriodPausedExam() throws InterruptedException {
+    public void shouldResumeExistingExamOutsideGracePeriodPausedExam() throws InterruptedException {
         final String browserUserAgent = "007";
         Session session = new SessionBuilder().build();
         final Instant now = org.joda.time.Instant.now().minus(5000);
@@ -1062,7 +1075,48 @@ public class ExamServiceImplTest {
             .withRequestInterfaceTimeoutMinutes(5)
             .build();
         ExternalSessionConfiguration extSessionConfig = new ExternalSessionConfiguration(exam.getClientName(), SIMULATION_ENVIRONMENT, 0, 0, 0, 0);
+        ExamItem examItem1 = ExamItem.Builder
+            .fromExamItem(new ExamItemBuilder().build())
+            .withPosition(1)
+            .withResponse(new ExamItemResponse.Builder()
+                .fromExamItemResponse(new ExamItemResponseBuilder().build())
+                .withValid(true)
+                .build())
+            .build();
+        ExamItem examItem2 = ExamItem.Builder
+            .fromExamItem(new ExamItemBuilder().build())
+            .withPosition(2)
+            .withResponse(new ExamItemResponse.Builder()
+                .fromExamItemResponse(new ExamItemResponseBuilder().build())
+                .withValid(true)
+                .build())
+            .build();
+        new ExamItem.Builder(UUID.randomUUID());
+        ExamItem examItem3 = ExamItem.Builder
+            .fromExamItem(new ExamItemBuilder().build())
+            .withPosition(3)
+            .withResponse(new ExamItemResponse.Builder()
+                .fromExamItemResponse(new ExamItemResponseBuilder().build())
+                .withValid(false)
+                .build())
+            .build();
 
+        ExamPageWrapper examPageWrapper1 = new ExamPageWrapper(
+            new ExamPage.Builder()
+                .fromExamPage(random(ExamPage.class))
+                .withExamRestartsAndResumptions(5)
+                .build(),
+            Arrays.asList(examItem1, examItem2),
+            true);
+        ExamPageWrapper examPageWrapper2 = new ExamPageWrapper(
+            new ExamPage.Builder()
+                .fromExamPage(random(ExamPage.class))
+                .withExamRestartsAndResumptions(5)
+                .build(),
+            Collections.singletonList(examItem3),
+            true);
+
+        ExamSegmentWrapper examSegmentWrapper = new ExamSegmentWrapper(random(ExamSegment.class), Arrays.asList(examPageWrapper1, examPageWrapper2));
         when(mockSessionService.findExternalSessionConfigurationByClientName(exam.getClientName())).thenReturn(Optional.of(extSessionConfig));
         when(mockExamQueryRepository.getExamById(exam.getId())).thenReturn(Optional.of(exam));
         when(mockExamQueryRepository.findLastStudentActivity(exam.getId())).thenReturn(Optional.of(lastStudentActivityTime));
@@ -1074,6 +1128,7 @@ public class ExamServiceImplTest {
         when(mockExamSegmentService.initializeExamSegments(exam, assessment)).thenReturn(testLength);
         when(mockExamApprovalService.verifyAccess(isA(ExamInfo.class), isA(Exam.class)))
             .thenReturn(Optional.empty());
+        when(mockExamSegmentWrapperService.findAllExamSegments(exam.getId())).thenReturn(Collections.singletonList(examSegmentWrapper));
 
         Response<ExamConfiguration> examConfigurationResponse = examService.startExam(exam.getId(), browserUserAgent);
 
@@ -1083,6 +1138,10 @@ public class ExamServiceImplTest {
         verify(mockTimeLimitConfigurationService).findTimeLimitConfiguration(exam.getClientName(), assessment.getAssessmentId());
         verify(mockExamCommandRepository).update(examArgumentCaptor.capture());
         verify(mockExamQueryRepository).findLastStudentActivity(exam.getId());
+        ArgumentCaptor<ExamPage> varArgs = ArgumentCaptor.forClass(ExamPage.class);
+        verify(mockExamPageService).update(varArgs.capture());
+        List<ExamPage> examPages = varArgs.getAllValues();
+        assertThat(examPages).hasSize(1);
 
         assertThat(examConfigurationResponse.getData().isPresent()).isTrue();
         ExamConfiguration examConfiguration = examConfigurationResponse.getData().get();
@@ -1092,7 +1151,7 @@ public class ExamServiceImplTest {
         assertThat(examConfiguration.getExamRestartWindowMinutes()).isEqualTo(timeLimitConfiguration.getExamRestartWindowMinutes());
         assertThat(examConfiguration.getInterfaceTimeoutMinutes()).isEqualTo(timeLimitConfiguration.getInterfaceTimeoutMinutes());
         assertThat(examConfiguration.getPrefetch()).isEqualTo(assessment.getPrefetch());
-        assertThat(examConfiguration.getStartPosition()).isEqualTo(1);
+        assertThat(examConfiguration.getStartPosition()).isEqualTo(3);
         assertThat(examConfiguration.getTestLength()).isEqualTo(testLength);
 
         // Sleep a bit to prevent intermittent test failures due to timing
@@ -1118,7 +1177,6 @@ public class ExamServiceImplTest {
         final Instant now = org.joda.time.Instant.now();
         final Instant approvedStatusDate = now.minus(5000);
         final Instant lastStudentActivityTime = now.minus(15 * 60 * 1000); // minus 15 minutes, within grace period
-        final int resumePosition = 5;
         final int testLength = 10;
 
         Exam exam = new ExamBuilder()
@@ -1140,6 +1198,48 @@ public class ExamServiceImplTest {
             .build();
         ExternalSessionConfiguration extSessionConfig = new ExternalSessionConfiguration(exam.getClientName(), SIMULATION_ENVIRONMENT, 0, 0, 0, 0);
 
+        ExamItem examItem1 = ExamItem.Builder
+            .fromExamItem(new ExamItemBuilder().build())
+            .withPosition(1)
+            .withResponse(new ExamItemResponse.Builder()
+                .fromExamItemResponse(new ExamItemResponseBuilder().build())
+                .withValid(true)
+                .build())
+            .build();
+        ExamItem examItem2 = ExamItem.Builder
+            .fromExamItem(new ExamItemBuilder().build())
+            .withPosition(2)
+            .withResponse(new ExamItemResponse.Builder()
+                .fromExamItemResponse(new ExamItemResponseBuilder().build())
+                .withValid(true)
+                .build())
+            .build();
+        new ExamItem.Builder(UUID.randomUUID());
+        ExamItem examItem3 = ExamItem.Builder
+            .fromExamItem(new ExamItemBuilder().build())
+            .withPosition(3)
+            .withResponse(new ExamItemResponse.Builder()
+                .fromExamItemResponse(new ExamItemResponseBuilder().build())
+                .withValid(false)
+                .build())
+            .build();
+
+        ExamPageWrapper examPageWrapper1 = new ExamPageWrapper(
+            new ExamPage.Builder()
+                .fromExamPage(random(ExamPage.class))
+                .withExamRestartsAndResumptions(5)
+                .build(),
+            Arrays.asList(examItem1, examItem2),
+            true);
+        ExamPageWrapper examPageWrapper2 = new ExamPageWrapper(
+            new ExamPage.Builder()
+                .fromExamPage(random(ExamPage.class))
+                .withExamRestartsAndResumptions(5)
+                .build(),
+            Collections.singletonList(examItem3),
+            true);
+
+        ExamSegmentWrapper examSegmentWrapper = new ExamSegmentWrapper(random(ExamSegment.class), Arrays.asList(examPageWrapper1, examPageWrapper2));
         when(mockSessionService.findExternalSessionConfigurationByClientName(exam.getClientName())).thenReturn(Optional.of(extSessionConfig));
         when(mockExamQueryRepository.getExamById(exam.getId())).thenReturn(Optional.of(exam));
         when(mockExamQueryRepository.findLastStudentActivity(exam.getId())).thenReturn(Optional.of(lastStudentActivityTime));
@@ -1149,10 +1249,9 @@ public class ExamServiceImplTest {
         when(mockTimeLimitConfigurationService.findTimeLimitConfiguration(exam.getClientName(), assessment.getAssessmentId()))
             .thenReturn(Optional.of(timeLimitConfiguration));
         when(mockExamSegmentService.initializeExamSegments(exam, assessment)).thenReturn(testLength);
-        when(mockExamItemService.getExamPosition(exam.getId())).thenReturn(resumePosition);
-        when(mockExamItemService.getExamPosition(exam.getId())).thenReturn(5);
         when(mockExamApprovalService.verifyAccess(isA(ExamInfo.class), isA(Exam.class)))
             .thenReturn(Optional.empty());
+        when(mockExamSegmentWrapperService.findAllExamSegments(exam.getId())).thenReturn(Collections.singletonList(examSegmentWrapper));
 
         Response<ExamConfiguration> examConfigurationResponse = examService.startExam(exam.getId(), browserUserAgent);
 
@@ -1161,9 +1260,14 @@ public class ExamServiceImplTest {
         verify(mockAssessmentService).findAssessment(exam.getClientName(), exam.getAssessmentKey());
         verify(mockTimeLimitConfigurationService).findTimeLimitConfiguration(exam.getClientName(), assessment.getAssessmentId());
         verify(mockExamCommandRepository).update(examArgumentCaptor.capture());
-        verify(mockExamItemService).getExamPosition(exam.getId());
         verify(mockExamQueryRepository).findLastStudentActivity(exam.getId());
-        verify(mockExamItemService).getExamPosition(exam.getId());
+        verify(mockExamSegmentWrapperService).findAllExamSegments(exam.getId());
+
+        ArgumentCaptor<ExamPage> varArgs = ArgumentCaptor.forClass(ExamPage.class);
+        verify(mockExamPageService).update(varArgs.capture());
+
+        List<ExamPage> examPages = varArgs.getAllValues();
+        assertThat(examPages).hasSize(2);
 
         assertThat(examConfigurationResponse.getData().isPresent()).isTrue();
         ExamConfiguration examConfiguration = examConfigurationResponse.getData().get();
@@ -1173,10 +1277,9 @@ public class ExamServiceImplTest {
         assertThat(examConfiguration.getExamRestartWindowMinutes()).isEqualTo(timeLimitConfiguration.getExamRestartWindowMinutes());
         assertThat(examConfiguration.getInterfaceTimeoutMinutes()).isEqualTo(timeLimitConfiguration.getInterfaceTimeoutMinutes());
         assertThat(examConfiguration.getPrefetch()).isEqualTo(assessment.getPrefetch());
-        assertThat(examConfiguration.getStartPosition()).isEqualTo(5);
+        assertThat(examConfiguration.getStartPosition()).isEqualTo(3);
         assertThat(examConfiguration.getTestLength()).isEqualTo(testLength);
 
-        // Sleep a bit to prevent intermittent test failures due to timing
         Exam updatedExam = examArgumentCaptor.getValue();
         assertThat(updatedExam).isNotNull();
         assertThat(updatedExam.getAttempts()).isEqualTo(0);

--- a/service/src/test/java/tds/exam/web/endpoints/ExamSegmentWrapperControllerIntegrationTests.java
+++ b/service/src/test/java/tds/exam/web/endpoints/ExamSegmentWrapperControllerIntegrationTests.java
@@ -66,7 +66,7 @@ public class ExamSegmentWrapperControllerIntegrationTests {
             .withSegmentKey("segmentKey")
             .withPagePosition(1)
             .build(),
-            singletonList(examItem));
+            singletonList(examItem), true);
 
         when(mockExamSegmentWrapperService.findAllExamSegments(examId)).thenReturn(singletonList(new ExamSegmentWrapper(examSegment, singletonList(examPageWrapper))));
 
@@ -110,14 +110,14 @@ public class ExamSegmentWrapperControllerIntegrationTests {
             .withSegmentKey("segmentKey")
             .withPagePosition(1)
             .build(),
-            singletonList(examItem));
+            singletonList(examItem), true);
 
         ExamPageWrapper examPageWrapper2 = new ExamPageWrapper(new ExamPageBuilder()
             .withExamId(examId)
             .withSegmentKey("segmentKey")
             .withPagePosition(1)
             .build(),
-            singletonList(examItem));
+            singletonList(examItem), true);
 
         when(mockExamSegmentWrapperService.findExamSegment(examId, 1)).thenReturn(Optional.of(new ExamSegmentWrapper(examSegment, Arrays.asList(examPageWrapper, examPageWrapper2))));
 
@@ -156,7 +156,7 @@ public class ExamSegmentWrapperControllerIntegrationTests {
             .withSegmentKey("segmentKey")
             .withPagePosition(1)
             .build(),
-            singletonList(examItem));
+            singletonList(examItem), true);
 
         when(mockExamSegmentWrapperService.findExamSegmentWithPageAtPosition(examId, 1, 2)).thenReturn(Optional.of(new ExamSegmentWrapper(examSegment, singletonList(examPageWrapper))));
 


### PR DESCRIPTION
https://jira.fairwaytech.com/browse/TDS-983

This PR includes a number of bugfixes/missing features from the legacy system. With these fixes:
1. A student resuming an exam within the grace period should resume from the position of the last item that was answered. The should be able to access previous pages that were answered previously before the exam was paused.
2. A student resuming an exam outside of the grace period will be placed on the first unanswered item. They will not be able to access previously answered pages.

Some notes:
- Initially while writing /startExam, I was under the impression that resuming outside of the grace period would make the student start the exam from scratch. This is not the case. Instead the exam resumes from the same position it normally would, but prior pages become inaccessible.
- I noticed page duration wasn't being carried over into the database and I fixed this issue while addressing resumes.
- ExamPageWrapper now has an "isVisible" flag that will be used by the student application to determine whether or not the page can be accessed by an exam after a resume. If the exam is restarted outside of the grace period, this value will be "false" for all previously answered pages.
- Added a column to exam_page_event for the attempt restart number (exam_restarts_and_resumptions). This is the total number of restarts/gracePeriodRestarts. We can consider renaming "restarts" and "restartsAndResumptions" to simply "resumptions"/"gracePeriodResumptions" as there is essentially no such thing as restarting an exam from scratch in TDS (unless the exam is somehow submitted/completed), but I did not make this change part of this PR.