### PR TITLE
TDS-1118: Bugfix/s3 path case

### DIFF
--- a/service/src/main/java/tds/exam/repositories/impl/S3ItemDataRepository.java
+++ b/service/src/main/java/tds/exam/repositories/impl/S3ItemDataRepository.java
@@ -21,15 +21,14 @@ import org.apache.commons.io.IOUtils;
 import org.springframework.context.annotation.Primary;
 import org.springframework.stereotype.Repository;
 
+import java.io.File;
 import java.io.IOException;
 
 import tds.exam.configuration.scoring.ScoringS3Properties;
 import tds.score.repositories.ItemDataRepository;
 
 import static org.apache.commons.io.Charsets.UTF_8;
-import static org.apache.commons.io.FilenameUtils.getName;
-import static org.apache.commons.io.FilenameUtils.removeExtension;
-import static org.apache.commons.lang3.StringUtils.capitalize;
+import static org.apache.commons.io.FilenameUtils.normalize;
 
 @Repository
 @Primary
@@ -67,12 +66,14 @@ public class S3ItemDataRepository implements ItemDataRepository {
      * to
      * items/Item-187-2501/item-187-2501.xml
      *
-     * @param itemDataPath   The item resource path
+     * @param itemDataPath The item resource path
      * @return The resource path relative to our S3 bucket and prefix
      */
     private String buildPath(final String itemDataPath) {
-        final String itemName = getName(itemDataPath);
-        final String dirName = capitalize(removeExtension(itemName));
+        final File file = new File(normalize(itemDataPath));
+        final String itemName = file.getName();
+        final String dirName = file.getParentFile().getName();
+
         return "items/" + dirName + "/" + itemName;
     }
 }

--- a/service/src/main/java/tds/exam/repositories/impl/S3ItemDataRepository.java
+++ b/service/src/main/java/tds/exam/repositories/impl/S3ItemDataRepository.java
@@ -61,19 +61,26 @@ public class S3ItemDataRepository implements ItemDataRepository {
     }
 
     /**
-     * This is a fragile path trimmer that reduces resource paths from something like:
-     * /usr/local/tomcat/resources/tds/bank/items/Item-187-2501/item-187-2501.xml
-     * to
-     * items/Item-187-2501/item-187-2501.xml
+     * Get the item file name and its parent directory and prefix it with "items/".
+     * <p>
+     *     The {@code itemPath} has the full path to the item XML file on the filesystem, e.g.
+     *     /usr/local/tomcat/resources/tds/bank/items/Item-187-2501/item-187-2501.xml.  This method will convert that
+     *     path to items/Item-187-2501/item-187-2501.xml for retrieval from the S3 bucket.  Casing is preserved on the
+     *     expectation that the file path's case is consistent between the database, the filesystem and what has been
+     *     uploaded to S3.  For example if the path on the filesystem is
+     *     /usr/local/tomcat/resources/tds/bank/items/item-187-2501/item-187-2501.xml, this method will return
+     *     /items/item-187-2501/item-187-2501.xml.
+     * </p>
      *
      * @param itemDataPath The item resource path
      * @return The resource path relative to our S3 bucket and prefix
      */
     private String buildPath(final String itemDataPath) {
         final File file = new File(normalize(itemDataPath));
-        final String itemName = file.getName();
-        final String dirName = file.getParentFile().getName();
+        final String dirName = file.getParentFile() == null
+            ? ""
+            : file.getParentFile().getName();
 
-        return "items/" + dirName + "/" + itemName;
+        return normalize("items/" + dirName + "/" + file.getName());
     }
 }


### PR DESCRIPTION
[TDS-1118](https://jira.fairwaytech.com/browse/TDS-1118):  Update to preserve the case of the file path when attempting to fetch item content from S3.  Some environments have their item content paths set to `item-187-2645/item-2645.xml` instead of `Item-187-2645/item-2645.xml`.

*NOTE:*  This fix assumes consistency between the file path in the database, on the local filesystem and S3.