### PR TITLE
TDS-999: Feature/exam page wrapper tuning

### DIFF
--- a/client/src/main/java/tds/exam/ExamItemResponse.java
+++ b/client/src/main/java/tds/exam/ExamItemResponse.java
@@ -14,6 +14,7 @@ import static tds.common.util.Preconditions.checkNotNull;
 public class ExamItemResponse {
     private long id;
     private UUID examItemId;
+    private UUID examId;
     private String response;
     private int sequence;
     private boolean valid;
@@ -31,6 +32,7 @@ public class ExamItemResponse {
     private ExamItemResponse(Builder builder) {
         id = builder.id;
         examItemId = checkNotNull(builder.examItemId);
+        examId = checkNotNull(builder.examId);
         response = checkNotNull(builder.response);
         sequence = builder.sequence;
         valid = builder.valid;
@@ -43,6 +45,7 @@ public class ExamItemResponse {
     public static final class Builder {
         private long id;
         private UUID examItemId;
+        private UUID examId;
         private String response;
         private int sequence;
         private boolean valid;
@@ -51,10 +54,11 @@ public class ExamItemResponse {
         private Instant createdAt;
         private boolean markedForReview;
 
-        public static Builder fromExamItemResponse(ExamItemResponse examItemResponse) {
+        public static Builder fromExamItemResponse(final ExamItemResponse examItemResponse) {
             return new Builder()
                 .withId(examItemResponse.id)
                 .withExamItemId(examItemResponse.examItemId)
+                .withExamId(examItemResponse.examId)
                 .withResponse(examItemResponse.response)
                 .withSequence(examItemResponse.sequence)
                 .withValid(examItemResponse.valid)
@@ -65,22 +69,27 @@ public class ExamItemResponse {
         }
 
 
-        public Builder withId(long id) {
+        public Builder withId(final long id) {
             this.id = id;
             return this;
         }
 
-        public Builder withExamItemId(UUID examItemId) {
+        public Builder withExamItemId(final UUID examItemId) {
             this.examItemId = examItemId;
             return this;
         }
 
-        public Builder withResponse(String response) {
+        public Builder withExamId(final UUID examId) {
+            this.examId = examId;
+            return this;
+        }
+
+        public Builder withResponse(final String response) {
             this.response = checkNotNull(response, "Response cannot be null");
             return this;
         }
 
-        public Builder withSequence(int sequence) {
+        public Builder withSequence(final int sequence) {
             if (sequence < 1) {
                 throw new IllegalArgumentException("Sequence cannot be less than 1");
             }
@@ -89,27 +98,27 @@ public class ExamItemResponse {
             return this;
         }
 
-        public Builder withValid(boolean valid) {
+        public Builder withValid(final boolean valid) {
             this.valid = valid;
             return this;
         }
 
-        public Builder withSelected(boolean selected) {
+        public Builder withSelected(final boolean selected) {
             this.selected = selected;
             return this;
         }
 
-        public Builder withScore(ExamItemResponseScore score) {
+        public Builder withScore(final ExamItemResponseScore score) {
             this.score = score;
             return this;
         }
 
-        public Builder withCreatedAt(Instant createdAt) {
+        public Builder withCreatedAt(final Instant createdAt) {
             this.createdAt = createdAt;
             return this;
         }
 
-        public Builder withMarkedForReview(boolean markedForReview) {
+        public Builder withMarkedForReview(final boolean markedForReview) {
             this.markedForReview = markedForReview;
             return this;
         }
@@ -131,6 +140,13 @@ public class ExamItemResponse {
      */
     public UUID getExamItemId() {
         return examItemId;
+    }
+
+    /**
+     * @return The id of the {@link tds.exam.Exam} this {@link tds.exam.ExamItemResponse} corresponds to
+     */
+    public UUID getExamId() {
+        return examId;
     }
 
     /**

--- a/client/src/test/java/tds/exam/ExamItemResponseTest.java
+++ b/client/src/test/java/tds/exam/ExamItemResponseTest.java
@@ -11,17 +11,20 @@ public class ExamItemResponseTest {
     @Test
     public void shouldBuildAnItemResponse() {
         UUID examId = UUID.randomUUID();
+        UUID examItemId = UUID.randomUUID();
         ExamItemResponse response = new ExamItemResponse.Builder()
             .withId(1L)
             .withResponse("response text")
-            .withExamItemId(examId)
+            .withExamItemId(examItemId)
+            .withExamId(examId)
             .withSequence(1)
             .withCreatedAt(Instant.now().minus(20000))
             .build();
 
         assertThat(response.getId()).isEqualTo(1L);
         assertThat(response.getResponse()).isEqualTo("response text");
-        assertThat(response.getExamItemId()).isEqualTo(examId);
+        assertThat(response.getExamItemId()).isEqualTo(examItemId);
+        assertThat(response.getExamId()).isEqualTo(examId);
         assertThat(response.getSequence()).isEqualTo(1);
         assertThat(response.getCreatedAt()).isLessThan(Instant.now());
     }

--- a/service/src/main/java/tds/exam/repositories/impl/ExamItemCommandRepositoryImpl.java
+++ b/service/src/main/java/tds/exam/repositories/impl/ExamItemCommandRepositoryImpl.java
@@ -86,6 +86,7 @@ public class ExamItemCommandRepositoryImpl implements ExamItemCommandRepository 
             .map(response -> {
                 MapSqlParameterSource sqlParameterSource =
                     new MapSqlParameterSource("examItemId", response.getExamItemId().toString())
+                        .addValue("examId", response.getExamId().toString())
                         .addValue("response", response.getResponse())
                         .addValue("sequence", response.getSequence())
                         .addValue("isValid", response.isValid())
@@ -123,6 +124,7 @@ public class ExamItemCommandRepositoryImpl implements ExamItemCommandRepository 
         final String SQL =
             "INSERT INTO exam_item_response ( \n" +
                 "   exam_item_id, \n" +
+                "   exam_id, \n" +
                 "   response, \n" +
                 "   sequence, \n" +
                 "   is_valid, \n" +
@@ -139,6 +141,7 @@ public class ExamItemCommandRepositoryImpl implements ExamItemCommandRepository 
                 "   scored_at) \n" +
                 "VALUES ( \n" +
                 "   :examItemId, \n" +
+                "   :examId, \n" +
                 "   :response, \n" +
                 "   :sequence, \n" +
                 "   :isValid, \n" +

--- a/service/src/main/java/tds/exam/repositories/impl/ExamItemQueryRepositoryImpl.java
+++ b/service/src/main/java/tds/exam/repositories/impl/ExamItemQueryRepositoryImpl.java
@@ -9,12 +9,6 @@ import org.springframework.jdbc.core.namedparam.MapSqlParameterSource;
 import org.springframework.jdbc.core.namedparam.NamedParameterJdbcTemplate;
 import org.springframework.jdbc.core.namedparam.SqlParameterSource;
 import org.springframework.stereotype.Repository;
-import tds.common.data.mapping.ResultSetMapperUtility;
-import tds.exam.ExamItem;
-import tds.exam.ExamItemResponse;
-import tds.exam.ExamItemResponseScore;
-import tds.exam.ExamScoringStatus;
-import tds.exam.repositories.ExamItemQueryRepository;
 
 import java.sql.ResultSet;
 import java.sql.SQLException;
@@ -25,6 +19,13 @@ import java.util.Map;
 import java.util.Optional;
 import java.util.UUID;
 import java.util.stream.Collectors;
+
+import tds.common.data.mapping.ResultSetMapperUtility;
+import tds.exam.ExamItem;
+import tds.exam.ExamItemResponse;
+import tds.exam.ExamItemResponseScore;
+import tds.exam.ExamScoringStatus;
+import tds.exam.repositories.ExamItemQueryRepository;
 
 @Repository
 public class ExamItemQueryRepositoryImpl implements ExamItemQueryRepository {
@@ -187,6 +188,7 @@ public class ExamItemQueryRepositoryImpl implements ExamItemQueryRepository {
             "  I.created_at, \n" +
             "  I.group_id, \n" +
             "  R.id as responseId,\n" +
+            "  R.exam_id AS examId, \n" +
             "  R.response,\n" +
             "  R.sequence,\n" +
             "  R.is_valid,\n" +
@@ -246,7 +248,7 @@ public class ExamItemQueryRepositoryImpl implements ExamItemQueryRepository {
                 .withGroupId(rs.getString("group_id"))
                 .withItemFilePath(rs.getString("item_file_path"));
 
-            if(rs.getObject("stimulus_file_path") != null) {
+            if (rs.getObject("stimulus_file_path") != null) {
                 itemBuilder.withStimulusFilePath(rs.getString("stimulus_file_path"));
             }
 
@@ -255,6 +257,7 @@ public class ExamItemQueryRepositoryImpl implements ExamItemQueryRepository {
                 ExamItemResponse.Builder responseBuilder = new ExamItemResponse.Builder()
                     .withId(rs.getLong("responseId"))
                     .withExamItemId(UUID.fromString(rs.getString("examItemId")))
+                    .withExamId(UUID.fromString(rs.getString("examId")))
                     .withResponse(rs.getString("response"))
                     .withSequence(rs.getInt("sequence"))
                     .withSelected(rs.getBoolean("is_selected"))

--- a/service/src/main/java/tds/exam/repositories/impl/ExamPageCommandRepositoryImpl.java
+++ b/service/src/main/java/tds/exam/repositories/impl/ExamPageCommandRepositoryImpl.java
@@ -70,11 +70,13 @@ public class ExamPageCommandRepositoryImpl implements ExamPageCommandRepository 
             "INSERT INTO \n" +
                 "exam_page_event (\n" +
                 "   exam_page_id, \n" +
+                "   exam_id, \n" +
                 "   deleted_at, \n" +
                 "   started_at, \n" +
                 "   created_at) \n" +
                 "SELECT \n" +
                 "   exam_page_id, \n" +
+                "   exam_id, \n" +
                 "   UTC_TIMESTAMP(), \n" +
                 "   started_at, \n " +
                 "   UTC_TIMESTAMP() \n" +
@@ -94,11 +96,23 @@ public class ExamPageCommandRepositoryImpl implements ExamPageCommandRepository 
     public void update(final ExamPage... examPages) {
         final Timestamp createdAt = mapJodaInstantToTimestamp(Instant.now());
         final String updatePageSQL =
-            "INSERT INTO exam_page_event (exam_page_id, deleted_at, started_at, created_at) \n" +
-                "VALUES (:examPageId, :deletedAt, :startedAt, :createdAt)";
+            "INSERT INTO \n" +
+                "exam_page_event (\n" +
+                "   exam_page_id, \n" +
+                "   exam_id, \n" +
+                "   deleted_at, \n" +
+                "   started_at, \n" +
+                "   created_at) \n" +
+                "VALUES ( \n" +
+                "   :examPageId, \n" +
+                "   :examId, \n" +
+                "   :deletedAt, \n" +
+                "   :startedAt, \n" +
+                "   :createdAt)";
 
         SqlParameterSource[] parameters = Stream.of(examPages).map(examPage ->
             new MapSqlParameterSource("examPageId", examPage.getId().toString())
+                .addValue("examId", examPage.getExamId())
                 .addValue("startedAt", mapJodaInstantToTimestamp(examPage.getStartedAt()))
                 .addValue("deletedAt", mapJodaInstantToTimestamp(examPage.getDeletedAt()))
                 .addValue("createdAt", createdAt))

--- a/service/src/main/java/tds/exam/repositories/impl/ExamPageCommandRepositoryImpl.java
+++ b/service/src/main/java/tds/exam/repositories/impl/ExamPageCommandRepositoryImpl.java
@@ -75,10 +75,10 @@ public class ExamPageCommandRepositoryImpl implements ExamPageCommandRepository 
                 "   started_at, \n" +
                 "   created_at) \n" +
                 "SELECT \n" +
-                "   exam_page_id, \n" +
-                "   exam_id, \n" +
+                "   PE.exam_page_id, \n" +
+                "   PE.exam_id, \n" +
                 "   UTC_TIMESTAMP(), \n" +
-                "   started_at, \n " +
+                "   PE.started_at, \n " +
                 "   UTC_TIMESTAMP() \n" +
                 "FROM \n" +
                 "   exam_page_event PE\n" +
@@ -112,7 +112,7 @@ public class ExamPageCommandRepositoryImpl implements ExamPageCommandRepository 
 
         SqlParameterSource[] parameters = Stream.of(examPages).map(examPage ->
             new MapSqlParameterSource("examPageId", examPage.getId().toString())
-                .addValue("examId", examPage.getExamId())
+                .addValue("examId", examPage.getExamId().toString())
                 .addValue("startedAt", mapJodaInstantToTimestamp(examPage.getStartedAt()))
                 .addValue("deletedAt", mapJodaInstantToTimestamp(examPage.getDeletedAt()))
                 .addValue("createdAt", createdAt))

--- a/service/src/main/java/tds/exam/repositories/impl/ExamPageWrapperQueryRepositoryImpl.java
+++ b/service/src/main/java/tds/exam/repositories/impl/ExamPageWrapperQueryRepositoryImpl.java
@@ -100,7 +100,7 @@ public class ExamPageWrapperQueryRepositoryImpl implements ExamPageWrapperQueryR
         "   WHERE \n" +
         "       exam_id = :examId \n" +
         "   GROUP BY \n" +
-        "       exam_item_id DESC) most_recent_response \n" +
+        "       exam_item_id) most_recent_response \n" +
         "   ON item.id = most_recent_response.exam_item_id \n" +
         "LEFT JOIN \n" +
         "   exam_item_response response \n" +

--- a/service/src/main/java/tds/exam/repositories/impl/ExamPageWrapperQueryRepositoryImpl.java
+++ b/service/src/main/java/tds/exam/repositories/impl/ExamPageWrapperQueryRepositoryImpl.java
@@ -72,16 +72,17 @@ public class ExamPageWrapperQueryRepositoryImpl implements ExamPageWrapperQueryR
         "   exam_page page \n" +
         "JOIN ( \n" +
         "   SELECT \n" +
-        "       exam_page_id, \n" +
-        "       MAX(id) AS id \n" +
+        "       MAX(id) AS id, \n" +
+        "       exam_page_id \n" +
         "   FROM \n" +
         "       exam_page_event \n" +
+        "   WHERE \n" +
+        "       exam_id = :examId \n" +
         "   GROUP BY \n" +
-        "       exam_page_id \n" +
-        ") last_page_event \n" +
+        "       exam_page_id) last_page_event \n" +
         "   ON page.id = last_page_event.exam_page_id \n" +
         "JOIN \n" +
-        "   exam_page_event page_event \n" +
+        "   exam_page_event AS page_event \n" +
         "   ON page_event.id = last_page_event.id \n" +
         "JOIN \n" +
         "   exam_segment segment \n" +
@@ -90,19 +91,20 @@ public class ExamPageWrapperQueryRepositoryImpl implements ExamPageWrapperQueryR
         "JOIN \n" +
         "   exam_item item \n" +
         "   ON page.id = item.exam_page_id \n" +
-        "LEFT JOIN \n" +
-        "   (SELECT \n" +
-        "       exam_item_id, \n" +
-        "       MAX(id) AS id\n" +
+        "LEFT JOIN (" +
+        "   SELECT \n" +
+        "       MAX(id) AS id, \n" +
+        "       exam_item_id \n" +
         "   FROM \n" +
         "       exam_item_response \n" +
+        "   WHERE \n" +
+        "       exam_id = :examId \n" +
         "   GROUP BY \n" +
-        "       exam_item_id) most_recent_response \n" +
+        "       exam_item_id DESC) most_recent_response \n" +
         "   ON item.id = most_recent_response.exam_item_id \n" +
         "LEFT JOIN \n" +
         "   exam_item_response response \n" +
         "   ON most_recent_response.id = response.id \n";
-
 
     @Autowired
     public ExamPageWrapperQueryRepositoryImpl(@Qualifier("queryJdbcTemplate") final NamedParameterJdbcTemplate jdbcTemplate) {
@@ -118,9 +120,7 @@ public class ExamPageWrapperQueryRepositoryImpl implements ExamPageWrapperQueryR
             EXAM_PAGE_WRAPPER_WITH_ITEM_SELECT +
                 "WHERE \n" +
                 "   page.exam_id = :examId \n" +
-                "   AND page.page_position = :position \n" +
-                "ORDER BY \n" +
-                "   item.position";
+                "   AND page.page_position = :position";
 
         List<ExamPageWrapper> examPageWrappers = jdbcTemplate.query(SQL, parameters, examPageResultExtractor);
 
@@ -138,9 +138,7 @@ public class ExamPageWrapperQueryRepositoryImpl implements ExamPageWrapperQueryR
         final String SQL =
             EXAM_PAGE_WRAPPER_WITH_ITEM_SELECT +
                 "WHERE \n" +
-                "   page.exam_id = :examId \n" +
-                "ORDER BY \n" +
-                "   item.position";
+                "   page.exam_id = :examId";
 
         return jdbcTemplate.query(SQL, parameters, examPageResultExtractor);
     }
@@ -154,9 +152,7 @@ public class ExamPageWrapperQueryRepositoryImpl implements ExamPageWrapperQueryR
             EXAM_PAGE_WRAPPER_WITH_ITEM_SELECT +
                 "WHERE \n" +
                 "   page.exam_id = :examId \n" +
-                "   AND page.segment_key = :segmentKey \n" +
-                "ORDER BY \n" +
-                "   item.position";
+                "   AND page.segment_key = :segmentKey";
 
         return jdbcTemplate.query(SQL, parameters, examPageResultExtractor);
     }
@@ -189,6 +185,7 @@ public class ExamPageWrapperQueryRepositoryImpl implements ExamPageWrapperQueryR
                 if (resultExtractor.getString("response") != null) {
                     response = new ExamItemResponse.Builder()
                         .withExamItemId(UUID.fromString(resultExtractor.getString("item_id")))
+                        .withExamId(UUID.fromString(resultExtractor.getString("exam_id")))
                         .withResponse(resultExtractor.getString("response"))
                         .withSequence(resultExtractor.getInt("sequence"))
                         .withValid(resultExtractor.getBoolean("is_valid"))

--- a/service/src/main/java/tds/exam/services/impl/ExamItemServiceImpl.java
+++ b/service/src/main/java/tds/exam/services/impl/ExamItemServiceImpl.java
@@ -120,6 +120,7 @@ public class ExamItemServiceImpl implements ExamItemService {
             // If the item has no response yet, mark the item and create an "empty" response
             examItemCommandRepository.insertResponses(new ExamItemResponse.Builder()
                 .withExamItemId(examItem.getId())
+                .withExamId(examId)
                 .withResponse("")
                 .withMarkedForReview(mark)
                 .withSequence(1)

--- a/service/src/main/resources/db/migration/V1495156051__exam_exam_page_wrapper_updates.sql
+++ b/service/src/main/resources/db/migration/V1495156051__exam_exam_page_wrapper_updates.sql
@@ -1,0 +1,55 @@
+/***********************************************************************************************************************
+  File: V1495156051__exam_exam_page_wrapper_updates.sql
+
+  Desc: Schema modification to tune the exam database for performance.
+
+***********************************************************************************************************************/
+USE exam;
+
+-- ----------------------------------------------------------------------------
+-- Add exam_id to exam_page_event table
+-- ----------------------------------------------------------------------------
+ALTER TABLE exam.exam_page_event
+	ADD exam_id CHAR(36) NOT NULL AFTER exam_page_id;
+
+-- Populate w/existing data
+UPDATE
+  exam.exam_page_event
+JOIN
+  exam.exam_page
+	ON exam.exam_page.id = exam.exam_page_event.exam_page_id
+SET
+  exam.exam_page_event.exam_id = exam_page.exam_id;
+
+ALTER TABLE exam.exam_page_event
+	ADD CONSTRAINT fk_exam_page_event_exam_id
+    FOREIGN KEY (exam_id) REFERENCES exam(id);
+
+CREATE INDEX ix_exam_page_event_id_exam_id ON exam.exam_page_event(id, exam_id);
+
+-- ----------------------------------------------------------------------------
+-- Add exam_id to exam_item_response table
+-- ----------------------------------------------------------------------------
+ALTER TABLE exam.exam_item_response
+	ADD exam_id CHAR(36) NOT NULL AFTER exam_item_id;
+
+-- Populate w/existing data
+UPDATE
+	exam.exam_item_response AS response
+JOIN
+	exam_item AS item
+	ON item.id = response.exam_item_id
+JOIN
+	exam_page AS page
+    ON page.id = item.exam_page_id
+JOIN
+	exam AS exam
+    ON exam.id = page.exam_id
+SET
+	response.exam_id = exam.id;
+
+ALTER TABLE exam.exam_item_response
+	ADD CONSTRAINT fk_exam_item_response_exam_id
+		FOREIGN KEY (exam_id) REFERENCES exam(id);
+
+CREATE INDEX ix_exam_item_response_exam_id ON exam.exam_item_response(exam_id);

--- a/service/src/main/resources/db/migration/V1495156051__exam_exam_page_wrapper_updates.sql
+++ b/service/src/main/resources/db/migration/V1495156051__exam_exam_page_wrapper_updates.sql
@@ -12,7 +12,7 @@ USE exam;
 ALTER TABLE exam.exam_page_event
 	ADD exam_id CHAR(36) NOT NULL AFTER exam_page_id;
 
--- Populate w/existing data
+-- Migrate existing data
 UPDATE
   exam.exam_page_event
 JOIN
@@ -25,7 +25,8 @@ ALTER TABLE exam.exam_page_event
 	ADD CONSTRAINT fk_exam_page_event_exam_id
     FOREIGN KEY (exam_id) REFERENCES exam(id);
 
-CREATE INDEX ix_exam_page_event_id_exam_id ON exam.exam_page_event(id, exam_id);
+CREATE UNIQUE INDEX ix_exam_page_event_id_exam_id ON exam.exam_page_event(id, exam_id);
+CREATE INDEX ix_exam_page_event_exam_id_exam_page_id ON exam.exam_page_event(exam_id, exam_page_id);
 
 -- ----------------------------------------------------------------------------
 -- Add exam_id to exam_item_response table
@@ -33,7 +34,7 @@ CREATE INDEX ix_exam_page_event_id_exam_id ON exam.exam_page_event(id, exam_id);
 ALTER TABLE exam.exam_item_response
 	ADD exam_id CHAR(36) NOT NULL AFTER exam_item_id;
 
--- Populate w/existing data
+-- Migrate existing data
 UPDATE
 	exam.exam_item_response AS response
 JOIN
@@ -53,3 +54,4 @@ ALTER TABLE exam.exam_item_response
 		FOREIGN KEY (exam_id) REFERENCES exam(id);
 
 CREATE INDEX ix_exam_item_response_exam_id ON exam.exam_item_response(exam_id);
+CREATE INDEX ix_exam_item_response_exam_id_exam_item_id ON exam.exam_item_response(exam_id, exam_item_id);

--- a/service/src/test/java/tds/exam/builder/ExamItemResponseBuilder.java
+++ b/service/src/test/java/tds/exam/builder/ExamItemResponseBuilder.java
@@ -15,6 +15,7 @@ public class ExamItemResponseBuilder {
 
     private long id = DEFAULT_ID;
     private UUID examItemId = UUID.randomUUID();
+    private UUID examId = UUID.randomUUID();
     private String response = "response text";
     private int sequence = 1;
     private boolean selected;
@@ -26,6 +27,7 @@ public class ExamItemResponseBuilder {
         return new ExamItemResponse.Builder()
             .withId(id)
             .withExamItemId(examItemId)
+            .withExamId(examId)
             .withResponse(response)
             .withSequence(sequence)
             .withSelected(selected)
@@ -35,42 +37,47 @@ public class ExamItemResponseBuilder {
             .build();
     }
 
-    public ExamItemResponseBuilder withId(long id) {
+    public ExamItemResponseBuilder withId(final long id) {
         this.id = id;
         return this;
     }
 
-    public ExamItemResponseBuilder withExamItemId(UUID examItemId) {
+    public ExamItemResponseBuilder withExamItemId(final UUID examItemId) {
         this.examItemId = examItemId;
         return this;
     }
 
-    public ExamItemResponseBuilder withResponse(String response) {
+    public ExamItemResponseBuilder withExamId(final UUID examId) {
+        this.examId = examId;
+        return this;
+    }
+
+    public ExamItemResponseBuilder withResponse(final String response) {
         this.response = response;
         return this;
     }
 
-    public ExamItemResponseBuilder withSequence(int sequence) {
+    public ExamItemResponseBuilder withSequence(final int sequence) {
         this.sequence = sequence;
         return this;
     }
 
-    public ExamItemResponseBuilder withSelected(boolean selected) {
+    public ExamItemResponseBuilder withSelected(final boolean selected) {
         this.selected = selected;
         return this;
     }
 
-    public ExamItemResponseBuilder withValid(boolean valid) {
+    public ExamItemResponseBuilder withValid(final boolean valid) {
         this.valid = valid;
         return this;
     }
 
-    public ExamItemResponseBuilder withScore(ExamItemResponseScore score) {
+    public ExamItemResponseBuilder withScore(final ExamItemResponseScore score) {
         this.score = score;
         return this;
     }
 
-    public ExamItemResponseBuilder withCreatedAt(Instant createdAt) {
+    public ExamItemResponseBuilder withCreatedAt(final Instant createdAt) {
         this.createdAt = createdAt;
         return this;
     }

--- a/service/src/test/java/tds/exam/repositories/impl/ExamDataGenerator.java
+++ b/service/src/test/java/tds/exam/repositories/impl/ExamDataGenerator.java
@@ -137,6 +137,7 @@ public class ExamDataGenerator {
 
                     final ExamItemResponse response = new ExamItemResponse.Builder()
                         .withExamItemId(items[i].getId())
+                        .withExamId(exam.getId())
                         .withResponse(String.format("response for item %s", items[i].getId()))
                         .withSequence(i + 1)
                         .withValid(true)

--- a/service/src/test/java/tds/exam/repositories/impl/ExamItemCommandRepositoryImplIntegrationTests.java
+++ b/service/src/test/java/tds/exam/repositories/impl/ExamItemCommandRepositoryImplIntegrationTests.java
@@ -104,6 +104,7 @@ public class ExamItemCommandRepositoryImplIntegrationTests {
 
         ExamItemResponse response = new ExamItemResponseBuilder()
             .withExamItemId(savedExamItem.getId())
+            .withExamId(mockExam.getId())
             .build();
 
         examItemCommandRepository.insertResponses(response);
@@ -127,10 +128,14 @@ public class ExamItemCommandRepositoryImplIntegrationTests {
                 "VALUES (:examId, 'segment-key-1', 'segment-id-1', 1, UTC_TIMESTAMP() )";
         final String insertPageSQL =
             "INSERT INTO exam_page (id, page_position, segment_key, item_group_key, exam_id, created_at) " +
-                "VALUES (805, 1, 'segment-key-1', 'GroupKey1', :examId, UTC_TIMESTAMP()), (806, 2, 'segment-key-1', 'GroupKey2', :examId, UTC_TIMESTAMP())";
+                "VALUES " +
+                "(805, 1, 'segment-key-1', 'GroupKey1', :examId, UTC_TIMESTAMP()), " +
+                "(806, 2, 'segment-key-1', 'GroupKey2', :examId, UTC_TIMESTAMP())";
         final String insertPageEventSQL = // Create two pages, second page is deleted
-            "INSERT INTO exam_page_event (exam_page_id, started_at, deleted_at, created_at) " +
-                "VALUES (805, now(), NULL, UTC_TIMESTAMP()), (806, UTC_TIMESTAMP(), UTC_TIMESTAMP(), UTC_TIMESTAMP())";
+            "INSERT INTO exam_page_event (exam_page_id, exam_id, started_at, deleted_at, created_at) " +
+                "VALUES " +
+                "(805, :examId, now(), NULL, UTC_TIMESTAMP()), " +
+                "(806, :examId, UTC_TIMESTAMP(), UTC_TIMESTAMP(), UTC_TIMESTAMP())";
         final String insertItemSQL = // Two items on first page, 1 item on deleted (second) page
             "INSERT INTO exam_item (id, item_key, assessment_item_bank_key, assessment_item_key, item_type, exam_page_id, position, item_file_Path, created_at, group_id)" +
                 "VALUES " +
@@ -145,6 +150,7 @@ public class ExamItemCommandRepositoryImplIntegrationTests {
 
         ExamItemResponse examItem1Response = new ExamItemResponseBuilder()
             .withExamItemId(item1Id)
+            .withExamId(exam.getId())
             .withResponse("response1")
             .withSequence(1)
             .withScore(new ExamItemResponseScoreBuilder()
@@ -158,12 +164,14 @@ public class ExamItemCommandRepositoryImplIntegrationTests {
 
         ExamItemResponse examItem2Response = new ExamItemResponseBuilder()
             .withExamItemId(item2Id)
+            .withExamId(exam.getId())
             .withResponse("response2")
             .withSequence(2)
             .build();
 
         ExamItemResponse examDeletedItemResponse = new ExamItemResponseBuilder()
             .withExamItemId(item3Id)
+            .withExamId(exam.getId())
             .withResponse("response3")
             .withSequence(3)
             .build();

--- a/service/src/test/java/tds/exam/repositories/impl/ExamItemQueryRepositoryImplIntegrationTests.java
+++ b/service/src/test/java/tds/exam/repositories/impl/ExamItemQueryRepositoryImplIntegrationTests.java
@@ -34,7 +34,6 @@ import tds.exam.repositories.ExamItemQueryRepository;
 import tds.exam.repositories.ExamPageCommandRepository;
 import tds.exam.repositories.ExamSegmentCommandRepository;
 
-import static io.github.benas.randombeans.api.EnhancedRandom.random;
 import static org.assertj.core.api.Assertions.assertThat;
 
 @RunWith(SpringJUnit4ClassRunner.class)
@@ -84,6 +83,7 @@ public class ExamItemQueryRepositoryImplIntegrationTests {
         ExamItemResponse examItemResponse = new ExamItemResponse.Builder()
             .withResponse("test")
             .withExamItemId(examItem.getId())
+            .withExamId(mockExam.getId())
             .withSelected(false)
             .withSequence(1)
             .withMarkedForReview(true)
@@ -128,6 +128,7 @@ public class ExamItemQueryRepositoryImplIntegrationTests {
         assertThat(response.getScore().isPresent()).isTrue();
         assertThat(response.isMarkedForReview()).isTrue();
         assertThat(response.getExamItemId()).isEqualTo(fetchedItem.getId());
+        assertThat(response.getExamId()).isEqualTo(examItemResponse.getExamId());
         assertThat(response.getCreatedAt()).isLessThanOrEqualTo(Instant.now());
 
         ExamItemResponseScore score = response.getScore().get();
@@ -195,6 +196,7 @@ public class ExamItemQueryRepositoryImplIntegrationTests {
         ExamItemResponse examItemResponse = new ExamItemResponse.Builder()
             .withResponse("test")
             .withExamItemId(examItem.getId())
+            .withExamId(mockExam.getId())
             .withSelected(false)
             .withSequence(1)
             .withMarkedForReview(true)
@@ -267,22 +269,27 @@ public class ExamItemQueryRepositoryImplIntegrationTests {
 
         ExamItemResponse item1Response1 = new ExamItemResponse.Builder()
             .withExamItemId(examItem1.getId())
+            .withExamId(mockExam.getId())
             .withResponse("response1")
             .build();
         ExamItemResponse item1Response2 = new ExamItemResponse.Builder()
             .withExamItemId(examItem1.getId())
+            .withExamId(mockExam.getId())
             .withResponse("response2")
             .build();
         ExamItemResponse item2Response1 = new ExamItemResponse.Builder()
             .withExamItemId(examItem2.getId())
+            .withExamId(mockExam.getId())
             .withResponse("response1")
             .build();
         ExamItemResponse item2Response2 = new ExamItemResponse.Builder()
             .withExamItemId(examItem2.getId())
+            .withExamId(mockExam.getId())
             .withResponse("response2")
             .build();
         ExamItemResponse item2Response3 = new ExamItemResponse.Builder()
             .withExamItemId(examItem2.getId())
+            .withExamId(mockExam.getId())
             .withResponse("response3")
             .build();
 

--- a/service/src/test/java/tds/exam/repositories/impl/ExamItemRepositoryIntegrationTests.java
+++ b/service/src/test/java/tds/exam/repositories/impl/ExamItemRepositoryIntegrationTests.java
@@ -85,6 +85,7 @@ public class ExamItemRepositoryIntegrationTests {
 
         ExamItemResponse examItemResponse = new ExamItemResponseBuilder()
             .withExamItemId(examItem.getId())
+            .withExamId(exam.getId())
             .withSequence(2)
             .build();
 
@@ -111,6 +112,7 @@ public class ExamItemRepositoryIntegrationTests {
 
         ExamItemResponse examItemResponse2 = new ExamItemResponseBuilder()
             .withExamItemId(examItem.getId())
+            .withExamId(exam.getId())
             .withSequence(2)
             .build();
 
@@ -192,23 +194,28 @@ public class ExamItemRepositoryIntegrationTests {
         // Exam 1
         ExamItemResponse exam1Item1Response = new ExamItemResponseBuilder()
             .withExamItemId(exam1Item1.getId())
+            .withExamId(exam1.getId())
             .withSequence(2)
             .build();
         ExamItemResponse exam1Item2Response1 = new ExamItemResponseBuilder()
             .withExamItemId(exam1Item2.getId())
+            .withExamId(exam1.getId())
             .withSequence(1)
             .build();
         ExamItemResponse exam1Item2Response2 = new ExamItemResponseBuilder()
             .withExamItemId(exam1Item2.getId())
+            .withExamId(exam1.getId())
             .withSequence(3)
             .build();
         // Exam 2
         ExamItemResponse exam2Item1Response1 = new ExamItemResponseBuilder()
             .withExamItemId(exam2Item1.getId())
+            .withExamId(exam2.getId())
             .withSequence(1)
             .build();
         ExamItemResponse exam2Item1Response2 = new ExamItemResponseBuilder()
             .withExamItemId(exam2Item1.getId())
+            .withExamId(exam2.getId())
             .withSequence(2)
             .build();
 

--- a/service/src/test/java/tds/exam/repositories/impl/ExamPageWrapperQueryRepositoryIntegrationTests.java
+++ b/service/src/test/java/tds/exam/repositories/impl/ExamPageWrapperQueryRepositoryIntegrationTests.java
@@ -112,6 +112,7 @@ public class ExamPageWrapperQueryRepositoryIntegrationTests {
         // ...and responds to the first item
         ExamItemResponse mockResponseForFirstItem = new ExamItemResponseBuilder()
             .withExamItemId(wrapper.getExamItems().get(0).getId())
+            .withExamId(mockExam.getId())
             .withResponse("first item response")
             .withSequence(1)
             .build();
@@ -178,6 +179,7 @@ public class ExamPageWrapperQueryRepositoryIntegrationTests {
         // Mark for review
         examItemCommandRepository.insertResponses(new ExamItemResponse.Builder()
             .withExamItemId(otherExamItem.getId())
+            .withExamId(mockExam.getId())
             .withMarkedForReview(true)
             .withResponse("")
             .withSequence(1)

--- a/service/src/test/java/tds/exam/repositories/impl/ExamPrintRequestRepositoryIntegrationTests.java
+++ b/service/src/test/java/tds/exam/repositories/impl/ExamPrintRequestRepositoryIntegrationTests.java
@@ -118,6 +118,7 @@ public class ExamPrintRequestRepositoryIntegrationTests {
         ExamItemResponse examItemResponse1 = new ExamItemResponseBuilder()
             .withCreatedAt(Instant.now().minus(20000))
             .withExamItemId(itemWithResponses.getId())
+            .withExamId(exam.getId())
             .withSequence(1)
             .build();
 
@@ -125,6 +126,7 @@ public class ExamPrintRequestRepositoryIntegrationTests {
 
         ExamItemResponse examItemResponse2 = new ExamItemResponseBuilder()
             .withExamItemId(itemWithResponses.getId())
+            .withExamId(exam.getId())
             .withSequence(1)
             .build();
 

--- a/service/src/test/java/tds/exam/repositories/impl/ExamQueryRepositoryImplIntegrationTests.java
+++ b/service/src/test/java/tds/exam/repositories/impl/ExamQueryRepositoryImplIntegrationTests.java
@@ -311,15 +311,15 @@ public class ExamQueryRepositoryImplIntegrationTests {
             "INSERT INTO exam_page (id, page_position, segment_key, item_group_key, exam_id, created_at) " +
                 "VALUES (805, 1, 'segment-key-1', 'GroupKey1', :examId, :pageCreatedAt)";
         final String insertPageEventSQL =
-            "INSERT INTO exam_page_event (exam_page_id, started_at, created_at) VALUES (805, UTC_TIMESTAMP(), UTC_TIMESTAMP())";
+            "INSERT INTO exam_page_event (exam_page_id, exam_id, started_at, created_at) VALUES (805, :examId, UTC_TIMESTAMP(), UTC_TIMESTAMP())";
         final String insertItemSQL =
             "INSERT INTO exam_item (id, item_key, assessment_item_bank_key, assessment_item_key, item_type, exam_page_id, position, item_file_path, created_at, group_id)" +
                 "VALUES (2112, '187-1234', 187, 1234, 'MS', 805, 1, '/path/to/item/187-1234.xml', UTC_TIMESTAMP(), 'group-123')";
         final String insertResponsesSQL =
-            "INSERT INTO exam_item_response (id, exam_item_id, response, sequence, created_at) " +
+            "INSERT INTO exam_item_response (id, exam_item_id, exam_id, response, sequence, created_at) " +
                 "VALUES " +
-                "(1337, 2112, 'Response 1', 1, :lastResponseSubmittedAt), " +
-                "(1338, 2112, 'Response 2', 1, :earlierResponseSubmittedAt)";
+                "(1337, 2112, :examId, 'Response 1', 1, :lastResponseSubmittedAt), " +
+                "(1338, 2112, :examId, 'Response 2', 1, :earlierResponseSubmittedAt)";
 
         jdbcTemplate.update(insertSegmentSQL, testParams);
         jdbcTemplate.update(insertPageSQL, testParams);

--- a/service/src/test/java/tds/exam/services/impl/ExamItemServiceImplTest.java
+++ b/service/src/test/java/tds/exam/services/impl/ExamItemServiceImplTest.java
@@ -206,6 +206,7 @@ public class ExamItemServiceImplTest {
         ExamItem examItem = new ExamItemBuilder().withId(examItemId)
             .withResponse(new ExamItemResponse.Builder()
                 .withExamItemId(examItemId)
+                .withExamId(examId)
                 .withSequence(3)
                 .withResponse("the response")
                 .withMarkedForReview(false)

--- a/service/src/test/java/tds/exam/services/scoring/ResponseServiceImplTest.java
+++ b/service/src/test/java/tds/exam/services/scoring/ResponseServiceImplTest.java
@@ -107,6 +107,7 @@ public class ResponseServiceImplTest {
             .withScore(new ExamItemResponseScore.Builder().build())
             .withCreatedAt(Instant.now())
             .withExamItemId(UUID.randomUUID())
+            .withExamId(UUID.randomUUID())
             .withResponse("Response")
             .withValid(true)
             .withSequence(1)


### PR DESCRIPTION
[TDS-999](https://jira.fairwaytech.com/browse/TDS-999):  Query performance tuning for the `ExamPageWrapperQueryRepositoryImpl`.
* Added `exam_id` to the `exam_page_event` and `exam_item_response` tables
* Added indexes to help with the grouping of event records
* Removed `ORDER BY` in queries; we're sorting the `ExamPage` and `ExamItem`s in code after we hydrate the objects

With these changes, the execution plan for the `EXAM_PAGE_WRAPPER_WITH_ITEM_SELECT` query using the various predicates is all green.