### PR TITLE
Fixing MSB assessments - returning all ltemCandidates (instead of onl…

### DIFF
--- a/service/src/main/java/tds/exam/services/item/selection/ExamSegmentWrapper.java
+++ b/service/src/main/java/tds/exam/services/item/selection/ExamSegmentWrapper.java
@@ -14,7 +14,7 @@ import tds.exam.ExamSegment;
  * A Wrapper class that associates {@link tds.exam.ExamSegment} with its exams
  */
 class ExamSegmentWrapper {
-    private final ExamSegment examSegment;
+    private ExamSegment examSegment;
     private Set<UUID> pageIds = new HashSet<>();
     private List<ExamItem> items = new ArrayList<>();
 
@@ -65,5 +65,9 @@ class ExamSegmentWrapper {
      */
     public ExamSegment getExamSegment() {
         return examSegment;
+    }
+
+    public void setExamSegment(final ExamSegment examSegment) {
+        this.examSegment = examSegment;
     }
 }

--- a/service/src/test/java/tds/exam/services/item/selection/ItemCandidateServiceImplTest.java
+++ b/service/src/test/java/tds/exam/services/item/selection/ItemCandidateServiceImplTest.java
@@ -173,11 +173,11 @@ public class ItemCandidateServiceImplTest {
         ArgumentCaptor<ExamSegment> varArgs = ArgumentCaptor.forClass(ExamSegment.class);
         verify(mockExamSegmentService).update(varArgs.capture());
 
-        assertThat(candidates).hasSize(1);
+        assertThat(candidates).hasSize(2);
 
         ItemCandidatesData data = candidates.get(0);
 
-        assertThat(data.getSegmentKey()).isEqualTo(segment2.getKey());
+        assertThat(data.getSegmentKey()).isEqualTo(segment.getKey());
 
         assertThat(varArgs.getAllValues()).hasSize(1);
 
@@ -318,7 +318,7 @@ public class ItemCandidateServiceImplTest {
         verify(mockExamSegmentService).update(varArgs.capture());
 
         assertThat(varArgs.getAllValues()).hasSize(1);
-        assertThat(varArgs.getAllValues().get(0).getSegmentKey()).isEqualTo("segment2");
+        assertThat(varArgs.getAllValues().get(0).getSegmentKey()).isEqualTo("segment3");
     }
 
     @Test


### PR DESCRIPTION
…y unsatisfied candidates)

Previously, satisfied segments were being filtered out of the list returned to the adaptive selector. Because of this, fixed form assessments were being processed incorrect as adaptive segments (since the first segment is always assumed to be adaptive) and the selection

This addresses the following:
TDS-1029
TDS-1030
TDS-1031

**This PR will NOT be merged into the develop for the release on 6/7/2017. This will be added as a patch post-release**