### PR TITLE
Bugfix/remove duplicates for exam expiration

### DIFF
--- a/client/src/main/java/tds/exam/ExpiredExamResponse.java
+++ b/client/src/main/java/tds/exam/ExpiredExamResponse.java
@@ -3,7 +3,7 @@ package tds.exam;
 import java.util.Collection;
 
 /**
- * Represents
+ * Contains information about the exams that were expired and also whether there are additional exams that need to be expired.
  */
 public class ExpiredExamResponse {
     private boolean additionalExamsToExpire;
@@ -18,10 +18,16 @@ public class ExpiredExamResponse {
         this.expiredExams = expiredExams;
     }
 
+    /**
+     * @return {@code true} if there are more exams to expire
+     */
     public boolean isAdditionalExamsToExpire() {
         return additionalExamsToExpire;
     }
 
+    /**
+     * @return the collection of {@link tds.exam.ExpiredExamInformation} for expired exams
+     */
     public Collection<ExpiredExamInformation> getExpiredExams() {
         return expiredExams;
     }

--- a/client/src/main/java/tds/exam/ExpiredExamResponse.java
+++ b/client/src/main/java/tds/exam/ExpiredExamResponse.java
@@ -1,0 +1,28 @@
+package tds.exam;
+
+import java.util.Collection;
+
+/**
+ * Represents
+ */
+public class ExpiredExamResponse {
+    private boolean additionalExamsToExpire;
+    private Collection<ExpiredExamInformation> expiredExams;
+
+    //For frameworks
+    ExpiredExamResponse() {
+    }
+
+    public ExpiredExamResponse(final boolean additionalExamsToExpire, final Collection<ExpiredExamInformation> expiredExams) {
+        this.additionalExamsToExpire = additionalExamsToExpire;
+        this.expiredExams = expiredExams;
+    }
+
+    public boolean isAdditionalExamsToExpire() {
+        return additionalExamsToExpire;
+    }
+
+    public Collection<ExpiredExamInformation> getExpiredExams() {
+        return expiredExams;
+    }
+}

--- a/pom.xml
+++ b/pom.xml
@@ -33,7 +33,7 @@
         <tds-session.version>3.1.3.RELEASE</tds-session.version>
         <tds-assessment-client.version>4.0.1</tds-assessment-client.version>
         <tds-student-client.version>4.0.3.RELEASE</tds-student-client.version>
-        <tds-config-client.version>4.0.3</tds-config-client.version>
+        <tds-config-client.version>4.0.4-SNAPSHOT</tds-config-client.version>
         <tds-student-common.version>4.0.6.RELEASE</tds-student-common.version>
         <tds-item-selection.version>4.0.3.RELEASE</tds-item-selection.version>
         <ss-multijar.version>4.0.6.RELEASE</ss-multijar.version>

--- a/pom.xml
+++ b/pom.xml
@@ -33,7 +33,7 @@
         <tds-session.version>3.1.3.RELEASE</tds-session.version>
         <tds-assessment-client.version>4.0.1</tds-assessment-client.version>
         <tds-student-client.version>4.0.3.RELEASE</tds-student-client.version>
-        <tds-config-client.version>4.0.4-SNAPSHOT</tds-config-client.version>
+        <tds-config-client.version>4.0.4</tds-config-client.version>
         <tds-student-common.version>4.0.6.RELEASE</tds-student-common.version>
         <tds-item-selection.version>4.0.3.RELEASE</tds-item-selection.version>
         <ss-multijar.version>4.0.6.RELEASE</ss-multijar.version>

--- a/service/src/main/java/tds/exam/configuration/ExamServiceProperties.java
+++ b/service/src/main/java/tds/exam/configuration/ExamServiceProperties.java
@@ -24,6 +24,7 @@ public class ExamServiceProperties {
     private String assessmentUrl = "";
     private String configUrl = "";
     private String contentUrl = "";
+    private int expireExamLimit = 100;
 
     /**
      * Get the URL for the content microservice.
@@ -102,6 +103,17 @@ public class ExamServiceProperties {
     public void setAssessmentUrl(String assessmentUrl) {
         if (assessmentUrl == null) throw new IllegalArgumentException("asssessmentUrl cannot be null");
         this.assessmentUrl = removeTrailingSlash(assessmentUrl);
+    }
+
+    /**
+     * @return the expire exam limit
+     */
+    public int getExpireExamLimit() {
+        return expireExamLimit;
+    }
+
+    public void setExpireExamLimit(final int expireExamLimit) {
+        this.expireExamLimit = expireExamLimit;
     }
 
     private String removeTrailingSlash(String url) {

--- a/service/src/main/java/tds/exam/repositories/ExamQueryRepository.java
+++ b/service/src/main/java/tds/exam/repositories/ExamQueryRepository.java
@@ -15,6 +15,7 @@ package tds.exam.repositories;
 
 import org.joda.time.Instant;
 
+import java.util.Collection;
 import java.util.List;
 import java.util.Optional;
 import java.util.Set;
@@ -104,8 +105,10 @@ public interface ExamQueryRepository {
     /**
      * Find all the exams to expire based on the status codes
      *
-     * @param statusCodesToIgnore     the status codes to ignore
+     * @param statusCodesToIgnore the status codes to ignore
+     * @param expireExamLimit     the max number of exams to find
+     * @param assessmentIds       the assessment ids to include in the query
      * @return the list of {@link tds.exam.Exam} to expire
      */
-    List<Exam> findExamsToExpire(List<String> statusCodesToIgnore);
+    List<Exam> findExamsToExpire(final List<String> statusCodesToIgnore, final int expireExamLimit, Collection<String> assessmentIds);
 }

--- a/service/src/main/java/tds/exam/repositories/impl/ExamQueryRepositoryImpl.java
+++ b/service/src/main/java/tds/exam/repositories/impl/ExamQueryRepositoryImpl.java
@@ -460,22 +460,22 @@ public class ExamQueryRepositoryImpl implements ExamQueryRepository {
         2. Do not have the status codes passed in
          */
         String SQL = "SELECT " + EXAM_QUERY_COLUMN_LIST +
-            "from exam e\n" +
+            "from exam.exam e\n" +
             "join (\n" +
             "   select a.* from exam.exam_event a\n" +
             "   JOIN (\n" +
             "   select b.exam_id, max(id) as id\n" +
-            "   from exam_event b\n" +
+            "   from exam.exam_event b\n" +
             "   group by b.exam_id\n" +
             "   ) last_event on last_event.id = a.id\n" +
             "   WHERE \n" +
-            "       a.status not in(:statusCodesToIgnore) \n" +
+            "       a.status not in (:statusCodesToIgnore) \n" +
             "       and a.completed_at is null \n" +
             "       and a.deleted_at is null \n" +
-            ") ee on e.id = ee.exam_id \n" +
+            ") ee on e.id = ee.exam_id\n" +
             "JOIN exam.exam_status_codes esc \n" +
-            "   ON esc.status = ee.status\n" +
-            "JOIN exam.exam_page page on e.id = page.exam_id\n" +
+            "   ON esc.status = ee.status \n" +
+            "JOIN (select exam_id from exam.exam_page group by exam_id) page on page.exam_id = e.id\n" +
             "LEFT JOIN exam.exam_accommodation lang \n" +
             "   ON lang.exam_id = e.id \n" +
             "   AND lang.id = ( \n" +
@@ -487,7 +487,7 @@ public class ExamQueryRepositoryImpl implements ExamQueryRepository {
             "           exam_id = e.id \n" +
             "           AND type = 'Language' \n" +
             "       ORDER BY created_at DESC \n" +
-            "       LIMIT 1); ";
+            "       LIMIT 1); \n ";
 
         return jdbcTemplate.query(SQL, parameters, examRowMapper);
     }

--- a/service/src/main/java/tds/exam/services/ConfigService.java
+++ b/service/src/main/java/tds/exam/services/ConfigService.java
@@ -13,6 +13,7 @@
 
 package tds.exam.services;
 
+import java.util.Collection;
 import java.util.Optional;
 
 import tds.config.ClientSystemFlag;
@@ -66,4 +67,12 @@ public interface ConfigService {
      * @return The message string with placeholders included
      */
     String getFormattedMessage(final String clientName, final String context, final String messageKey, final String languageCode, final String subject, final String grade, final Object... replacements);
+
+    /**
+     * Finds assessment ids that have force complete enabled
+     *
+     * @param clientName the client name
+     * @return collection of assessment ids
+     */
+    Collection<String> findForceCompleteAssessmentIds(final String clientName);
 }

--- a/service/src/main/java/tds/exam/services/ExamExpirationService.java
+++ b/service/src/main/java/tds/exam/services/ExamExpirationService.java
@@ -1,8 +1,6 @@
 package tds.exam.services;
 
-import java.util.Collection;
-
-import tds.exam.ExpiredExamInformation;
+import tds.exam.ExpiredExamResponse;
 
 /**
  * Expires exams
@@ -12,7 +10,7 @@ public interface ExamExpirationService {
      * Expire all exams that fit criteria
      * @param clientName the client name associated with the exam
      *
-     * @return collection of {@link tds.exam.ExpiredExamInformation}
+     * @return {@link tds.exam.ExpiredExamResponse}
      */
-    Collection<ExpiredExamInformation> expireExams(final String clientName);
+    ExpiredExamResponse expireExams(final String clientName);
 }

--- a/service/src/main/java/tds/exam/services/impl/ConfigServiceImpl.java
+++ b/service/src/main/java/tds/exam/services/impl/ConfigServiceImpl.java
@@ -17,12 +17,15 @@ import org.apache.commons.lang3.StringUtils;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.cache.annotation.Cacheable;
 import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
 import org.springframework.stereotype.Service;
 import org.springframework.web.client.HttpClientErrorException;
 import org.springframework.web.client.RestTemplate;
 import org.springframework.web.util.UriComponentsBuilder;
 
 import java.text.MessageFormat;
+import java.util.Arrays;
+import java.util.Collection;
 import java.util.Optional;
 
 import tds.common.cache.CacheType;
@@ -126,5 +129,19 @@ class ConfigServiceImpl implements ConfigService {
         Note: The messages in the database use {0}, {1}, {2}, etc. as the placeholders.
         */
         return MessageFormat.format(messageTemplate, replacements);
+    }
+
+    @Override
+    public Collection<String> findForceCompleteAssessmentIds(final String clientName) {
+        UriComponentsBuilder builder =
+            UriComponentsBuilder
+                .fromHttpUrl(String.format("%s/%s/client-test-properties/%s/forceComplete",
+                    examServiceProperties.getConfigUrl(),
+                    CONFIG_APP_CONTEXT,
+                    clientName));
+
+        ResponseEntity<String[]> responseEntity = restTemplate.getForEntity(builder.toUriString(), String[].class);
+
+        return Arrays.asList(responseEntity.getBody());
     }
 }

--- a/service/src/main/java/tds/exam/web/endpoints/ExamExpirationController.java
+++ b/service/src/main/java/tds/exam/web/endpoints/ExamExpirationController.java
@@ -8,9 +8,7 @@ import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
-import java.util.Collection;
-
-import tds.exam.ExpiredExamInformation;
+import tds.exam.ExpiredExamResponse;
 import tds.exam.services.ExamExpirationService;
 
 @RestController
@@ -24,7 +22,7 @@ public class ExamExpirationController {
     }
 
     @PostMapping(value = "expire/{clientName}", produces = MediaType.APPLICATION_JSON_VALUE)
-    ResponseEntity<Collection<ExpiredExamInformation>> expireExams(@PathVariable  final String clientName) {
+    ResponseEntity<ExpiredExamResponse> expireExams(@PathVariable  final String clientName) {
         return ResponseEntity.ok(examExpirationService.expireExams(clientName));
     }
 }

--- a/service/src/test/java/tds/exam/repositories/impl/ExamQueryRepositoryImplIntegrationTests.java
+++ b/service/src/test/java/tds/exam/repositories/impl/ExamQueryRepositoryImplIntegrationTests.java
@@ -227,8 +227,10 @@ public class ExamQueryRepositoryImplIntegrationTests {
         UUID deletedAtExamId = UUID.randomUUID();
         UUID completedExamId = UUID.randomUUID();
         UUID pausedExamWithLongAgoChangeDateId = UUID.randomUUID();
+        UUID examStartedButShouldNotExpire = UUID.randomUUID();
 
-        List<UUID> examIdsThatShouldNotExpire = Arrays.asList(deletedAtExamId, completedExamId, pausedExamWithLongAgoChangeDateId);
+
+        List<UUID> examIdsThatShouldNotExpire = Arrays.asList(deletedAtExamId, completedExamId, pausedExamWithLongAgoChangeDateId, examStartedButShouldNotExpire);
 
         List<Exam> examsForExpire = new ArrayList<>();
         examsForExpire.add(new ExamBuilder()
@@ -254,7 +256,15 @@ public class ExamQueryRepositoryImplIntegrationTests {
             .withChangedAt(Instant.now().minus(Days.days(5).toStandardDuration()))
             .build();
 
+        Exam examStarted2 = new ExamBuilder()
+            .withId(examStartedButShouldNotExpire)
+            .withAssessmentId("assementId2")
+            .withStatus(new ExamStatusCode(ExamStatusCode.STATUS_PAUSED, ExamStatusStage.OPEN), Instant.now())
+            .withChangedAt(Instant.now().minus(Days.days(5).toStandardDuration()))
+            .build();
+
         examsForExpire.add(examStarted);
+        examsForExpire.add(examStarted2);
 
         ExamSegment examSegment = new ExamSegmentBuilder().withExamId(pausedExamWithLongAgoChangeDateId).build();
         ExamPage examPage = new ExamPageBuilder().withId(UUID.randomUUID()).withExamId(pausedExamWithLongAgoChangeDateId).withPagePosition(1).withSegmentKey(examSegment.getSegmentKey()).build();
@@ -278,7 +288,7 @@ public class ExamQueryRepositoryImplIntegrationTests {
         examSegmentCommandRepository.insert(Collections.singletonList(examSegment));
         examPageCommandRepository.insert(examPage, examPage2);
 
-        List<Exam> examsToExpire = examQueryRepository.findExamsToExpire(Arrays.asList(ExamStatusCode.STATUS_APPROVED, ExamStatusCode.STATUS_CLOSED));
+        List<Exam> examsToExpire = examQueryRepository.findExamsToExpire(Arrays.asList(ExamStatusCode.STATUS_APPROVED, ExamStatusCode.STATUS_CLOSED), 5, Collections.singletonList("assementId2"));
 
         boolean foundStarted = false;
 
@@ -295,6 +305,59 @@ public class ExamQueryRepositoryImplIntegrationTests {
 
         assertThat(foundStarted).isTrue();
     }
+
+    @Test
+    public void shouldFindExamsToExpireByStatusCodesAndAssessmentId() {
+        UUID pausedExamWithLongAgoChangeDateId = UUID.randomUUID();
+        UUID examStartedButShouldNotExpire = UUID.randomUUID();
+
+        List<Exam> examsForExpire = new ArrayList<>();
+
+        Exam examStarted = new ExamBuilder()
+            .withId(pausedExamWithLongAgoChangeDateId)
+            .withAssessmentId("assementId1")
+            .withStatus(new ExamStatusCode(ExamStatusCode.STATUS_PAUSED, ExamStatusStage.OPEN), Instant.now())
+            .withChangedAt(Instant.now().minus(Days.days(5).toStandardDuration()))
+            .build();
+
+        Exam examStarted2 = new ExamBuilder()
+            .withId(examStartedButShouldNotExpire)
+            .withAssessmentId("assementId2")
+            .withStatus(new ExamStatusCode(ExamStatusCode.STATUS_PAUSED, ExamStatusStage.OPEN), Instant.now())
+            .withChangedAt(Instant.now().minus(Days.days(5).toStandardDuration()))
+            .build();
+
+        examsForExpire.add(examStarted);
+        examsForExpire.add(examStarted2);
+
+        ExamSegment examSegment = new ExamSegmentBuilder().withExamId(pausedExamWithLongAgoChangeDateId).build();
+        ExamPage examPage = new ExamPageBuilder().withId(UUID.randomUUID()).withExamId(pausedExamWithLongAgoChangeDateId).withPagePosition(1).withSegmentKey(examSegment.getSegmentKey()).build();
+        ExamPage examPage2 = new ExamPageBuilder().withId(UUID.randomUUID()).withExamId(pausedExamWithLongAgoChangeDateId).withPagePosition(2).withSegmentKey(examSegment.getSegmentKey()).build();
+
+        examsForExpire.forEach(exam -> {
+            Instant changedAtDate = exam.getChangedAt();
+            examCommandRepository.insert(exam);
+            examAccommodationCommandRepository.insert(Collections.singletonList(
+                new ExamAccommodationBuilder()
+                    .withType("Language")
+                    .withCode("ENU")
+                    .withExamId(exam.getId())
+                    .withSegmentPosition(0)
+                    .build()
+            ));
+
+            updateEventCreatedAt(exam.getId(), changedAtDate);
+        });
+
+        examSegmentCommandRepository.insert(Collections.singletonList(examSegment));
+        examPageCommandRepository.insert(examPage, examPage2);
+
+        List<Exam> examsToExpire = examQueryRepository.findExamsToExpire(Arrays.asList(ExamStatusCode.STATUS_APPROVED, ExamStatusCode.STATUS_CLOSED), 5, Collections.singletonList("assementId1"));
+
+        assertThat(examsToExpire).hasSize(1);
+        assertThat(examsToExpire.get(0).getId()).isEqualTo(examStarted.getId());
+    }
+
 
     private void updateEventCreatedAt(UUID examId, Instant changedAt) {
         MapSqlParameterSource parameterSource = new MapSqlParameterSource("changedAt", mapJodaInstantToTimestamp(changedAt))

--- a/service/src/test/java/tds/exam/repositories/impl/ExamQueryRepositoryImplIntegrationTests.java
+++ b/service/src/test/java/tds/exam/repositories/impl/ExamQueryRepositoryImplIntegrationTests.java
@@ -257,7 +257,8 @@ public class ExamQueryRepositoryImplIntegrationTests {
         examsForExpire.add(examStarted);
 
         ExamSegment examSegment = new ExamSegmentBuilder().withExamId(pausedExamWithLongAgoChangeDateId).build();
-        ExamPage examPage = new ExamPageBuilder().withExamId(pausedExamWithLongAgoChangeDateId).withSegmentKey(examSegment.getSegmentKey()).build();
+        ExamPage examPage = new ExamPageBuilder().withId(UUID.randomUUID()).withExamId(pausedExamWithLongAgoChangeDateId).withPagePosition(1).withSegmentKey(examSegment.getSegmentKey()).build();
+        ExamPage examPage2 = new ExamPageBuilder().withId(UUID.randomUUID()).withExamId(pausedExamWithLongAgoChangeDateId).withPagePosition(2).withSegmentKey(examSegment.getSegmentKey()).build();
 
         examsForExpire.forEach(exam -> {
             Instant changedAtDate = exam.getChangedAt();
@@ -275,7 +276,7 @@ public class ExamQueryRepositoryImplIntegrationTests {
         });
 
         examSegmentCommandRepository.insert(Collections.singletonList(examSegment));
-        examPageCommandRepository.insert(examPage);
+        examPageCommandRepository.insert(examPage, examPage2);
 
         List<Exam> examsToExpire = examQueryRepository.findExamsToExpire(Arrays.asList(ExamStatusCode.STATUS_APPROVED, ExamStatusCode.STATUS_CLOSED));
 

--- a/service/src/test/java/tds/exam/services/impl/ExamExpirationServiceImplTest.java
+++ b/service/src/test/java/tds/exam/services/impl/ExamExpirationServiceImplTest.java
@@ -29,7 +29,6 @@ import tds.exam.builder.AssessmentBuilder;
 import tds.exam.builder.ExamBuilder;
 import tds.exam.configuration.ExamServiceProperties;
 import tds.exam.repositories.ExamQueryRepository;
-import tds.exam.services.AssessmentService;
 import tds.exam.services.ConfigService;
 import tds.exam.services.ExamService;
 import tds.exam.services.TimeLimitConfigurationService;
@@ -54,9 +53,6 @@ public class ExamExpirationServiceImplTest {
     private TimeLimitConfigurationService mockTimeLimitConfigurationService;
 
     @Mock
-    private AssessmentService mockAssessmentService;
-
-    @Mock
     private ConfigService mockConfigService;
 
     private TimeLimitConfiguration clientTimeLimitConfiguration;
@@ -70,7 +66,7 @@ public class ExamExpirationServiceImplTest {
     public void setUp() {
         examServiceProperties = new ExamServiceProperties();
         examServiceProperties.setExpireExamLimit(2);
-        examExpirationService = new ExamExpirationServiceImpl(mockExamService, mockExamQueryRepository, mockTimeLimitConfigurationService, mockAssessmentService, examServiceProperties, mockConfigService);
+        examExpirationService = new ExamExpirationServiceImpl(mockExamService, mockExamQueryRepository, mockTimeLimitConfigurationService, examServiceProperties, mockConfigService);
         clientTimeLimitConfiguration = new TimeLimitConfiguration.Builder()
             .withClientName("SBAC")
             .withExamExpireDays(3)
@@ -90,17 +86,10 @@ public class ExamExpirationServiceImplTest {
             .withChangedAt(Instant.now().toDateTime().minusDays(5).toInstant())
             .build();
 
-        Assessment assessment = new AssessmentBuilder()
-            .withAssessmentId(exam.getAssessmentId())
-            .withKey(exam.getAssessmentKey())
-            .withForceComplete(true)
-            .build();
-
-        when(mockConfigService.findForceCompleteAssessmentIds("SBAC")).thenReturn(Collections.singletonList("assessmentId1"));
+        when(mockConfigService.findForceCompleteAssessmentIds("SBAC")).thenReturn(Collections.singletonList(exam.getAssessmentId()));
         when(mockTimeLimitConfigurationService.findTimeLimitConfiguration("SBAC")).thenReturn(Optional.of(clientTimeLimitConfiguration));
-        when(mockExamQueryRepository.findExamsToExpire(ExamExpirationServiceImpl.STATUSES_TO_IGNORE_FOR_EXPIRATION, examServiceProperties.getExpireExamLimit() + 1, Collections.singletonList("assessmentId1"))).thenReturn(Collections.singletonList(exam));
-        when(mockAssessmentService.findAssessment("SBAC", assessment.getKey())).thenReturn(Optional.of(assessment));
-        when(mockTimeLimitConfigurationService.findTimeLimitConfiguration("SBAC", assessment.getAssessmentId())).thenReturn(Optional.empty());
+        when(mockExamQueryRepository.findExamsToExpire(ExamExpirationServiceImpl.STATUSES_TO_IGNORE_FOR_EXPIRATION, examServiceProperties.getExpireExamLimit() + 1, Collections.singletonList(exam.getAssessmentId()))).thenReturn(Collections.singletonList(exam));
+        when(mockTimeLimitConfigurationService.findTimeLimitConfiguration("SBAC", exam.getAssessmentId())).thenReturn(Optional.empty());
 
         ExpiredExamResponse expireExamResponse = examExpirationService.expireExams("SBAC");
         Collection<ExpiredExamInformation> expireExams = expireExamResponse.getExpiredExams();
@@ -144,7 +133,6 @@ public class ExamExpirationServiceImplTest {
         when(mockConfigService.findForceCompleteAssessmentIds("SBAC")).thenReturn(Collections.singletonList("assessmentId1"));
         when(mockTimeLimitConfigurationService.findTimeLimitConfiguration("SBAC")).thenReturn(Optional.of(clientTimeLimitConfiguration));
         when(mockExamQueryRepository.findExamsToExpire(ExamExpirationServiceImpl.STATUSES_TO_IGNORE_FOR_EXPIRATION, examServiceProperties.getExpireExamLimit() + 1, Collections.singletonList("assessmentId"))).thenReturn(Collections.singletonList(exam));
-        when(mockAssessmentService.findAssessment("SBAC", assessment.getKey())).thenReturn(Optional.of(assessment));
         when(mockTimeLimitConfigurationService.findTimeLimitConfiguration("SBAC", assessment.getAssessmentId())).thenReturn(Optional.empty());
 
         ExpiredExamResponse expireExamResponse = examExpirationService.expireExams("SBAC");
@@ -176,7 +164,6 @@ public class ExamExpirationServiceImplTest {
         when(mockConfigService.findForceCompleteAssessmentIds("SBAC")).thenReturn(Collections.singletonList("assessmentId1"));
         when(mockTimeLimitConfigurationService.findTimeLimitConfiguration("SBAC")).thenReturn(Optional.of(clientTimeLimitConfiguration));
         when(mockExamQueryRepository.findExamsToExpire(ExamExpirationServiceImpl.STATUSES_TO_IGNORE_FOR_EXPIRATION, examServiceProperties.getExpireExamLimit() + 1, Collections.singletonList("assessmentId"))).thenReturn(Collections.singletonList(exam));
-        when(mockAssessmentService.findAssessment("SBAC", assessment.getKey())).thenReturn(Optional.of(assessment));
         when(mockTimeLimitConfigurationService.findTimeLimitConfiguration("SBAC", assessment.getAssessmentId())).thenReturn(Optional.of(assessmentTimeLimitConfiguration));
 
         ExpiredExamResponse expireExamResponse = examExpirationService.expireExams("SBAC");
@@ -201,22 +188,15 @@ public class ExamExpirationServiceImplTest {
             .withChangedAt(Instant.now().toDateTime().minusDays(5).toInstant())
             .build();
 
-        Assessment assessment = new AssessmentBuilder()
-            .withAssessmentId(exam.getAssessmentId())
-            .withKey(exam.getAssessmentKey())
-            .withForceComplete(true)
-            .build();
-
         TimeLimitConfiguration assessmentTimeLimitConfiguration = new TimeLimitConfiguration.Builder()
-            .withAssessmentId(assessment.getAssessmentId())
+            .withAssessmentId(exam.getAssessmentId())
             .withExamExpireDays(1)
             .build();
 
-        when(mockConfigService.findForceCompleteAssessmentIds("SBAC")).thenReturn(Collections.singletonList("assessmentId1"));
+        when(mockConfigService.findForceCompleteAssessmentIds("SBAC")).thenReturn(Collections.singletonList(exam.getAssessmentId()));
         when(mockTimeLimitConfigurationService.findTimeLimitConfiguration("SBAC")).thenReturn(Optional.of(clientTimeLimitConfiguration));
-        when(mockExamQueryRepository.findExamsToExpire(ExamExpirationServiceImpl.STATUSES_TO_IGNORE_FOR_EXPIRATION, examServiceProperties.getExpireExamLimit() + 1, Collections.singletonList("assessmentId1"))).thenReturn(Arrays.asList(exam, exam2));
-        when(mockAssessmentService.findAssessment("SBAC", assessment.getKey())).thenReturn(Optional.of(assessment));
-        when(mockTimeLimitConfigurationService.findTimeLimitConfiguration("SBAC", assessment.getAssessmentId())).thenReturn(Optional.of(assessmentTimeLimitConfiguration));
+        when(mockExamQueryRepository.findExamsToExpire(ExamExpirationServiceImpl.STATUSES_TO_IGNORE_FOR_EXPIRATION, examServiceProperties.getExpireExamLimit() + 1, Collections.singletonList(exam.getAssessmentId()))).thenReturn(Arrays.asList(exam, exam2));
+        when(mockTimeLimitConfigurationService.findTimeLimitConfiguration("SBAC", exam.getAssessmentId())).thenReturn(Optional.of(assessmentTimeLimitConfiguration));
 
         ExpiredExamResponse expireExamResponse = examExpirationService.expireExams("SBAC");
         Collection<ExpiredExamInformation> expireExams = expireExamResponse.getExpiredExams();

--- a/service/src/test/java/tds/exam/web/endpoints/ExamExpirationControllerTest.java
+++ b/service/src/test/java/tds/exam/web/endpoints/ExamExpirationControllerTest.java
@@ -8,11 +8,11 @@ import org.mockito.runners.MockitoJUnitRunner;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 
-import java.util.Collection;
 import java.util.Collections;
 import java.util.UUID;
 
 import tds.exam.ExpiredExamInformation;
+import tds.exam.ExpiredExamResponse;
 import tds.exam.services.ExamExpirationService;
 
 import static org.assertj.core.api.Assertions.assertThat;
@@ -33,10 +33,10 @@ public class ExamExpirationControllerTest {
     @Test
     public void shouldExpireExams() {
         ExpiredExamInformation info = new ExpiredExamInformation(1L, "key", "id", UUID.randomUUID());
-        when(mockExamExpirationService.expireExams("SBAC")).thenReturn(Collections.singletonList(info));
-        ResponseEntity<Collection<ExpiredExamInformation>> response = examExpirationController.expireExams("SBAC");
+        when(mockExamExpirationService.expireExams("SBAC")).thenReturn(new ExpiredExamResponse(false, Collections.singletonList(info)));
+        ResponseEntity<ExpiredExamResponse> response = examExpirationController.expireExams("SBAC");
 
         assertThat(response.getStatusCode()).isEqualTo(HttpStatus.OK);
-        assertThat(response.getBody()).containsExactly(info);
+        assertThat(response.getBody().getExpiredExams()).containsExactly(info);
     }
 }


### PR DESCRIPTION
This makes a few changes:
1. It adds a new object and field so that client knows there are additional exams that need to be expired.
2. Fetches the assessment ids that are forced completed to have a better performing query.
3. Slight tweak where we fetch expired exams + 1 of what is configured.  If we get more than the amount we send back the more exams to be expired as true.