### PR TITLE
Release of 4.0.6.RELEASE

### DIFF
--- a/client/pom.xml
+++ b/client/pom.xml
@@ -11,7 +11,7 @@
     <parent>
         <groupId>org.opentestsystem.delivery</groupId>
         <artifactId>tds-exam</artifactId>
-        <version>4.0.6.RELEASE</version>
+        <version>4.0.7-SNAPSHOT</version>
     </parent>
 
     <properties>

--- a/client/pom.xml
+++ b/client/pom.xml
@@ -11,7 +11,7 @@
     <parent>
         <groupId>org.opentestsystem.delivery</groupId>
         <artifactId>tds-exam</artifactId>
-        <version>4.0.7-SNAPSHOT</version>
+        <version>4.0.6.RELEASE</version>
     </parent>
 
     <properties>

--- a/client/pom.xml
+++ b/client/pom.xml
@@ -11,7 +11,7 @@
     <parent>
         <groupId>org.opentestsystem.delivery</groupId>
         <artifactId>tds-exam</artifactId>
-        <version>4.0.6-SNAPSHOT</version>
+        <version>4.0.6.RELEASE</version>
     </parent>
 
     <properties>

--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
     <artifactId>tds-exam</artifactId>
     <name>tds-exam</name>
     <packaging>pom</packaging>
-    <version>4.0.6-SNAPSHOT</version>
+    <version>4.0.6.RELEASE</version>
 
     <modules>
         <module>client</module>
@@ -34,11 +34,11 @@
         <tds-assessment-client.version>4.0.0.RELEASE</tds-assessment-client.version>
         <tds-student-client.version>4.0.3.RELEASE</tds-student-client.version>
         <tds-config-client.version>4.0.2.RELEASE</tds-config-client.version>
-        <tds-student-common.version>4.0.5</tds-student-common.version>
+        <tds-student-common.version>4.0.6.RELEASE</tds-student-common.version>
         <tds-item-selection.version>4.0.3.RELEASE</tds-item-selection.version>
         <ss-multijar.version>4.0.6.RELEASE</ss-multijar.version>
         <item-scoring.version>4.0.2.RELEASE</item-scoring.version>
-        <item-renderer.version>4.0.7</item-renderer.version>
+        <item-renderer.version>4.0.7.RELEASE</item-renderer.version>
 
         <maven.compiler.plugin.version>3.5.1</maven.compiler.plugin.version>
         <maven.release.plugin.version>2.5.3</maven.release.plugin.version>

--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
     <artifactId>tds-exam</artifactId>
     <name>tds-exam</name>
     <packaging>pom</packaging>
-    <version>4.0.7-SNAPSHOT</version>
+    <version>4.0.6.RELEASE</version>
 
     <modules>
         <module>client</module>
@@ -88,7 +88,7 @@
         <connection>scm:git:https://github.com/SmarterApp/TDS_ExamService.git</connection>
         <developerConnection>scm:git:git://github.com/SmarterApp/TDS_ExamService.git</developerConnection>
         <url>https://github.com/SmarterApp/TDS_ExamService</url>
-        <tag>HEAD</tag>
+        <tag>4.0.6.RELEASE</tag>
     </scm>
 
     <distributionManagement>

--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
     <artifactId>tds-exam</artifactId>
     <name>tds-exam</name>
     <packaging>pom</packaging>
-    <version>4.0.6.RELEASE</version>
+    <version>4.0.7-SNAPSHOT</version>
 
     <modules>
         <module>client</module>
@@ -88,7 +88,7 @@
         <connection>scm:git:https://github.com/SmarterApp/TDS_ExamService.git</connection>
         <developerConnection>scm:git:git://github.com/SmarterApp/TDS_ExamService.git</developerConnection>
         <url>https://github.com/SmarterApp/TDS_ExamService</url>
-        <tag>4.0.6.RELEASE</tag>
+        <tag>HEAD</tag>
     </scm>
 
     <distributionManagement>

--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
     <artifactId>tds-exam</artifactId>
     <name>tds-exam</name>
     <packaging>pom</packaging>
-    <version>4.0.6.RELEASE</version>
+    <version>4.0.7-SNAPSHOT</version>
 
     <modules>
         <module>client</module>

--- a/scoring/pom.xml
+++ b/scoring/pom.xml
@@ -11,7 +11,7 @@
     <parent>
         <groupId>org.opentestsystem.delivery</groupId>
         <artifactId>tds-exam</artifactId>
-        <version>4.0.7-SNAPSHOT</version>
+        <version>4.0.6.RELEASE</version>
     </parent>
 
     <dependencies>

--- a/scoring/pom.xml
+++ b/scoring/pom.xml
@@ -11,7 +11,7 @@
     <parent>
         <groupId>org.opentestsystem.delivery</groupId>
         <artifactId>tds-exam</artifactId>
-        <version>4.0.6-SNAPSHOT</version>
+        <version>4.0.6.RELEASE</version>
     </parent>
 
     <dependencies>

--- a/scoring/pom.xml
+++ b/scoring/pom.xml
@@ -11,7 +11,7 @@
     <parent>
         <groupId>org.opentestsystem.delivery</groupId>
         <artifactId>tds-exam</artifactId>
-        <version>4.0.6.RELEASE</version>
+        <version>4.0.7-SNAPSHOT</version>
     </parent>
 
     <dependencies>

--- a/service/pom.xml
+++ b/service/pom.xml
@@ -11,7 +11,7 @@
     <parent>
         <groupId>org.opentestsystem.delivery</groupId>
         <artifactId>tds-exam</artifactId>
-        <version>4.0.7-SNAPSHOT</version>
+        <version>4.0.6.RELEASE</version>
     </parent>
 
     <dependencies>

--- a/service/pom.xml
+++ b/service/pom.xml
@@ -11,7 +11,7 @@
     <parent>
         <groupId>org.opentestsystem.delivery</groupId>
         <artifactId>tds-exam</artifactId>
-        <version>4.0.6-SNAPSHOT</version>
+        <version>4.0.6.RELEASE</version>
     </parent>
 
     <dependencies>

--- a/service/pom.xml
+++ b/service/pom.xml
@@ -11,7 +11,7 @@
     <parent>
         <groupId>org.opentestsystem.delivery</groupId>
         <artifactId>tds-exam</artifactId>
-        <version>4.0.6.RELEASE</version>
+        <version>4.0.7-SNAPSHOT</version>
     </parent>
 
     <dependencies>


### PR DESCRIPTION
Releasing 4.0.6.RELEASE of TDS_ExamService, which includes:
* Updating `item-renderer` dependency to 4.0.7.RELEASE
* Updating `tds-student-common` dependency to 4.0.6.RELEASE