### PR TITLE
Handle the updates to the ChangeListener for exam updates

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -29,7 +29,7 @@
         <mysql.version>5.1.39</mysql.version>
         <joda-time.version>2.9.5</joda-time.version>
 
-        <tds-common.version>4.0.2-SNAPSHOT</tds-common.version>
+        <tds-common.version>4.0.2</tds-common.version>
         <tds-session.version>3.1.3.RELEASE</tds-session.version>
         <tds-assessment-client.version>4.0.0.RELEASE</tds-assessment-client.version>
         <tds-student-client.version>4.0.3.RELEASE</tds-student-client.version>

--- a/pom.xml
+++ b/pom.xml
@@ -29,7 +29,7 @@
         <mysql.version>5.1.39</mysql.version>
         <joda-time.version>2.9.5</joda-time.version>
 
-        <tds-common.version>4.0.1.RELEASE</tds-common.version>
+        <tds-common.version>4.0.2-SNAPSHOT</tds-common.version>
         <tds-session.version>3.1.3.RELEASE</tds-session.version>
         <tds-assessment-client.version>4.0.0.RELEASE</tds-assessment-client.version>
         <tds-student-client.version>4.0.3.RELEASE</tds-student-client.version>

--- a/service/src/main/java/tds/exam/repositories/impl/ExamQueryRepositoryImpl.java
+++ b/service/src/main/java/tds/exam/repositories/impl/ExamQueryRepositoryImpl.java
@@ -448,14 +448,6 @@ public class ExamQueryRepositoryImpl implements ExamQueryRepository {
         return jdbcTemplate.query(SQL, parameters, examRowMapper);
     }
 
-    public void findExamsToExpire() {
-        String QUERY_TO_GET_LATEST = "select * from exam.exam_event\n" +
-            "JOIN (select exam_id, max(id) as id\n" +
-            "from exam.exam_event \n" +
-            "group by exam_id) last_event on last_event.id = exam.exam_event.id\n" +
-            "where status != 'completed'";
-    }
-
     private static class AbilityRowMapper implements RowMapper<Ability> {
         @Override
         public Ability mapRow(ResultSet rs, int rowNum) throws SQLException {

--- a/service/src/main/java/tds/exam/repositories/impl/ExamQueryRepositoryImpl.java
+++ b/service/src/main/java/tds/exam/repositories/impl/ExamQueryRepositoryImpl.java
@@ -22,13 +22,6 @@ import org.springframework.jdbc.core.namedparam.MapSqlParameterSource;
 import org.springframework.jdbc.core.namedparam.NamedParameterJdbcTemplate;
 import org.springframework.jdbc.core.namedparam.SqlParameterSource;
 import org.springframework.stereotype.Repository;
-import tds.common.data.mapping.ResultSetMapperUtility;
-import tds.common.data.mysql.UuidAdapter;
-import tds.exam.Exam;
-import tds.exam.ExamStatusCode;
-import tds.exam.ExamStatusStage;
-import tds.exam.models.Ability;
-import tds.exam.repositories.ExamQueryRepository;
 
 import java.sql.ResultSet;
 import java.sql.SQLException;
@@ -40,6 +33,14 @@ import java.util.Map;
 import java.util.Optional;
 import java.util.Set;
 import java.util.UUID;
+
+import tds.common.data.mapping.ResultSetMapperUtility;
+import tds.common.data.mysql.UuidAdapter;
+import tds.exam.Exam;
+import tds.exam.ExamStatusCode;
+import tds.exam.ExamStatusStage;
+import tds.exam.models.Ability;
+import tds.exam.repositories.ExamQueryRepository;
 
 import static tds.common.data.mapping.ResultSetMapperUtility.mapTimestampToJodaInstant;
 import static tds.exam.ExamStatusCode.STATUS_PENDING;
@@ -445,6 +446,14 @@ public class ExamQueryRepositoryImpl implements ExamQueryRepository {
                 "   AND ee.deleted_at IS NULL";
 
         return jdbcTemplate.query(SQL, parameters, examRowMapper);
+    }
+
+    public void findExamsToExpire() {
+        String QUERY_TO_GET_LATEST = "select * from exam.exam_event\n" +
+            "JOIN (select exam_id, max(id) as id\n" +
+            "from exam.exam_event \n" +
+            "group by exam_id) last_event on last_event.id = exam.exam_event.id\n" +
+            "where status != 'completed'";
     }
 
     private static class AbilityRowMapper implements RowMapper<Ability> {

--- a/service/src/main/java/tds/exam/services/ExamService.java
+++ b/service/src/main/java/tds/exam/services/ExamService.java
@@ -17,6 +17,7 @@ import java.util.List;
 import java.util.Optional;
 import java.util.UUID;
 
+import tds.common.EntityUpdate;
 import tds.common.Response;
 import tds.common.ValidationError;
 import tds.exam.ApproveAccommodationsRequest;
@@ -122,4 +123,11 @@ public interface ExamService {
      * @return The list of {@link tds.exam.Exam}s the student has taken
      */
     List<Exam> findAllExamsForStudent(final long studentId);
+
+    /**
+     * Updates exams
+     *
+     * @param examUpdates update exams
+     */
+    void updateExams(final List<EntityUpdate<Exam>> examUpdates);
 }

--- a/service/src/main/java/tds/exam/utils/listeners/OnCompletedStatusExamChangeListener.java
+++ b/service/src/main/java/tds/exam/utils/listeners/OnCompletedStatusExamChangeListener.java
@@ -20,6 +20,7 @@ import org.springframework.transaction.annotation.Transactional;
 import java.util.List;
 import java.util.stream.Collectors;
 
+import tds.common.EntityUpdate;
 import tds.common.entity.utils.ChangeListener;
 import tds.common.util.Preconditions;
 import tds.exam.Exam;
@@ -55,7 +56,10 @@ public class OnCompletedStatusExamChangeListener implements ChangeListener<Exam>
 
     @Override
     @Transactional
-    public void accept(final Exam oldExam, final Exam newExam) {
+    public void accept(final EntityUpdate<Exam> examUpdate) {
+        Exam oldExam = examUpdate.getExistingEntity();
+        Exam newExam = examUpdate.getUpdatedEntity();
+
         Preconditions.checkNotNull(oldExam, "oldExam cannot be null");
         Preconditions.checkNotNull(newExam, "newExam cannot be null");
 

--- a/service/src/main/java/tds/exam/utils/listeners/OnDeniedStatusExamChangeListener.java
+++ b/service/src/main/java/tds/exam/utils/listeners/OnDeniedStatusExamChangeListener.java
@@ -16,6 +16,7 @@ package tds.exam.utils.listeners;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Component;
 
+import tds.common.EntityUpdate;
 import tds.common.entity.utils.ChangeListener;
 import tds.common.util.Preconditions;
 import tds.exam.Exam;
@@ -35,7 +36,10 @@ public class OnDeniedStatusExamChangeListener implements ChangeListener<Exam> {
     }
 
     @Override
-    public void accept(final Exam oldExam, final Exam newExam) {
+    public void accept(EntityUpdate<Exam> examEntityUpdate) {
+        Exam oldExam = examEntityUpdate.getExistingEntity();
+        Exam newExam = examEntityUpdate.getUpdatedEntity();
+
         Preconditions.checkNotNull(oldExam, "oldExam cannot be null");
         Preconditions.checkNotNull(newExam, "newExam cannot be null");
 

--- a/service/src/main/java/tds/exam/utils/listeners/OnPausedStatusExamChangeListener.java
+++ b/service/src/main/java/tds/exam/utils/listeners/OnPausedStatusExamChangeListener.java
@@ -19,7 +19,7 @@ import org.springframework.transaction.annotation.Transactional;
 
 import java.util.Optional;
 
-import tds.common.Response;
+import tds.common.EntityUpdate;
 import tds.common.entity.utils.ChangeListener;
 import tds.common.util.Preconditions;
 import tds.exam.Exam;
@@ -41,7 +41,10 @@ public class OnPausedStatusExamChangeListener implements ChangeListener<Exam> {
 
     @Override
     @Transactional
-    public void accept(final Exam oldExam, final Exam newExam) {
+    public void accept(EntityUpdate<Exam> examEntityUpdate) {
+        Exam oldExam = examEntityUpdate.getExistingEntity();
+        Exam newExam = examEntityUpdate.getUpdatedEntity();
+
         Preconditions.checkNotNull(oldExam, "oldExam cannot be null");
         Preconditions.checkNotNull(newExam, "newExam cannot be null");
 

--- a/service/src/test/java/tds/exam/utils/listeners/OnCompletedStatusExamChangeListenerTest.java
+++ b/service/src/test/java/tds/exam/utils/listeners/OnCompletedStatusExamChangeListenerTest.java
@@ -29,6 +29,7 @@ import java.util.Collections;
 import java.util.List;
 import java.util.UUID;
 
+import tds.common.EntityUpdate;
 import tds.common.entity.utils.ChangeListener;
 import tds.exam.Exam;
 import tds.exam.ExamSegment;
@@ -132,7 +133,7 @@ public class OnCompletedStatusExamChangeListenerTest {
         when(mockFieldTestService.findUsageInExam(newExam.getId()))
             .thenReturn(Arrays.asList(mockFirstFtItemGroup, mockSecondFtItemGroup));
 
-        onCompletedExamStatusChangeListener.accept(oldExam, newExam);
+        onCompletedExamStatusChangeListener.accept(new EntityUpdate<>(oldExam, newExam));
         verify(mockExamSegmentService).findExamSegments(newExam.getId());
         verify(mockFieldTestService).findUsageInExam(newExam.getId());
         verify(mockExamSegmentService).update(examSegmentsArgumentCaptor.capture());
@@ -162,7 +163,7 @@ public class OnCompletedStatusExamChangeListenerTest {
         when(mockFieldTestService.findUsageInExam(newExam.getId()))
             .thenReturn(Collections.emptyList());
 
-        onCompletedExamStatusChangeListener.accept(oldExam, newExam);
+        onCompletedExamStatusChangeListener.accept(new EntityUpdate<>(oldExam, newExam));
         verify(mockExamSegmentService).findExamSegments(newExam.getId());
         verify(mockFieldTestService).findUsageInExam(newExam.getId());
     }
@@ -172,7 +173,7 @@ public class OnCompletedStatusExamChangeListenerTest {
         final Exam oldExam = new ExamBuilder().build();
         final Exam newExam = new ExamBuilder().build();
 
-        onCompletedExamStatusChangeListener.accept(oldExam, newExam);
+        onCompletedExamStatusChangeListener.accept(new EntityUpdate<>(oldExam, newExam));
         verifyZeroInteractions(mockExamSegmentService);
         verifyZeroInteractions(mockExamineeService);
         verifyZeroInteractions(mockFieldTestService);
@@ -187,7 +188,7 @@ public class OnCompletedStatusExamChangeListenerTest {
             .withStatus(new ExamStatusCode(ExamStatusCode.STATUS_STARTED, ExamStatusStage.IN_PROGRESS), Instant.now())
             .build();
 
-        onCompletedExamStatusChangeListener.accept(oldExam, newExam);
+        onCompletedExamStatusChangeListener.accept(new EntityUpdate<>(oldExam, newExam));
         verifyZeroInteractions(mockExamSegmentService);
         verifyZeroInteractions(mockExamineeService);
         verifyZeroInteractions(mockFieldTestService);
@@ -203,7 +204,7 @@ public class OnCompletedStatusExamChangeListenerTest {
         when(mockExamSegmentService.findExamSegments(newExam.getId()))
             .thenReturn(new ArrayList<>());
 
-        onCompletedExamStatusChangeListener.accept(oldExam, newExam);
+        onCompletedExamStatusChangeListener.accept(new EntityUpdate<>(oldExam, newExam));
         verify(mockExamSegmentService).findExamSegments(any(UUID.class));
     }
 
@@ -215,7 +216,7 @@ public class OnCompletedStatusExamChangeListenerTest {
             .withStatus(new ExamStatusCode(ExamStatusCode.STATUS_COMPLETED, ExamStatusStage.IN_PROGRESS), Instant.now())
             .build();
 
-        onCompletedExamStatusChangeListener.accept(oldExam, newExam);
+        onCompletedExamStatusChangeListener.accept(new EntityUpdate<>(oldExam, newExam));
         verify(mockMessagingService).sendExamCompletion(eq(oldExam.getId()));
     }
 
@@ -228,7 +229,7 @@ public class OnCompletedStatusExamChangeListenerTest {
             .withStatus(new ExamStatusCode(ExamStatusCode.STATUS_COMPLETED, ExamStatusStage.IN_PROGRESS), Instant.now())
             .build();
 
-        onCompletedExamStatusChangeListener.accept(oldExam, newExam);
+        onCompletedExamStatusChangeListener.accept(new EntityUpdate<>(oldExam, newExam));
         verifyZeroInteractions(mockMessagingService);
     }
 }

--- a/service/src/test/java/tds/exam/utils/listeners/OnDeniedStatusExamChangeListenerTest.java
+++ b/service/src/test/java/tds/exam/utils/listeners/OnDeniedStatusExamChangeListenerTest.java
@@ -20,6 +20,7 @@ import org.junit.runner.RunWith;
 import org.mockito.Mock;
 import org.mockito.runners.MockitoJUnitRunner;
 
+import tds.common.EntityUpdate;
 import tds.common.entity.utils.ChangeListener;
 import tds.exam.Exam;
 import tds.exam.ExamStatusCode;
@@ -49,7 +50,7 @@ public class OnDeniedStatusExamChangeListenerTest {
             .withStatus(new ExamStatusCode(ExamStatusCode.STATUS_DENIED), Instant.now())
             .build();
 
-        onDeniedStatusExamChangeListener.accept(exam, deniedExam);
+        onDeniedStatusExamChangeListener.accept(new EntityUpdate<>(exam, deniedExam));
         verify(mockExamAccommodationService).denyAccommodations(exam.getId(), deniedExam.getChangedAt());
     }
 
@@ -61,7 +62,7 @@ public class OnDeniedStatusExamChangeListenerTest {
             .withStatus(new ExamStatusCode(ExamStatusCode.STATUS_APPROVED), Instant.now())
             .build();
 
-        onDeniedStatusExamChangeListener.accept(exam, deniedExam);
+        onDeniedStatusExamChangeListener.accept(new EntityUpdate<>(exam, deniedExam));
         verify(mockExamAccommodationService, never()).denyAccommodations(exam.getId(), deniedExam.getChangedAt());
     }
 }

--- a/service/src/test/java/tds/exam/utils/listeners/OnPausedStatusExamChangeListenerTest.java
+++ b/service/src/test/java/tds/exam/utils/listeners/OnPausedStatusExamChangeListenerTest.java
@@ -22,9 +22,8 @@ import org.mockito.runners.MockitoJUnitRunner;
 
 import java.util.Optional;
 
-import tds.common.Response;
+import tds.common.EntityUpdate;
 import tds.common.entity.utils.ChangeListener;
-import tds.common.web.exceptions.NotFoundException;
 import tds.exam.Exam;
 import tds.exam.ExamSegment;
 import tds.exam.ExamStatusCode;
@@ -68,7 +67,7 @@ public class OnPausedStatusExamChangeListenerTest {
             newExam.getCurrentSegmentPosition()))
             .thenReturn(Optional.of(mockSegment));
 
-        onPausedStatusExamChangeListener.accept(oldExam, newExam);
+        onPausedStatusExamChangeListener.accept(new EntityUpdate<>(oldExam, newExam));
         verify(mockExamSegmentService).findByExamIdAndSegmentPosition(newExam.getId(),
             newExam.getCurrentSegmentPosition());
         verify(mockExamSegmentService).update(any(ExamSegment.class));
@@ -79,7 +78,7 @@ public class OnPausedStatusExamChangeListenerTest {
         Exam oldExam = new ExamBuilder().build();
         Exam newExam = new ExamBuilder().build();
 
-        onPausedStatusExamChangeListener.accept(oldExam, newExam);
+        onPausedStatusExamChangeListener.accept(new EntityUpdate<>(oldExam, newExam));
         verifyZeroInteractions(mockExamSegmentService);
     }
 
@@ -92,7 +91,7 @@ public class OnPausedStatusExamChangeListenerTest {
             .withStatus(new ExamStatusCode(ExamStatusCode.STATUS_STARTED, ExamStatusStage.IN_PROGRESS), Instant.now())
             .build();
 
-        onPausedStatusExamChangeListener.accept(oldExam, newExam);
+        onPausedStatusExamChangeListener.accept(new EntityUpdate<>(oldExam, newExam));
         verifyZeroInteractions(mockExamSegmentService);
     }
 
@@ -111,7 +110,7 @@ public class OnPausedStatusExamChangeListenerTest {
             newExam.getCurrentSegmentPosition()))
             .thenReturn(Optional.of(mockSegment));
 
-        onPausedStatusExamChangeListener.accept(oldExam, newExam);
+        onPausedStatusExamChangeListener.accept(new EntityUpdate<>(oldExam, newExam));
         verify(mockExamSegmentService).findByExamIdAndSegmentPosition(newExam.getId(),
             newExam.getCurrentSegmentPosition());
         verify(mockExamSegmentService, never()).update(anyVararg());
@@ -133,7 +132,7 @@ public class OnPausedStatusExamChangeListenerTest {
             newExam.getCurrentSegmentPosition()))
             .thenReturn(Optional.of(mockSegment));
 
-        onPausedStatusExamChangeListener.accept(oldExam, newExam);
+        onPausedStatusExamChangeListener.accept(new EntityUpdate<>(oldExam, newExam));
         verify(mockExamSegmentService).findByExamIdAndSegmentPosition(newExam.getId(),
             newExam.getCurrentSegmentPosition());
         verify(mockExamSegmentService, never()).update(anyVararg());
@@ -150,7 +149,7 @@ public class OnPausedStatusExamChangeListenerTest {
             newExam.getCurrentSegmentPosition()))
             .thenReturn(Optional.empty());
 
-        onPausedStatusExamChangeListener.accept(oldExam, newExam);
+        onPausedStatusExamChangeListener.accept(new EntityUpdate<>(oldExam, newExam));
         verify(mockExamSegmentService, never()).update(anyVararg());
     }
 }


### PR DESCRIPTION
This is a refactor that will make it easier to force submit exams which have a unique logic path when updating exams.  I needed a way to update multiple exams in a single go.  Rather than clutter the expiration logic in one massive PR this is a refactor to allow multiple updates