### PR TITLE
Removing “empty response” condition when deciding where to resume an …

### DIFF
--- a/service/src/main/java/tds/exam/services/impl/ExamServiceImpl.java
+++ b/service/src/main/java/tds/exam/services/impl/ExamServiceImpl.java
@@ -607,8 +607,7 @@ class ExamServiceImpl implements ExamService {
 
     private static boolean isItemUnanswered(final ExamItem examItem) {
         return !examItem.getResponse().isPresent()
-            || (examItem.getResponse().get().getResponse().equals("")
-            && !examItem.getResponse().get().isValid());
+            || !examItem.getResponse().get().isValid();
     }
 
     private Exam initializeExam(final Exam exam, final Assessment assessment, final String browserUserAgent) {


### PR DESCRIPTION
…exam

For grid items, the response value is pre-populated with scoring rubric xml, so this condition was failing for the grid item and assuming the item had been answered. In fact, the legacy code corresponding to this functionality does not look at the response "value", only if it is valid. isValid is set to "true" whenever a student takes an action in responding to an item. This extra conditional would be harmless, except that in the case of grid items, the response is populated with the rubric XML.

https://jira.fairwaytech.com/browse/TDS-1028